### PR TITLE
fix(root): fixed broken reference link on page

### DIFF
--- a/src/content/structured/accessibility/needs/auditory.mdx
+++ b/src/content/structured/accessibility/needs/auditory.mdx
@@ -55,7 +55,7 @@ Don't rely on automated subtitling and transcription because it might be inaccur
 ## References
 
 1. <a
-     href=" https://www.actiononhearingloss.org.uk/about-us/our-research-and-evidence/facts-and-figures/"
+     href="https://rnid.org.uk/about-us/research-and-policy/facts-and-figures/"
      id="fn-1"
    >
      Facts and figures


### PR DESCRIPTION
Fixed link that contained space and was therefore directing the user to a non-existent page in the site instead of an external page
