### PR TITLE
Fix/safari regex bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5843,17 +5843,17 @@
     },
     "node_modules/@ukic/docs": {
       "version": "2.1.0-beta.0",
-      "resolved": "http://localhost:4873/@ukic%2fdocs/-/docs-2.1.0-beta.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ukic/docs/-/docs-2.1.0-beta.0.tgz",
       "integrity": "sha512-eQNeRmVruRiERvH6uJ5ymlnCtXg1W9a0+Lc1Awe7lTcLfDTmmaow6oCAZLO5XAHpsVCitfr3MDfaJI6One8W4w=="
     },
     "node_modules/@ukic/fonts": {
       "version": "2.1.0-beta.0",
-      "resolved": "http://localhost:4873/@ukic%2ffonts/-/fonts-2.1.0-beta.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.0.tgz",
       "integrity": "sha512-xMVJpStdTnRfGBnwNCIk6oqJmD8wcoxkSgJpxarU8O91RQTOTZuMjhoNR1CVnAb6Wfbd9xOmBDLYBOv0SbKEyA=="
     },
     "node_modules/@ukic/react": {
       "version": "2.1.0-beta.0",
-      "resolved": "http://localhost:4873/@ukic%2freact/-/react-2.1.0-beta.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ukic/react/-/react-2.1.0-beta.0.tgz",
       "integrity": "sha512-SJDeQyJ49lWuBN2HJeJaa4u+q4AUR1iWa4ZNYg005xu2C/EWRwzR1GOpOdtxjPwBGwah64yypC+RpA1GH3iBLQ==",
       "dependencies": {
         "@ukic/fonts": "^2.1.0-beta.0",
@@ -5866,7 +5866,7 @@
     },
     "node_modules/@ukic/web-components": {
       "version": "2.1.0-beta.0",
-      "resolved": "http://localhost:4873/@ukic%2fweb-components/-/web-components-2.1.0-beta.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.1.0-beta.0.tgz",
       "integrity": "sha512-/gvCVDOxjr6LIUXNTWfnkBqkhYXGwW6h5C9cdvBdn6yG94yYSPLYMLaPQkBorLxf9SfMGFeoSYF6bAeYGQdSKg==",
       "dependencies": {
         "@popperjs/core": "^2.11.2",
@@ -9209,9 +9209,9 @@
       }
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.1.tgz",
+      "integrity": "sha512-XZHyaFJ6QMWhYmlz+UcmtaLeecNiXwkTGzCqG5WByt+1P1HnU6Siwf0TeP3OsZmlnGqQRSEMIxue0LLCaGY3dw==",
       "engines": {
         "node": ">=0.10"
       }
@@ -22532,11 +22532,11 @@
       }
     },
     "node_modules/query-string": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
-      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.2.tgz",
+      "integrity": "sha512-KPbFzz/8pmtYOMH6zlYZgqTYJKQ18FxwfW3RLHIBwHWQ0iQG18X16XtIOk68ddfaM6j3grjYSnMPMrqQEjwR4w==",
       "dependencies": {
-        "decode-uri-component": "^0.2.0",
+        "decode-uri-component": "^0.2.1",
         "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
@@ -33354,17 +33354,17 @@
     },
     "@ukic/docs": {
       "version": "2.1.0-beta.0",
-      "resolved": "http://localhost:4873/@ukic%2fdocs/-/docs-2.1.0-beta.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ukic/docs/-/docs-2.1.0-beta.0.tgz",
       "integrity": "sha512-eQNeRmVruRiERvH6uJ5ymlnCtXg1W9a0+Lc1Awe7lTcLfDTmmaow6oCAZLO5XAHpsVCitfr3MDfaJI6One8W4w=="
     },
     "@ukic/fonts": {
       "version": "2.1.0-beta.0",
-      "resolved": "http://localhost:4873/@ukic%2ffonts/-/fonts-2.1.0-beta.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ukic/fonts/-/fonts-2.1.0-beta.0.tgz",
       "integrity": "sha512-xMVJpStdTnRfGBnwNCIk6oqJmD8wcoxkSgJpxarU8O91RQTOTZuMjhoNR1CVnAb6Wfbd9xOmBDLYBOv0SbKEyA=="
     },
     "@ukic/react": {
       "version": "2.1.0-beta.0",
-      "resolved": "http://localhost:4873/@ukic%2freact/-/react-2.1.0-beta.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ukic/react/-/react-2.1.0-beta.0.tgz",
       "integrity": "sha512-SJDeQyJ49lWuBN2HJeJaa4u+q4AUR1iWa4ZNYg005xu2C/EWRwzR1GOpOdtxjPwBGwah64yypC+RpA1GH3iBLQ==",
       "requires": {
         "@ukic/fonts": "^2.1.0-beta.0",
@@ -33373,7 +33373,7 @@
     },
     "@ukic/web-components": {
       "version": "2.1.0-beta.0",
-      "resolved": "http://localhost:4873/@ukic%2fweb-components/-/web-components-2.1.0-beta.0.tgz",
+      "resolved": "https://registry.npmjs.org/@ukic/web-components/-/web-components-2.1.0-beta.0.tgz",
       "integrity": "sha512-/gvCVDOxjr6LIUXNTWfnkBqkhYXGwW6h5C9cdvBdn6yG94yYSPLYMLaPQkBorLxf9SfMGFeoSYF6bAeYGQdSKg==",
       "requires": {
         "@popperjs/core": "^2.11.2",
@@ -35900,9 +35900,9 @@
       }
     },
     "decode-uri-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.1.tgz",
+      "integrity": "sha512-XZHyaFJ6QMWhYmlz+UcmtaLeecNiXwkTGzCqG5WByt+1P1HnU6Siwf0TeP3OsZmlnGqQRSEMIxue0LLCaGY3dw=="
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -45789,11 +45789,11 @@
       }
     },
     "query-string": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
-      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.2.tgz",
+      "integrity": "sha512-KPbFzz/8pmtYOMH6zlYZgqTYJKQ18FxwfW3RLHIBwHWQ0iQG18X16XtIOk68ddfaM6j3grjYSnMPMrqQEjwR4w==",
       "requires": {
-        "decode-uri-component": "^0.2.0",
+        "decode-uri-component": "^0.2.1",
         "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes
There is a safari reg exp bug which doesnt support the lookahead syntax `(?<=/\)`. This was used to delete cookies. This has been replaced. 

## Related issue
N/A

## Checklist
- [x] I have manually accessibility tested any changes, if relevant.