### PR TITLE
fix(root): stopping workflows from triggering incorrectly

### DIFF
--- a/.github/workflows/add-qa-link-to-issues.yml
+++ b/.github/workflows/add-qa-link-to-issues.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.event.pull_request.head.repo.name == 'ic-design-system'
+    if: github.event.pull_request.head.repo.full_name == 'mi6/ic-design-system'
     steps:
       - name: Extract branch name
         run: echo "branch=${GITHUB_HEAD_REF#refs/heads/}" >> $GITHUB_OUTPUT

--- a/.github/workflows/welcome-new-contributors.yml
+++ b/.github/workflows/welcome-new-contributors.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   welcome-message:
     runs-on: ubuntu-latest
-
+    if: github.event.pull_request.head.repo.full_name != 'mi6/ic-design-system'
     steps:
       - uses: actions/first-interaction@v1
         with:


### PR DESCRIPTION
Stopping workflows from triggering on forks when not needed, and when triggering on our branches when not needed
