### PR TITLE
feat(root): add explanation about slots to components' code pages

### DIFF
--- a/src/components/ComponentDetails/SlotTable/index.tsx
+++ b/src/components/ComponentDetails/SlotTable/index.tsx
@@ -36,6 +36,38 @@ const PropTable: React.FC<PropTableProps> = ({ slotData }) => {
       <ic-typography variant="h3" apply-vertical-margins>
         <h3>Slots</h3>
       </ic-typography>
+      <ic-typography apply-vertical-margins>
+        <p>
+          A slot allows for any type of element or markup to be passed into and
+          rendered within a web component. This creates more flexibility than
+          using a prop which must take a specific type of data.
+        </p>
+      </ic-typography>
+      <ic-typography apply-vertical-margins>
+        <p>
+          Content can be slotted into a component by adding it as a top-level
+          child of the component.
+        </p>
+      </ic-typography>
+      <ic-typography apply-vertical-margins>
+        <p>
+          Slots can have a name to identify them. These specify which slot the
+          content will be inserted into, and therefore where it will be rendered
+          and how it will be used within the component. The name of the slot to
+          be used can be specified by passing it via a{" "}
+          <code className="language-text">slot</code> attribute on the slotted
+          content.
+        </p>
+      </ic-typography>
+      <ic-typography apply-vertical-margins>
+        <p>
+          <ic-link href="https://javascript.info/slots-composition">
+            Read more about slots
+          </ic-link>
+          .
+        </p>
+      </ic-typography>
+      <br />
       <AttributeTable columns={columns} data={data} />
       <AttributeCards data={data} />
     </>


### PR DESCRIPTION
## Summary of the changes

Add an explanation about slots above the slots table on the code pages for the components. Had to add the 'language-text' class to the `<code>` so it displays the same grey background as other code blocks written in markdown.

## Related issue

#15
