### PR TITLE
fix(root): fixed QA link repo to not run on forked branches

### DIFF
--- a/.github/workflows/add-qa-link-to-issues.yml
+++ b/.github/workflows/add-qa-link-to-issues.yml
@@ -2,12 +2,15 @@ name: Add QA link to issues on successful build
 
 on:
   pull_request:
+    types:
+      - opened
 
 jobs:
   add-comment:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+    if: github.event.pull_request.head.repo.name == 'ic-design-system'
     steps:
       - name: Extract branch name
         run: echo "branch=${GITHUB_HEAD_REF#refs/heads/}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Write access is not granted when a PR is from a forked repo, so adding a condition to only run when the head branch is from the ic-design-system repo