### PR TITLE
docs(root): add additional code examples for stepper

### DIFF
--- a/src/content/structured/components/page-header/code.mdx
+++ b/src/content/structured/components/page-header/code.mdx
@@ -39,16 +39,16 @@ import { NavLink, MemoryRouter } from "react-router-dom";
 export const snippets = [
   {
     language: "Web component",
-    snippet: `<ic-page-header heading="App title" sub-heading="App information"></ic-page-header>`,
+    snippet: `<ic-page-header heading="App title" subheading="App information"></ic-page-header>`,
   },
   {
     language: "React",
-    snippet: `<IcPageHeader heading="App title" subHeading="App information" />`,
+    snippet: `<IcPageHeader heading="App title" subheading="App information" />`,
   },
 ];
 
 <ComponentPreview snippets={snippets} style={{ flexDirection: "column" }}>
-  <IcPageHeader heading="App title" subHeading="App information" />
+  <IcPageHeader heading="App title" subheading="App information" />
 </ComponentPreview>
 
 ## Page header details
@@ -62,7 +62,7 @@ export const snippets = [
 export const withBreadcrumbNavigation = [
   {
     language: "Web component",
-    snippet: `<ic-page-header heading="Coffee recipes" sub-heading="This is a page header component that has breadcrumb navigation.">
+    snippet: `<ic-page-header heading="Coffee recipes" subheading="This is a page header component that has breadcrumb navigation.">
   <ic-status-tag slot="heading-adornment" label="Beta"></ic-status-tag>
   <ic-breadcrumb-group slot="breadcrumbs">
     <ic-breadcrumb page-title="Breadcrumb 1" href="#"></ic-breadcrumb>
@@ -78,7 +78,7 @@ export const withBreadcrumbNavigation = [
   },
   {
     language: "React",
-    snippet: `<IcPageHeader heading="Coffee recipes" subHeading="This is a page header component that has breadcrumb navigation.">
+    snippet: `<IcPageHeader heading="Coffee recipes" subheading="This is a page header component that has breadcrumb navigation.">
   <IcStatusTag slot="heading-adornment" label="Beta" />
   <IcBreadcrumbGroup slot="breadcrumbs">
     <IcBreadcrumb pageTitle="Breadcrumb 1" href="#" />
@@ -99,7 +99,7 @@ export const withBreadcrumbNavigation = [
 >
   <IcPageHeader
     heading="Coffee recipes"
-    subHeading="This is a page header component that has breadcrumb navigation."
+    subheading="This is a page header component that has breadcrumb navigation."
   >
     <IcStatusTag slot="heading-adornment" label="Beta" />
     <IcBreadcrumbGroup slot="breadcrumbs">
@@ -114,7 +114,7 @@ export const withBreadcrumbNavigation = [
 export const withActionsInputStepper = [
   {
     language: "Web component",
-    snippet: `<ic-page-header heading="Coffee recipes" sub-heading="This is a page header component that has an input area, actions &amp; stepper." reverse-order="true">
+    snippet: `<ic-page-header heading="Coffee recipes" subheading="This is a page header component that has an input area, actions &amp; stepper." reverse-order="true">
   <ic-status-tag slot="heading-adornment" label="Beta"></ic-status-tag>
   <ic-button slot="actions" variant="primary">Create coffee</ic-button>
   <ic-button slot="actions" variant="tertiary">Filter coffee</ic-button>
@@ -129,7 +129,7 @@ export const withActionsInputStepper = [
   },
   {
     language: "React",
-    snippet: `<IcPageHeader heading="Coffee recipes" subHeading="This is a page header component that has an input area, actions and stepper." reverseOrder>
+    snippet: `<IcPageHeader heading="Coffee recipes" subheading="This is a page header component that has an input area, actions and stepper." reverseOrder>
   <IcStatusTag slot="heading-adornment" label="Beta" />
   <IcButton slot="actions" variant="primary">
     Create coffee
@@ -154,7 +154,7 @@ export const withActionsInputStepper = [
 >
   <IcPageHeader
     heading="Coffee recipes"
-    subHeading="This is a page header component that has an input area, actions and stepper."
+    subheading="This is a page header component that has an input area, actions and stepper."
     reverseOrder
   >
     <IcStatusTag slot="heading-adornment" label="Beta" />
@@ -189,7 +189,7 @@ export const withActionsInputTabs = [
     language: "Web component",
     snippet: `<ic-page-header 
   heading="Coffee recipes" 
-  sub-heading="This is a page header component that has an input area, actions &amp; tabs." 
+  subheading="This is a page header component that has an input area, actions &amp; tabs." 
   reverse-order="true"
 >
   <ic-status-tag slot="heading-adornment" label="Beta"></ic-status-tag>
@@ -216,7 +216,7 @@ export const withActionsInputTabs = [
     language: "React",
     snippet: `<IcPageHeader 
   heading="Coffee recipes" 
-  subHeading="This is a page header component that has an input area, actions and tabs." 
+  subheading="This is a page header component that has an input area, actions and tabs." 
   reverseOrder>
   <IcStatusTag slot="heading-adornment" label="Beta" />
   <IcButton slot="actions" variant="primary">
@@ -253,7 +253,7 @@ export const withActionsInputTabs = [
 >
   <IcPageHeader
     heading="Coffee recipes"
-    subHeading="This is a page header component that has an input area, actions and tabs."
+    subheading="This is a page header component that has an input area, actions and tabs."
     reverseOrder
   >
     <IcStatusTag slot="heading-adornment" label="Beta" />
@@ -282,7 +282,7 @@ export const withReactRouter = [
     snippet: `<MemoryRouter initialEntries={["/"]}>
   <IcPageHeader
     heading="Coffee recipes"
-    sub-heading="This is a page header component that has an input area, actions and tabs. This page header uses React Router."
+    subheading="This is a page header component that has an input area, actions and tabs. This page header uses React Router."
     reverseOrder
   >
     <IcStatusTag slot="heading-adornment" label="Beta" />
@@ -323,7 +323,7 @@ export const withReactRouter = [
   <MemoryRouter initialEntries={["/"]}>
     <IcPageHeader
       heading="Coffee recipes"
-      sub-heading="This is a page header component that has an input area, actions and tabs. This page header uses React Router."
+      subheading="This is a page header component that has an input area, actions and tabs. This page header uses React Router."
       reverseOrder
     >
       <IcStatusTag slot="heading-adornment" label="Beta" />

--- a/src/content/structured/components/page-header/guidance.mdx
+++ b/src/content/structured/components/page-header/guidance.mdx
@@ -26,7 +26,8 @@ import {
   IcStatusTag,
   IcButton,
   IcTextField,
-  IcNavigationItem,
+  IcStepper,
+  IcStep,
 } from "@ukic/react";
 import pageHeaderFig1 from "./images/fig-1-page-header-anatomy.png";
 import pageHeaderFig2 from "./images/fig-2-dont-use-global-actions-in-a-page-header.png";
@@ -47,8 +48,8 @@ An example of the page header component.
 <ComponentPreview>
   <IcPageHeader
     heading="Coffee recipes"
-    sub-heading="This is a page header component that has an input area, actions and tabs."
-    reverse-order=""
+    subheading="This is a page header component that has an input area, actions and stepper."
+    reverseOrder
   >
     <IcStatusTag slot="heading-adornment" label="Beta" />
     <IcButton slot="actions" variant="primary">
@@ -57,9 +58,21 @@ An example of the page header component.
     <IcButton slot="actions" variant="tertiary">
       Filter coffee
     </IcButton>
-    <IcTextField slot="input" placeholder="Enter your input" hide-label="" />
-    <IcNavigationItem slot="tabs" label="All recipes" href="#" selected />
-    <IcNavigationItem slot="tabs" label="Favourites" href="#" />
+    <IcStepper slot="stepper">
+      <IcStep stepTitle="Warm kettle" stepType="completed" />
+      <IcStep
+        stepTitle="Warm milk"
+        stepSubtitle="Optional"
+        stepType="completed"
+      />
+      <IcStep stepTitle="Pour milk" stepType="current" />
+    </IcStepper>
+    <IcTextField
+      slot="input"
+      placeholder="Enter your input"
+      label="Input"
+      hideLabel
+    />
   </IcPageHeader>
 </ComponentPreview>
 

--- a/src/content/structured/components/side-nav/code.mdx
+++ b/src/content/structured/components/side-nav/code.mdx
@@ -24,7 +24,7 @@ import {
   IcNavigationItem,
   IcNavigationGroup,
   IcDivider,
-  IcLink
+  IcLink,
 } from "@ukic/react";
 
 import { MemoryRouter, NavLink } from "react-router-dom";
@@ -962,9 +962,11 @@ export const basicLayoutFixedViewport = [
     display: "flex",
     height: "100%",
     justifyContent: "center",
-    alignItems: 'center',
+    alignItems: "center",
     padding: "16px",
   }}
 >
-  <IcLink href='/ic-side-nav-fixed-example/index.html' target='_blank' showIcon>View example in new window</IcLink>
+  <IcLink href="/ic-side-nav-fixed-example/index.html" target="_blank" showIcon>
+    View example in new window
+  </IcLink>
 </ComponentPreview>

--- a/src/content/structured/components/stepper/code.mdx
+++ b/src/content/structured/components/stepper/code.mdx
@@ -60,6 +60,35 @@ export const snippets = [
 
 ## Variants
 
+### Compact stepper
+
+export const compactStepper = [
+  {
+    language: "Web component",
+    snippet: `<ic-stepper variant="compact">
+  <ic-step step-title="Order coffee" step-type="completed"></ic-step>
+  <ic-step step-title="Pay for order" step-type="current"></ic-step>
+  <ic-step step-title="Collect" step-type="disabled"></ic-step>
+</ic-stepper>`,
+  },
+  {
+    language: "React",
+    snippet: `<IcStepper variant="compact">
+  <IcStep stepTitle="Order coffee" stepType="completed" />
+  <IcStep stepTitle="Pay for order" stepType="current" />
+  <IcStep stepTitle="Collect" stepType="disabled" />
+</IcStepper>`,
+  },
+];
+
+<ComponentPreview snippets={compactStepper}>
+  <IcStepper variant="compact">
+    <IcStep stepTitle="Order coffee" stepType="completed" />
+    <IcStep stepTitle="Pay for order" stepType="current" />
+    <IcStep stepTitle="Collect" stepType="disabled" />
+  </IcStepper>
+</ComponentPreview>
+
 ### Left-aligned
 
 export const leftAligned = [
@@ -89,33 +118,32 @@ export const leftAligned = [
   </IcStepper>
 </ComponentPreview>
 
-### Without step titles
+### With hidden step information
 
-export const withoutStepTitles = [
+export const hiddenStepInfo = [
   {
     language: "Web component",
-    snippet: `<ic-stepper>
-  <ic-step step-type="completed"></ic-step>
-  <ic-step step-type="current"></ic-step>
-  <ic-step step-type="disabled"></ic-step>
-  <ic-step></ic-step>
+    snippet: `<ic-stepper hide-step-info="true">
+  <ic-step step-title="Order coffee" step-type="completed"></ic-step>
+  <ic-step step-title="Pay for order" step-type="current"></ic-step>
+  <ic-step step-title="Collect" step-type="disabled"></ic-step>
 </ic-stepper>`,
   },
   {
     language: "React",
-    snippet: `<IcStepper>
-  <IcStep stepType="completed" />
-  <IcStep stepType="current" />
-  <IcStep stepType="disabled" />
+    snippet: `<IcStepper hideStepInfo>
+  <IcStep stepTitle="Order coffee" stepType="completed" />
+  <IcStep stepTitle="Pay for order" stepType="current" />
+  <IcStep stepTitle="Collect" stepType="disabled" />
 </IcStepper>`,
   },
 ];
 
-<ComponentPreview snippets={withoutStepTitles}>
-  <IcStepper>
-    <IcStep stepType="completed" />
-    <IcStep stepType="current" />
-    <IcStep stepType="disabled" />
+<ComponentPreview snippets={hiddenStepInfo}>
+  <IcStepper hideStepInfo>
+    <IcStep stepTitle="Order coffee" stepType="completed" />
+    <IcStep stepTitle="Pay for order" stepType="current" />
+    <IcStep stepTitle="Collect" stepType="disabled" />
   </IcStepper>
 </ComponentPreview>
 
@@ -190,7 +218,7 @@ export const customConnectorWidth = [
   },
   {
     language: "React",
-    snippet: `<IcStepper aligned="left" connectorWidth="150">
+    snippet: `<IcStepper aligned="left" connectorWidth={150}>
   <IcStep stepTitle="Order coffee" stepType="completed" />
   <IcStep stepTitle="Pay for order" stepType="current" />
   <IcStep stepTitle="Collect" stepType="disabled" />
@@ -199,7 +227,7 @@ export const customConnectorWidth = [
 ];
 
 <ComponentPreview snippets={customConnectorWidth}>
-  <IcStepper aligned="left" connectorWidth="150">
+  <IcStepper aligned="left" connectorWidth={150}>
     <IcStep stepTitle="Order coffee" stepType="completed" />
     <IcStep stepTitle="Pay for order" stepType="current" />
     <IcStep stepTitle="Collect" stepType="disabled" />

--- a/src/content/structured/components/stepper/guidance.mdx
+++ b/src/content/structured/components/stepper/guidance.mdx
@@ -21,7 +21,7 @@ tabs:
   ]
 ---
 
-import { IcStepper, IcStep, IcAlert } from "@ukic/react";
+import { IcStepper, IcStep } from "@ukic/react";
 import stepperFig1 from "./images/fig-1-stepper-component-being-used-to-describe-the-steps-of-a-multistep-form.png";
 import stepperFig2 from "./images/fig-2-use-concise-labels-within-a-stepper.png";
 import stepperFig3 from "./images/fig-3-dont-use-long-labels-within-a-stepper.png";
@@ -50,12 +50,6 @@ An example of the stepper component.
 Use the default stepper when you have the available space.
 
 ### Compact
-
-<IcAlert
-  heading="Coming soon"
-  message="Compact stepper functionality is currently in development."
-  variant="info"
-/>
 
 Use the compact variant for compact layouts or processes with many steps.
 
@@ -166,7 +160,7 @@ Hide step information only if the step content is clearly labelled itself. Do no
   caption="Don’t use a stepper without step labels if the page content does not include the step name in a heading."
 />
 
-Set a step status to show whether the step is required or optional in the step's subtitle. Override the step subtitle text to provide a custom message. 
+Set a step status to show whether the step is required or optional in the step's subtitle. Override the step subtitle text to provide a custom message.
 
 ### Validation
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add compact stepper and hideStepInfo code examples for stepper. Prettier fix to side nav. Update props on page header

## Related issue

#198 

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
