### PR TITLE
docs(docs): fix single character typo

### DIFF
--- a/src/content/structured/community/contribute.mdx
+++ b/src/content/structured/community/contribute.mdx
@@ -37,7 +37,7 @@ You can help us speed up the development of our Design System by contributing ne
 
 1. Select a ticket from the [backlog](https://github.com/mi6/ic-design-system/issues).
 2. [Claim a ticket](https://github.com/mi6/ic-design-system/issues), according to our [contribution guide](https://github.com/mi6/ic-design-system/tree/main/CONTRIBUTING.md), if you can help contribute code.
-3. If a backlog ticket doesn’t exist for your contribution, you can suggest it [through GitHub issues]](https://github.com/mi6/ic-design-system/issues), or our internal Service Desk.
+3. If a backlog ticket doesn’t exist for your contribution, you can suggest it [through GitHub issues](https://github.com/mi6/ic-design-system/issues), or our internal Service Desk.
 4. If you're an internal user, we will arrange a kickoff meeting to discuss the scope, plan and agree any support. For any external users, we'll work with you through GitHub issues.
 5. Refer to the technical instructions for [repository coding standards and practices](https://github.com/mi6/ic-design-system/tree/main/CONTRIBUTING.md).
 6. Create a pull request to the develop branch for review.


### PR DESCRIPTION
Extra `]` was breaking the markdown link.

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Fix a single character typo which was causing an invalid Markdown link.

## Related issue
No issue created, discussed privately

## Checklist
- [ ] I have manually accessibility tested any changes, if relevant.