### PR TITLE
Develop

### DIFF
--- a/src/content/structured/components/classification-banner/accessibility.mdx
+++ b/src/content/structured/components/classification-banner/accessibility.mdx
@@ -24,7 +24,7 @@ tabs:
 
 import { IcClassificationBanner } from "@ukic/react";
 
-<IcClassificationBanner classification="official" />
+<IcClassificationBanner />
 
 ## Easy to use for everyone
 

--- a/src/content/structured/components/classification-banner/code.mdx
+++ b/src/content/structured/components/classification-banner/code.mdx
@@ -24,7 +24,7 @@ tabs:
 
 import { IcClassificationBanner } from "@ukic/react";
 
-<IcClassificationBanner classification="secret" />
+<IcClassificationBanner />
 
 export const snippets = [
   {

--- a/src/content/structured/components/classification-banner/guidance.mdx
+++ b/src/content/structured/components/classification-banner/guidance.mdx
@@ -38,7 +38,7 @@ Protective markings indicate the level of sensitivity of classified or controlle
   <IcClassificationBanner classification="top-secret" inline />
 </ComponentPreview>
 
-<IcClassificationBanner classification="top-secret" />
+<IcClassificationBanner />
 
 ## When to use
 

--- a/src/content/structured/components/loading-indicators/guidance.mdx
+++ b/src/content/structured/components/loading-indicators/guidance.mdx
@@ -73,7 +73,7 @@ The icon size is available for use within other components.
   variant="label"
   style={{ marginTop: "-16px", marginBottom: "24px" }}
 >
-  Radial determinate.
+  Radial indeterminate.
 </IcTypography>
 
 ## Linear


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

Updating classification banner prop. Removal of different variants and now only showing protective marking no set. 
Update to loading indicator examples

## Related issue

N/A

## Checklist

- [x] I have manually accessibility tested any changes, if relevant.
