### PR TITLE
fix(root): changed spacing token affecting the spacing between page c…

### DIFF
--- a/src/content/structured/styles/layout-spacing.mdx
+++ b/src/content/structured/styles/layout-spacing.mdx
@@ -37,7 +37,7 @@ Every component is created upon a grid comprising of eight-pixel squares. Each i
   imageSrc={layoutSpacingFig1}
   imageAlt="Two short forms each with a select box, text area and secondary button. All components and their internal elements align to a visible eight-pixel grid."
   state="none"
-  caption="Two examples of a side-navigation layout each with a page header. One uses a page header with tabs to provide secondary navigation. The other uses a page header with a stepper."
+  caption="Components are based upon an eight-pixel grid to help drive visual consistency between them."
 />
 
 Spacing tokens are used within the components to make sure they are consistent and to allow the quick update of spacing within the system by changing the token values. The spacing tokens are all multiples of the base eight-pixel grid square.

--- a/src/templates/CoreTemplate/index.css
+++ b/src/templates/CoreTemplate/index.css
@@ -87,7 +87,7 @@ ic-alert {
 
 @media screen and (min-width: 1201px) and (max-width: 1384px) {
   .content-container {
-    width: calc(100% - var(--ic-space-xxl));
+    width: calc(100% - var(--ic-space-lg));
   }
 }
 


### PR DESCRIPTION
…ontent

Used a spacing token that was half the size to halve the margin between content and anchor nav, so that it matches the designs. Also, fixed incorrect caption.

## Related issue
[#218 in ic-ui-kit](https://github.com/mi6/ic-ui-kit/issues/218)

## Checklist
- [x] I have manually accessibility tested any changes, if relevant.
