### PR TITLE
fix labelling of 'Radial indeterminate'

### DIFF
--- a/src/content/structured/components/loading-indicators/guidance.mdx
+++ b/src/content/structured/components/loading-indicators/guidance.mdx
@@ -73,7 +73,7 @@ The icon size is available for use within other components.
   variant="label"
   style={{ marginTop: "-16px", marginBottom: "24px" }}
 >
-  Radial determinate.
+  Radial indeterminate.
 </IcTypography>
 
 ## Linear


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

Simple typo fix to correctly label the `radial indeterminate`.

## Related issue

n/a

## Checklist

- [x] I have manually accessibility tested any changes, if relevant.
