### PR TITLE
fix(root): add missing opening breadcrumbs tag

### DIFF
--- a/src/content/structured/components/page-header/code.mdx
+++ b/src/content/structured/components/page-header/code.mdx
@@ -78,6 +78,7 @@ export const withBreadcrumbNavigation = [
     language: "React",
     snippet: `<IcPageHeader heading="Coffee recipes" subHeading="This is a page header component that has breadcrumb navigation.">
   <IcStatusTag slot="heading-adornment" label="Beta" />
+  <IcBreadcrumbGroup slot="breadcrumbs">
     <IcBreadcrumb pageTitle="Breadcrumb 1" href="#" />
     <IcBreadcrumb 
       current


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->

## Summary of the changes

Add missing opening breadcrumbs tag to react page header example

## Related issue

 #124

## Checklist

- [x] I have manually accessibility tested any changes, if relevant.
