### PR TITLE
fix(root): add max width to component preview, and use attribute cards for xs breakpoint

### DIFF
--- a/src/components/AttributeCards/index.css
+++ b/src/components/AttributeCards/index.css
@@ -1,0 +1,32 @@
+.attribute-cards {
+  border: 1px solid var(--ic-architectural-300);
+  border-radius: var(--ic-border-radius);
+  max-width: 90vw;
+}
+
+.attribute-cards-cell {
+  padding: 0;
+}
+
+.attribute-cards-cell:last-child {
+  padding-right: 0;
+}
+
+.attribute-cards-cell:first-child {
+  padding-left: 0;
+}
+
+.attribute-cards-row {
+  display: table-row;
+}
+
+.attribute-cards-row:last-child > td {
+  border-bottom: none;
+}
+
+.cards-cell-name,
+.cards-cell-description,
+.cards-cell-default,
+.cards-cell-signature {
+  padding: var(--ic-space-md);
+}

--- a/src/components/AttributeCards/index.tsx
+++ b/src/components/AttributeCards/index.tsx
@@ -1,0 +1,43 @@
+import { IcTypography } from "@ukic/react";
+import React from "react";
+
+import "./index.css";
+
+interface AttributeCardsProps {
+  data: any[];
+}
+
+const AttributeCards: React.FC<AttributeCardsProps> = ({ data }) => (
+  <table className="attribute-cards">
+    <tbody>
+      {data.map((cell) => (
+        <tr className="attribute-cards-row">
+          <td className="attribute-cards-cell">
+            <IcTypography variant="subtitle-large" className="cards-cell-name">
+              {cell.name}
+            </IcTypography>
+            <IcTypography variant="body" className="cards-cell-description">
+              {cell.description}
+            </IcTypography>
+            {cell.default !== undefined ? (
+              <IcTypography variant="body" className="cards-cell-default">
+                Default: {cell.default}
+              </IcTypography>
+            ) : (
+              ""
+            )}
+            {cell.signature !== undefined ? (
+              <IcTypography variant="body" className="cards-cell-signature">
+                {cell.signature}
+              </IcTypography>
+            ) : (
+              ""
+            )}
+          </td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+);
+
+export default AttributeCards;

--- a/src/components/CodePreview/index.css
+++ b/src/components/CodePreview/index.css
@@ -56,8 +56,8 @@
 
 .snippet {
   border-radius: 0;
-  margin: 0!important;
-  border-radius: 0!important;
+  margin: 0 !important;
+  border-radius: 0 !important;
   padding-bottom: var(--ic-space-sm);
 }
 
@@ -101,5 +101,11 @@
 @media screen and (min-width: 577px) {
   .comp-preview ic-side-navigation {
     position: relative;
+  }
+}
+
+@media (max-width: 480px) {
+  .comp-preview {
+    max-width: 90vw;
   }
 }

--- a/src/components/ComponentDetails/EventTable/index.tsx
+++ b/src/components/ComponentDetails/EventTable/index.tsx
@@ -4,6 +4,7 @@ import { IcTypography } from "@ukic/react";
 import { JsonDocsEvent } from "@ukic/docs";
 import AttributeTable from "../../AttributeTable";
 import CodeAttribute from "../../CodeAttribute";
+import AttributeCards from "../../AttributeCards";
 
 interface EventTableProps {
   eventData: JsonDocsEvent[];
@@ -40,10 +41,14 @@ const EventTable: React.FC<EventTableProps> = ({ eventData }) => {
 
   return (
     <>
-      <IcTypography variant="h3">
+      <IcTypography variant="h3" applyVerticalMargins>
         <h3>Events</h3>
       </IcTypography>
-      <AttributeTable columns={columns} data={data} />
+      {window.screen.width > 576 ? (
+        <AttributeTable columns={columns} data={data} />
+      ) : (
+        <AttributeCards data={data} />
+      )}
     </>
   );
 };

--- a/src/components/ComponentDetails/MethodTable/index.tsx
+++ b/src/components/ComponentDetails/MethodTable/index.tsx
@@ -4,6 +4,7 @@ import { IcTypography } from "@ukic/react";
 import { JsonDocsMethod } from "@ukic/docs";
 import AttributeTable from "../../AttributeTable";
 import CodeAttribute from "../../CodeAttribute";
+import AttributeCards from "../../AttributeCards";
 
 interface MethodTableProps {
   methodData: JsonDocsMethod[];
@@ -40,10 +41,14 @@ const EventTable: React.FC<MethodTableProps> = ({ methodData }) => {
 
   return (
     <>
-      <IcTypography variant="h3">
+      <IcTypography variant="h3" applyVerticalMargins>
         <h3>Methods</h3>
       </IcTypography>
-      <AttributeTable columns={columns} data={data} />
+      {window.screen.width > 576 ? (
+        <AttributeTable columns={columns} data={data} />
+      ) : (
+        <AttributeCards data={data} />
+      )}
     </>
   );
 };

--- a/src/components/ComponentDetails/PropTable/index.tsx
+++ b/src/components/ComponentDetails/PropTable/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 
 import { IcTypography } from "@ukic/react";
 import AttributeTable from "../../AttributeTable";
+import AttributeCards from "../../AttributeCards";
 import PropDescription from "./PropDescription";
 
 interface StencilProp {
@@ -51,7 +52,11 @@ const PropTable: React.FC<PropTableProps> = ({ propData }) => {
       <IcTypography variant="h3" applyVerticalMargins>
         <h3>Props</h3>
       </IcTypography>
-      <AttributeTable columns={columns} data={data} />
+      {window.screen.width > 576 ? (
+        <AttributeTable columns={columns} data={data} />
+      ) : (
+        <AttributeCards data={data} />
+      )}
     </>
   );
 };

--- a/src/components/ComponentDetails/SlotTable/index.tsx
+++ b/src/components/ComponentDetails/SlotTable/index.tsx
@@ -3,6 +3,7 @@ import React, { useMemo } from "react";
 import { IcTypography } from "@ukic/react";
 import { JsonDocsSlot } from "@ukic/docs";
 import AttributeTable from "../../AttributeTable";
+import AttributeCards from "../../AttributeCards";
 
 interface PropTableProps {
   slotData: JsonDocsSlot[];
@@ -34,10 +35,14 @@ const PropTable: React.FC<PropTableProps> = ({ slotData }) => {
 
   return (
     <>
-      <IcTypography variant="h3">
+      <IcTypography variant="h3" applyVerticalMargins>
         <h3>Slots</h3>
       </IcTypography>
-      <AttributeTable columns={columns} data={data} />
+      {window.screen.width > 576 ? (
+        <AttributeTable columns={columns} data={data} />
+      ) : (
+        <AttributeCards data={data} />
+      )}
     </>
   );
 };

--- a/src/components/ComponentDetails/StyleTable/index.tsx
+++ b/src/components/ComponentDetails/StyleTable/index.tsx
@@ -4,6 +4,7 @@ import { IcTypography } from "@ukic/react";
 import { JsonDocsStyle } from "@ukic/docs";
 import AttributeTable from "../../AttributeTable";
 import CodeAttribute from "../../CodeAttribute";
+import AttributeCards from "../../AttributeCards";
 
 interface StyleTableProps {
   styleData: JsonDocsStyle[];
@@ -35,10 +36,14 @@ const StyleTable: React.FC<StyleTableProps> = ({ styleData }) => {
 
   return (
     <>
-      <IcTypography variant="h3">
+      <IcTypography variant="h3" applyVerticalMargins>
         <h3>CSS Custom Properties</h3>
       </IcTypography>
-      <AttributeTable columns={columns} data={data} />
+      {window.screen.width > 576 ? (
+        <AttributeTable columns={columns} data={data} />
+      ) : (
+        <AttributeCards data={data} />
+      )}
     </>
   );
 };


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
Add max width to component preview, and use attribute cards for xs breakpoint

## Related issue
#86

## Checklist
- [x] I have manually accessibility tested any changes, if relevant.