### PR TITLE
feat(root): high contrast mode changes - nav components and colour page

### DIFF
--- a/src/components/AnchorNav/index.css
+++ b/src/components/AnchorNav/index.css
@@ -18,7 +18,6 @@
   color: var(--ic-color-primary-text) !important;
   transition: var(--ic-easing-transition-fast);
   text-decoration: none !important;
-  outline: none;
 }
 
 .nav-link:hover:not(:focus) {
@@ -32,6 +31,7 @@
 .nav-link:focus {
   box-shadow: var(--ic-border-focus-inset);
   border-radius: var(--ic-border-radius-inset);
+  outline: var(--ic-hc-focus-outline);
 }
 
 .active-nav-link {
@@ -115,5 +115,16 @@
   .nav-list-items-container {
     border-left: none;
     padding-bottom: var(--ic-space-lg);
+  }
+}
+
+@media (forced-colors: active) {
+  .nav-link:focus {
+    border-radius: var(--ic-border-radius);
+    z-index: 1;
+  }
+
+  .active-nav-list-item::before {
+    background-color: canvastext;
   }
 }

--- a/src/components/SubsectionNav/index.css
+++ b/src/components/SubsectionNav/index.css
@@ -146,7 +146,7 @@
 .list-item a:focus {
   box-shadow: var(--ic-border-focus-inset);
   border-radius: var(--ic-border-radius-inset);
-  outline: none;
+  outline: var(--ic-hc-focus-outline);
 }
 
 .list-item > ul > li > a > ic-typography {
@@ -216,5 +216,52 @@
 
   .scroll {
     height: calc(100vh - var(--ic-space-lg));
+  }
+}
+
+@media (forced-colors: active) {
+  .list-item a:focus {
+    width: calc(100% - 6px);
+    margin-left: 3px;
+    z-index: 1;
+    border-radius: var(--ic-border-radius);
+    transition: outline var(--ic-easing-transition-fast);
+  }
+
+  .list-item a:focus .list-typography {
+    padding-left: calc(var(--ic-space-md) - 3px);
+  }
+
+  .list-item a:focus.active {
+    width: calc(100% - 38px);
+    margin-left: 11px;
+  }
+
+  .list-item a:focus.active .list-typography {
+    margin-left: -3px;
+  }
+
+  .list-item .active:focus::before {
+    left: -11px;
+  }
+
+  .list-root > li.icds-gatsby-lp > a:focus {
+    width: calc(100% - 6px);
+  }
+
+  .list-root > li.icds-gatsby-lp > a:focus .chevron {
+    margin-right: 6px;
+  }
+
+  .list-item > ul > li > a:focus > .list-typography {
+    padding-left: calc(var(--ic-space-xl) - 3px) !important;
+  }
+
+  .list-item > ul > li > a:focus.active > .list-typography {
+    padding-left: var(--ic-space-md) !important;
+  }
+
+  .chevron {
+    color: linktext !important;
   }
 }

--- a/src/content/structured/styles/components/ColourTable/index.css
+++ b/src/content/structured/styles/components/ColourTable/index.css
@@ -34,3 +34,15 @@
 .color-token {
   flex-basis: 40%;
 }
+
+@media (forced-colors: active) {
+  .circle {
+    forced-color-adjust: none;
+  }
+}
+
+@media (forced-colors: active) and (prefers-color-scheme: dark) {
+  .circle {
+    border: 1px solid var(--ic-architectural-white);
+  }
+}


### PR DESCRIPTION
## Summary of the changes
Added outlines to show focus on left hand nav (including making sure outline is not cut off / hidden) and anchor nav items, made selected indicator visible on anchor nav, made colour swatches visible and added white outline when in dark mode for better contrast with background.

Selected indicator for left hand nav has been done in [GCHQ-Developer-741's PR](https://github.com/mi6/ic-design-system/pull/116/files).

## Related issue
#91

## Checklist
- [x] I have manually accessibility tested any changes, if relevant.