### PR TITLE
Change example component on page header to tabs variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ic-design-system",
-  "version": "6.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ic-design-system",
-      "version": "6.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@fontsource/open-sans": "^4.5.2",

--- a/src/content/structured/components/page-header/guidance.mdx
+++ b/src/content/structured/components/page-header/guidance.mdx
@@ -25,9 +25,8 @@ import {
   IcPageHeader,
   IcStatusTag,
   IcButton,
-  IcStepper,
-  IcStep,
   IcTextField,
+  IcNavigationItem,
 } from "@ukic/react";
 import pageHeaderFig1 from "./images/fig-1-page-header-anatomy.png";
 import pageHeaderFig2 from "./images/fig-2-dont-use-global-actions-in-a-page-header.png";
@@ -48,7 +47,7 @@ An example of the page header component.
 <ComponentPreview>
   <IcPageHeader
     heading="Coffee recipes"
-    sub-heading="This is a page header component that has an input area, actions and stepper."
+    sub-heading="This is a page header component that has an input area, actions and tabs."
     reverse-order=""
   >
     <IcStatusTag slot="heading-adornment" label="Beta" />
@@ -58,16 +57,9 @@ An example of the page header component.
     <IcButton slot="actions" variant="tertiary">
       Filter coffee
     </IcButton>
-    <IcStepper slot="stepper">
-      <IcStep stepTitle="Warm kettle" stepType="completed" />
-      <IcStep
-        stepTitle="Warm milk"
-        stepSubtitle="Optional"
-        stepType="completed"
-      />
-      <IcStep stepTitle="Pay for order" stepType="current" />
-    </IcStepper>
     <IcTextField slot="input" placeholder="Enter your input" hide-label="" />
+    <IcNavigationItem slot="tabs" label="All recipes" href="#" selected />
+    <IcNavigationItem slot="tabs" label="Favourites" href="#" />
   </IcPageHeader>
 </ComponentPreview>
 

--- a/src/content/structured/get-started/testing-with-jest.mdx
+++ b/src/content/structured/get-started/testing-with-jest.mdx
@@ -14,7 +14,7 @@ contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/struc
 
 [Jest](https://jestjs.io/) is a JavaScript testing framework designed to ensure correctness of any JavaScript codebase. It allows you to write tests with an approachable, familiar and feature-rich API that gives you results quickly.
 
-These instructions have been written with JavaScript in mind. Jest also supports TypeScript. Further instructions on how to set up Jest for TypeScript can be found on their ['Getting Started'](https://jestjs.io/docs/getting-started#using-typescript) page
+These instructions have been written with JavaScript in mind. Jest also supports TypeScript. Further instructions on how to set up Jest for TypeScript can be found on their ['Getting Started'](https://jestjs.io/docs/getting-started#using-typescript) page.
 
 ## Installing Jest
 
@@ -67,7 +67,7 @@ Note: components that have been slotted in can be found in the 'light' DOM. They
 ### Example
 
 ```js
-// To find all navigation items in a top nav
+// Find all navigation items in a top nav
 document
   .querySelector("ic-top-navigation")
   .querySelectorAll("ic-navigation-item");
@@ -86,7 +86,7 @@ document
 
 ## Example test
 
-Below is an example of a React component that uses the `IcTopNavigation` component. The labels for the navigation items are being mapped to the `IcNavigationItem` component
+Below is an example of a React component that uses the `IcTopNavigation` component. The labels for the navigation items are being mapped to the `IcNavigationItem` component.
 
 ```js
 // topNav.js


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

- Change page header example component to tabs variant
- Update package lock
- Add missing full stops to "Testing with Jest" page and remove "to" before finding nav items in example showing how to use the queryselector

## Related issue
#106 

## Checklist
- [x] I have manually accessibility tested any changes, if relevant.