### PR TITLE
fix(root): fix image in card causing overlay on mobile

### DIFF
--- a/src/content/structured/components/cards/code.mdx
+++ b/src/content/structured/components/cards/code.mdx
@@ -339,9 +339,14 @@ export const topImage = [
     </IcButton>
     <svg
       slot="image-top"
-      style={{ height: "326px", width: "326px" }}
+      style={{
+        height: "100%",
+        width: "100%",
+        maxHeight: "20.375rem",
+        maxWidth: "20.375rem",
+      }}
+      viewBox="0 0 1600 1250"
       xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 1600 900"
     >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
@@ -421,9 +426,13 @@ export const midImage = [
     <IcStatusTag slot="adornment" label="Neutral" small />
     <svg
       slot="image-mid"
-      style={{ height: "326px", width: "326px" }}
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 1600 900"
+      style={{
+        height: "100%",
+        width: "100%",
+        maxHeight: "20.375rem",
+        maxWidth: "20.375rem",
+      }}
+      viewBox="0 0 1600 1250"
     >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />

--- a/src/content/structured/components/cards/guidance.mdx
+++ b/src/content/structured/components/cards/guidance.mdx
@@ -64,9 +64,13 @@ There are three variants of cards:
     </IcButton>
     <svg
       slot="image-mid"
-      style={{ height: "326px", width: "326px" }}
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 1600 900"
+      style={{
+        height: "100%",
+        width: "100%",
+        maxHeight: "20.375rem",
+        maxWidth: "20.375rem",
+      }}
+      viewBox="0 0 1600 1250"
     >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />


### PR DESCRIPTION
## Summary of the changes

PX changed to '%' and a max width/height added to image. To test the changes;
- Navigate to card component
- Change to mobile view in inspect
- Shrink screen to see image shrink and maintain aspect ratio

Please note that in the guidance section the overlay will still pop out, this is due to the buttons causing the same issue. Navigate to the code examples and see 'top-image' and 'mid-image' variants to view the fix properly.

## Related issue

#294 

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [ ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
