### PR TITLE
fix(root): add deprecated event descriptions back

### DIFF
--- a/src/components/ComponentDetails/EventTable/EventDescription/index.css
+++ b/src/components/ComponentDetails/EventTable/EventDescription/index.css
@@ -1,0 +1,9 @@
+.event-description .deprecation-tag {
+  margin-top: var(--ic-space-xs);
+}
+
+@media screen and (max-width: 576px) {
+  .event-description .deprecation-tag {
+    margin-top: var(--ic-space-lg);
+  }
+}

--- a/src/components/ComponentDetails/EventTable/EventDescription/index.tsx
+++ b/src/components/ComponentDetails/EventTable/EventDescription/index.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import "./index.css";
+
+const EventDescription: React.FC<{
+  description: string;
+  deprecation: string | undefined;
+}> = ({ description, deprecation }) => (
+  <div className="event-description">
+    {!!description && <ic-typography>{description}</ic-typography>}
+    {deprecation && (
+      <>
+        <ic-typography>{deprecation}</ic-typography>
+        <div className="deprecation-tag">
+          <ic-status-tag label="Deprecated" status="warning" small />
+        </div>
+      </>
+    )}
+  </div>
+);
+
+export default EventDescription;

--- a/src/components/ComponentDetails/EventTable/index.tsx
+++ b/src/components/ComponentDetails/EventTable/index.tsx
@@ -3,6 +3,7 @@ import { JsonDocsEvent } from "@ukic/docs";
 import AttributeTable from "../../AttributeTable";
 import CodeAttribute from "../../CodeAttribute";
 import AttributeCards from "../../AttributeCards";
+import EventDescription from "./EventDescription";
 
 interface EventTableProps {
   eventData: JsonDocsEvent[];
@@ -31,7 +32,12 @@ const EventTable: React.FC<EventTableProps> = ({ eventData }) => {
     () =>
       eventData.map((event) => ({
         name: event.event,
-        description: event.docs,
+        description: (
+          <EventDescription
+            description={event.docs}
+            deprecation={event.deprecation}
+          />
+        ),
         signature: <CodeAttribute label={event.detail} />,
       })),
     []

--- a/src/components/ComponentDetails/PropTable/PropDescription/index.css
+++ b/src/components/ComponentDetails/PropTable/PropDescription/index.css
@@ -8,3 +8,13 @@
   color: var(--ic-status-error);
   content: "*";
 }
+
+.prop-description .deprecation-tag {
+  margin-top: var(--ic-space-xs);
+}
+
+@media screen and (max-width: 576px) {
+  .prop-description .deprecation-tag {
+    margin-top: var(--ic-space-lg);
+  }
+}

--- a/src/components/ComponentDetails/PropTable/PropDescription/index.tsx
+++ b/src/components/ComponentDetails/PropTable/PropDescription/index.tsx
@@ -6,13 +6,22 @@ const PropDescription: React.FC<{
   description: string;
   type: string;
   required: boolean;
-}> = ({ description, type, required }) => (
+  deprecation: string | undefined;
+}> = ({ description, type, required, deprecation }) => (
   <div className="prop-description">
     <ic-typography>{description}</ic-typography>
     {required && (
       <ic-typography variant="subtitle-small">Required</ic-typography>
     )}
     <CodeAttribute label={`type: ${type}`} />
+    {deprecation && (
+      <>
+        <ic-typography>{deprecation}</ic-typography>
+        <div className="deprecation-tag">
+          <ic-status-tag label="Deprecated" status="warning" small />
+        </div>
+      </>
+    )}
   </div>
 );
 

--- a/src/components/ComponentDetails/PropTable/index.tsx
+++ b/src/components/ComponentDetails/PropTable/index.tsx
@@ -11,6 +11,7 @@ interface StencilProp {
   type: string;
   default?: string;
   required: boolean;
+  deprecation?: string | undefined;
 }
 
 interface PropTableProps {
@@ -39,17 +40,28 @@ const PropTable: React.FC<PropTableProps> = ({ propData }) => {
   const data = useMemo(
     () =>
       propData
-        .map(({ name, attr, docs, type, required, default: defaultValue }) => ({
-          name: <PropName name={name} attribute={attr} />,
-          description: (
-            <PropDescription
-              description={docs}
-              type={type}
-              required={required}
-            />
-          ),
-          default: defaultValue,
-        }))
+        .map(
+          ({
+            name,
+            attr,
+            docs,
+            type,
+            required,
+            default: defaultValue,
+            deprecation,
+          }) => ({
+            name: <PropName name={name} attribute={attr} />,
+            description: (
+              <PropDescription
+                description={docs}
+                type={type}
+                required={required}
+                deprecation={deprecation}
+              />
+            ),
+            default: defaultValue,
+          })
+        )
         .sort(
           (a, b) => b.description.props.required - a.description.props.required
         ),


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add deprecation descriptions and warning status tag to events and props table.

## Related issue

#269

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
