### PR TITLE
docs: pr template, add links and highlight use of the develop branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,7 @@
 <!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
+<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->
+
+<!-- In particular all PRs must be raised against the `develop` branch. -->
 
 ## Summary of the changes
 
@@ -10,4 +13,5 @@ Tell us the issue number. If suggesting an improvement or component, please disc
 
 ## Checklist
 
-- [ ] I have manually accessibility tested any changes, if relevant.
+- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
+- [ ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

Updated the pull request template to add link to the manual accessibility testing guidance and draw more attention to that PRs should be raised against the `develop` branch

## Related issue

[fix labelling of 'Radial indeterminate'](https://github.com/mi6/ic-design-system/pull/150)

## Checklist

- [x] I have manually accessibility tested any changes, if relevant.
