### PR TITLE
docs(root): added heading for componentdetails

### DIFF
--- a/src/content/structured/components/alerts/code.mdx
+++ b/src/content/structured/components/alerts/code.mdx
@@ -74,6 +74,8 @@ export const snippetsDefault = [
   />
 </ComponentPreview>
 
+## Alert details
+
 <ComponentDetails component="ic-alert" />
 
 ## Variants

--- a/src/content/structured/components/back-to-top/code.mdx
+++ b/src/content/structured/components/back-to-top/code.mdx
@@ -45,4 +45,6 @@ export const snippets = [
   </IcButton>
 </ComponentPreview>
 
+## Back-to-top details
+
 <ComponentDetails component="ic-back-to-top" />

--- a/src/content/structured/components/buttons/code.mdx
+++ b/src/content/structured/components/buttons/code.mdx
@@ -47,6 +47,8 @@ export const snippetsDefault = [
   <IcButton variant="destructive">Destructive button</IcButton>
 </ComponentPreview>
 
+## Button details
+
 <ComponentDetails component="ic-button" />
 
 ## Variants

--- a/src/content/structured/components/cards/code.mdx
+++ b/src/content/structured/components/cards/code.mdx
@@ -42,6 +42,8 @@ export const snippets = [
   />
 </ComponentPreview>
 
+## Card details
+
 <ComponentDetails component="ic-card" />
 
 ## Variants

--- a/src/content/structured/components/classification-banner/code.mdx
+++ b/src/content/structured/components/classification-banner/code.mdx
@@ -55,6 +55,8 @@ export const snippets = [
   <IcClassificationBanner classification="top-secret" inline />
 </ComponentPreview>
 
+## Classification banner details
+
 <ComponentDetails component="ic-classification-banner" />
 
 ## Variants

--- a/src/content/structured/components/hero/code.mdx
+++ b/src/content/structured/components/hero/code.mdx
@@ -58,6 +58,8 @@ export const snippets = [
   </IcHero>
 </ComponentPreview>
 
+## Hero details
+
 <ComponentDetails component="ic-hero" />
 
 ## Variants

--- a/src/content/structured/components/links/code.mdx
+++ b/src/content/structured/components/links/code.mdx
@@ -40,6 +40,8 @@ export const snippets = [
   <IcLink href="/components/links/code">Links code page</IcLink>
 </ComponentPreview>
 
+## Link details
+
 <ComponentDetails component="ic-link" />
 
 ## Variants

--- a/src/content/structured/components/loading-indicators/code.mdx
+++ b/src/content/structured/components/loading-indicators/code.mdx
@@ -47,6 +47,8 @@ export const snippets = [
   <IcLoadingIndicator type="linear" label="Loading..." />
 </ComponentPreview>
 
+## Loading indicator details
+
 <ComponentDetails component="ic-loading-indicator" />
 
 ## Variants

--- a/src/content/structured/components/page-header/code.mdx
+++ b/src/content/structured/components/page-header/code.mdx
@@ -51,6 +51,8 @@ export const snippets = [
   <IcPageHeader heading="App title" subHeading="App information" />
 </ComponentPreview>
 
+## Page header details
+
 <ComponentDetails component="ic-page-header" />
 
 ## Variants

--- a/src/content/structured/components/search-bar/code.mdx
+++ b/src/content/structured/components/search-bar/code.mdx
@@ -69,6 +69,8 @@ export const snippets = [
   />
 </ComponentPreview>
 
+## Search bar details
+
 <ComponentDetails component="ic-search-bar" />
 
 ## Variants

--- a/src/content/structured/components/select/code.mdx
+++ b/src/content/structured/components/select/code.mdx
@@ -85,6 +85,8 @@ export const SelectExample = () => {
   <SelectExample />
 </ComponentPreview>
 
+## Select details
+
 <ComponentDetails component="ic-select" />
 
 ## Variants

--- a/src/content/structured/components/skeleton/code.mdx
+++ b/src/content/structured/components/skeleton/code.mdx
@@ -52,6 +52,8 @@ export const snippets = [
   </div>
 </ComponentPreview>
 
+## Skeleton details
+
 <ComponentDetails component="ic-skeleton" />
 
 ## Variants

--- a/src/content/structured/components/status-tags/code.mdx
+++ b/src/content/structured/components/status-tags/code.mdx
@@ -47,6 +47,8 @@ export const snippetsDefault = [
   <IcStatusTag label="Danger" status="danger" />
 </ComponentPreview>
 
+## Status tag details
+
 <ComponentDetails component="ic-status-tag" />
 
 ## Variants

--- a/src/content/structured/components/switch/code.mdx
+++ b/src/content/structured/components/switch/code.mdx
@@ -38,6 +38,8 @@ export const snippetsDefault = [
   <IcSwitch label="Unlimited coffee" />
 </ComponentPreview>
 
+## Switch details
+
 <ComponentDetails component="ic-switch" />
 
 ## Variants

--- a/src/content/structured/components/text-input/code.mdx
+++ b/src/content/structured/components/text-input/code.mdx
@@ -49,6 +49,8 @@ export const snippetsDefault = [
   />
 </ComponentPreview>
 
+## Text field details
+
 <ComponentDetails component="ic-text-field" />
 
 ## Variants

--- a/src/content/structured/components/tooltips/code.mdx
+++ b/src/content/structured/components/tooltips/code.mdx
@@ -59,6 +59,8 @@ export const snippets = [
   </div>
 </ComponentPreview>
 
+## Tooltip details
+
 <ComponentDetails component="ic-tooltip" />
 
 ## Variants

--- a/src/content/structured/components/typography/code.mdx
+++ b/src/content/structured/components/typography/code.mdx
@@ -61,7 +61,11 @@ export const spacingSnippets = [
   },
 ];
 
+## Typography details
+
 <ComponentDetails component="ic-typography" />
+
+## Variants
 
 ### With top and bottom margins applied
 


### PR DESCRIPTION
## Summary of the changes
After conversation with designers, instead of refactoring the codedetails tables to include the headers in the AnchorNav, added a Component Details header to markdown.

## Related issue
#25 

## Checklist
- [x] I have manually accessibility tested any changes, if relevant.