### PR TITLE
docs(root): add guidance about normalize.css file

### DIFF
--- a/src/content/structured/get-started/angular.mdx
+++ b/src/content/structured/get-started/angular.mdx
@@ -85,3 +85,13 @@ Add the following into the top level CSS file for your project. For newly genera
 @import "@ukic/fonts/dist/fonts.css";
 @import "@ukic/web-components/dist/core/core.css";
 ```
+
+<br />
+
+In order to be rendered consistently across browsers and in line with modern standards, each of the ICDS components uses styles from a global CSS file based on [Normalize.css](https://necolas.github.io/normalize.css/).
+
+If you would like to import these styles to apply them to the rest of your project and slotted elements used within any of the ICDS components, add the following into the top level CSS file as well.
+
+```css
+@import "@ukic/web-components/dist/core/normalize.css";
+```

--- a/src/content/structured/get-started/gatsby.mdx
+++ b/src/content/structured/get-started/gatsby.mdx
@@ -72,6 +72,16 @@ import "@ukic/fonts/dist/fonts.css";
 import "@ukic/react/dist/core/core.css";
 ```
 
+<br />
+
+In order to be rendered consistently across browsers and in line with modern standards, each of the ICDS components uses styles from a global CSS file based on [Normalize.css](https://necolas.github.io/normalize.css/).
+
+If you would like to import these styles to apply them to the rest of your project and slotted elements used within any of the ICDS components, add the following into the top level index file as well.
+
+```jsx
+import "@ukic/react/dist/core/normalize.css";
+```
+
 ## Helpful links
 
 The Gatsby documentation contains more information on the [gatsby-plugin-stencil](https://www.gatsbyjs.com/plugins/gatsby-plugin-stencil/) plugin. Further information can be found on [using Stencil web components in Gatsby](https://dev.to/brunnerlivio/use-stencil-with-gatsbyjs-1omo).

--- a/src/content/structured/get-started/react.mdx
+++ b/src/content/structured/get-started/react.mdx
@@ -44,6 +44,16 @@ Add the following into the top level CSS file for your project.
 @import "@ukic/react/dist/core/core.css";
 ```
 
+<br />
+
+In order to be rendered consistently across browsers and in line with modern standards, each of the ICDS components uses styles from a global CSS file based on [Normalize.css](https://necolas.github.io/normalize.css/).
+
+If you would like to import these styles to apply them to the rest of your project and slotted elements used within any of the ICDS components, add the following into the top level CSS file as well.
+
+```css
+@import "@ukic/react/dist/core/normalize.css";
+```
+
 ## Using NextJS
 
 The `@ukic/react` package will need to be transpiled for use with NextJS. The steps required will depend on the version of NextJS you are using.

--- a/src/content/structured/get-started/svelte.mdx
+++ b/src/content/structured/get-started/svelte.mdx
@@ -63,3 +63,13 @@ Add the following into the top level CSS file for your project. For newly genera
 @import "@ukic/fonts/dist/fonts.css";
 @import "@ukic/web-components/dist/core/core.css";
 ```
+
+<br />
+
+In order to be rendered consistently across browsers and in line with modern standards, each of the ICDS components uses styles from a global CSS file based on [Normalize.css](https://necolas.github.io/normalize.css/).
+
+If you would like to import these styles to apply them to the rest of your project and slotted elements used within any of the ICDS components, add the following into the top level CSS file as well.
+
+```css
+@import "@ukic/web-components/dist/core/normalize.css";
+```

--- a/src/content/structured/get-started/vue.mdx
+++ b/src/content/structured/get-started/vue.mdx
@@ -114,3 +114,13 @@ Add the following into the top level CSS file for your project.
 @import "@ukic/fonts/dist/fonts.css";
 @import "@ukic/web-components/dist/core/core.css";
 ```
+
+<br />
+
+In order to be rendered consistently across browsers and in line with modern standards, each of the ICDS components uses styles from a global CSS file based on [Normalize.css](https://necolas.github.io/normalize.css/).
+
+If you would like to import these styles to apply them to the rest of your project and slotted elements used within any of the ICDS components, add the following into the top level CSS file as well.
+
+```css
+@import "@ukic/web-components/dist/core/normalize.css";
+```

--- a/src/content/structured/get-started/web-components.mdx
+++ b/src/content/structured/get-started/web-components.mdx
@@ -62,6 +62,16 @@ Add the following into the top level CSS file for your project.
 @import "@ukic/web-components/dist/core/core.css";
 ```
 
+<br />
+
+In order to be rendered consistently across browsers and in line with modern standards, each of the ICDS components uses styles from a global CSS file based on [Normalize.css](https://necolas.github.io/normalize.css/).
+
+If you would like to import these styles to apply them to the rest of your project and slotted elements used within any of the ICDS components, add the following into the top level CSS file as well.
+
+```css
+@import "@ukic/web-components/dist/core/normalize.css";
+```
+
 ## Webpack example
 
 Webpack is a tool for bundling web applications. This example assumes the following config in `webpack.config.js`. For more detailed information on Webpack configuration, please refer to the Webpack documentation.


### PR DESCRIPTION
## Summary of the changes
Added guidance about adding import for normalize.css file to getting started guides.

The guidance has been copied from the guidance which was added and merged into the UI Kit repo (with very slight changes e.g. 'top level CSS file' -> 'top level index file' in the Gatsby instructions).

## Related issue

mi6/ic-ui-kit#296

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
