### PR TITLE
docs(root): restructure get started navigation to separate out testing

### DIFF
--- a/src/content/structured/get-started/test-components.mdx
+++ b/src/content/structured/get-started/test-components.mdx
@@ -1,0 +1,30 @@
+---
+path: "/get-started/test-components"
+
+navPriority: 2
+
+date: "2023-02-16"
+
+title: "Testing the components"
+
+subTitle: "Test the UI Kit components within the shadow DOM using a testing framework."
+
+contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/test-components.mdx"
+---
+
+## How we've built the components
+
+Typically, components sit in the DOM, also known as the ['light DOM'](https://www.codecademy.com/resources/blog/what-is-dom/). DOM stands for 'Document Object Model'. The light DOM represents the structure of a webpage as a tree, where each DOM object is a node.
+
+At the core, the UI Kit components are based off the web components specification which utilises the shadow DOM. This makes it possible to encapsulate each component’s markup structure, styling and functionality.
+
+According to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), the "shadow DOM allows hidden DOM trees to be attached to elements in the regular DOM tree — this shadow DOM tree starts with a shadow root, underneath which you can attach any element, in the same way as the normal DOM."
+
+Therefore, testing components within the shadow DOM can be problematic because elements inside a shadow root technically do not exist in the main DOM, and can prevent testing frameworks from selecting internal elements.
+
+## Testing the components
+
+To ease the process of testing, here are guides to testing our UI Kit components in different testing frameworks.
+
+- [Jest](/get-started/test-components/testing-with-jest)
+- [React Testing Library](/get-started/test-components/testing-with-react-testing-library)

--- a/src/content/structured/get-started/testing-with-jest.mdx
+++ b/src/content/structured/get-started/testing-with-jest.mdx
@@ -1,9 +1,7 @@
 ---
-path: "/get-started/install-components/testing-with-jest"
+path: "/get-started/test-components/testing-with-jest"
 
-navPriority: 8
-
-date: "2022-11-30"
+date: "2023-02-16"
 
 title: "Testing with Jest"
 
@@ -51,14 +49,6 @@ Add the following section to your package.json:
 Finally, run your tests using `npm test` or `yarn test`.
 
 More information on setting up Jest can be found on [Jest’s Getting Started page](https://jestjs.io/docs/getting-started).
-
-## What is the shadow DOM?
-
-Typically, components sit in the DOM, also known as the ['light DOM'](https://www.codecademy.com/resources/blog/what-is-dom/). DOM stands for 'Document Object Model'. The light DOM represents the structure of a webpage as a tree, where each DOM object is a node.
-
-A key part of our components is the shadow DOM. With the shadow DOM, we can encapsulate each component’s markup structure, styling and behaviour so different parts don’t clash.
-
-According to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM), the "shadow DOM allows hidden DOM trees to be attached to elements in the regular DOM tree — this shadow DOM tree starts with a shadow root, underneath which you can attach any element, in the same way as the normal DOM."
 
 ## Testing shadow components
 

--- a/src/content/structured/get-started/testing-with-react-testing-library.mdx
+++ b/src/content/structured/get-started/testing-with-react-testing-library.mdx
@@ -1,9 +1,7 @@
 ---
-path: "/get-started/install-components/testing-with-react-testing-library"
+path: "/get-started/test-components/testing-with-react-testing-library"
 
-navPriority: 9
-
-date: "2023-01-20"
+date: "2023-02-16"
 
 title: "Testing with React Testing Library"
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Restructure get started navigation to separate out testing with overview of the shadow dom moved out of jest page to overview.

## Related issue

#295

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
