### PR TITLE
docs(root): remove "beta" tag from pages other than the individual component pages

### DIFF
--- a/src/content/structured/community/contribute-criteria.mdx
+++ b/src/content/structured/community/contribute-criteria.mdx
@@ -9,8 +9,6 @@ title: "Contribution criteria"
 
 subTitle: "The contents of the Design System must be of a high quality, meet user needs and always be accessible."
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/community/contribute-criteria.mdx?at=develop"
 ---
 

--- a/src/content/structured/community/contribute.mdx
+++ b/src/content/structured/community/contribute.mdx
@@ -9,8 +9,6 @@ title: "How to contribute"
 
 subTitle: "Anyone can contribute to the Design System and UI Kit."
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/community/contribute.mdx?at=develop"
 ---
 

--- a/src/content/structured/get-started/design-principles.mdx
+++ b/src/content/structured/get-started/design-principles.mdx
@@ -9,8 +9,6 @@ title: "Design principles"
 
 subTitle: "Follow our community design principles."
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/design-principles.mdx?at=develop"
 
 hidden: false

--- a/src/content/structured/get-started/figma.mdx
+++ b/src/content/structured/get-started/figma.mdx
@@ -9,8 +9,6 @@ title: "Get the Figma kit"
 
 subTitle: "Reusable and flexible Figma components used to design, prototype and hand-off designs for apps and services."
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/figma.mdx"
 ---
 

--- a/src/content/structured/styles/colour.mdx
+++ b/src/content/structured/styles/colour.mdx
@@ -7,8 +7,6 @@ date: "2022-11-15"
 
 title: "Colour"
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/colour.mdx"
 ---
 

--- a/src/content/structured/styles/elevation.mdx
+++ b/src/content/structured/styles/elevation.mdx
@@ -7,8 +7,6 @@ date: "2022-11-15"
 
 title: "Elevation"
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/elevation.mdx"
 ---
 

--- a/src/content/structured/styles/focus-indicator.mdx
+++ b/src/content/structured/styles/focus-indicator.mdx
@@ -7,8 +7,6 @@ date: "2022-11-15"
 
 title: "Focus indicator"
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/focus-indicator.mdx"
 ---
 

--- a/src/content/structured/styles/icons.mdx
+++ b/src/content/structured/styles/icons.mdx
@@ -7,8 +7,6 @@ date: "2022-11-15"
 
 title: "Icons"
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/icons.mdx"
 ---
 

--- a/src/content/structured/styles/index.mdx
+++ b/src/content/structured/styles/index.mdx
@@ -9,8 +9,6 @@ title: "Styles"
 
 subTitle: "This section introduces our style tokens which describe how things look and feel."
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/index.mdx"
 ---
 

--- a/src/content/structured/styles/motion.mdx
+++ b/src/content/structured/styles/motion.mdx
@@ -7,8 +7,6 @@ date: "2022-11-15"
 
 title: "Motion"
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/motion.mdx"
 ---
 

--- a/src/content/structured/styles/typography.mdx
+++ b/src/content/structured/styles/typography.mdx
@@ -7,8 +7,6 @@ date: "2022-11-15"
 
 title: "Typography"
 
-status: "BETA"
-
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/typography.mdx"
 ---
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Remove "beta" tag from pages other than the individual component pages. The beta tag should only be on the component pages. The beta tag on the top nav covers the entire website. Patterns are still in development so the tags on that section will remain

## Related issue
#82

## Checklist
- [x] I have manually accessibility tested any changes, if relevant.