### PR TITLE
PX -> REM on guidance site

### DIFF
--- a/src/components/AnchorNav/index.css
+++ b/src/components/AnchorNav/index.css
@@ -1,6 +1,6 @@
 .side-nav {
   grid-area: sidenav;
-  width: 256px;
+  width: 16rem;
 }
 
 .nav {
@@ -102,7 +102,7 @@
 @media screen and (min-width: 769px) and (max-width: 1200px) {
   .side-nav {
     margin: auto auto var(--ic-space-lg) 0;
-    max-width: 800px;
+    max-width: 50rem;
     width: calc(100% - var(--ic-space-xl));
   }
 }

--- a/src/components/CodePreview/index.css
+++ b/src/components/CodePreview/index.css
@@ -17,7 +17,7 @@
 }
 
 .comp-preview ic-side-navigation {
-  height: 700px;
+  height: 43.75rem;
   z-index: 0;
 }
 
@@ -78,7 +78,7 @@
 }
 
 .snippet-container ic-button button svg {
-  max-width: 24px;
+  max-width: 1.5rem;
 }
 
 .comp-preview ic-tab-context {
@@ -95,8 +95,8 @@
 
 .comp-icon {
   position: absolute;
-  top: 10px;
-  left: 10px;
+  top: 0.625rem;
+  left: 0.625rem;
   border-radius: 50%;
 }
 

--- a/src/components/DoDontCaution/index.css
+++ b/src/components/DoDontCaution/index.css
@@ -48,7 +48,7 @@
 }
 
 .caution-icon > svg {
-  margin-top: 3px;
+  margin-top: 0.188rem;
 }
 
 .dont-icon {
@@ -69,5 +69,5 @@
 
 .image-wide {
   max-width: 100%;
-  margin: 0 0 5px 0;
+  margin: 0 0 0.313rem 0;
 }

--- a/src/components/Header/index.css
+++ b/src/components/Header/index.css
@@ -3,7 +3,7 @@ ic-page-header[data-class="page-header"] {
 }
 
 ic-page-header ic-navigation-item .link {
-  height: 44px !important;
+  height: 2.75rem !important;
   color: var(--ic-color-primary-text) !important;
   transition: all var(--ic-easing-transition-fast) !important;
 }

--- a/src/components/Layout/index.css
+++ b/src/components/Layout/index.css
@@ -100,7 +100,7 @@ ic-top-navigation .search-actions-container form {
 }
 
 ic-top-navigation form {
-  width: 320px;
+  width: 20rem;
 }
 
 ic-top-navigation form.not-loaded {
@@ -115,7 +115,7 @@ ic-top-navigation form.not-loaded {
 
 @media screen and (max-width: 992px) {
   .logo-wrapper svg {
-    height: 38px;
+    height: 2.375rem;
   }
 
   .logo-wrapper {
@@ -129,7 +129,7 @@ ic-top-navigation form.not-loaded {
   }
 
   ic-top-navigation .top-panel-container {
-    max-height: 60px;
+    max-height: 3.75rem;
   }
 
   ic-top-navigation h1 {
@@ -148,7 +148,7 @@ ic-top-navigation form.not-loaded {
 
   .logo-wrapper svg,
   .logo-wrapper > ic-footer-link {
-    height: 64px;
+    height: 4rem;
   }
 
   .logo-wrapper > ic-footer-link {
@@ -156,15 +156,15 @@ ic-top-navigation form.not-loaded {
   }
 
   .logo-wrapper > ic-footer-link:nth-child(1) svg {
-    transform: translate(-3.5px, var(--ic-space-xxxs));
+    transform: translate(-0.219rem, var(--ic-space-xxxs));
   }
 
   .logo-wrapper > ic-footer-link:nth-child(1) {
-    width: 68px;
+    width: 4.25rem;
   }
 
   .logo-wrapper > ic-footer-link:nth-child(2) {
-    width: 52px;
+    width: 3.25rem;
   }
 
   .logo-wrapper > ic-footer-link:nth-child(2) svg {
@@ -172,6 +172,6 @@ ic-top-navigation form.not-loaded {
   }
 
   .logo-wrapper > ic-footer-link:nth-child(3) {
-    width: 46px;
+    width: 2.875rem;
   }
 }

--- a/src/components/Metadata/index.css
+++ b/src/components/Metadata/index.css
@@ -1,5 +1,5 @@
 .spacing-left {
-  margin-left: 5px;
+  margin-left: 0.313rem;
 }
 
 .bottom-line {

--- a/src/components/Permalink/index.css
+++ b/src/components/Permalink/index.css
@@ -10,9 +10,9 @@ ic-typography:hover .permalink svg,
 
 .permalink {
   transition: var(--ic-easing-transition-fast);
-  width: 42px;
-  padding: 10px 0 0 0 !important;
-  height: 42px;
+  width: 2.625rem;
+  padding: 0.625rem 0 0 0 !important;
+  height: 2.625rem;
   border-radius: 50%;
   text-align: center;
   box-sizing: border-box;
@@ -40,7 +40,6 @@ ic-typography:hover .permalink svg,
 .permalink > svg {
   vertical-align: top;
 }
-
 
 @media (forced-colors: active) {
   .permalink:focus {

--- a/src/components/SubsectionNav/index.css
+++ b/src/components/SubsectionNav/index.css
@@ -1,7 +1,7 @@
 .linkbit {
   display: flex;
   align-items: center;
-  min-height: 40px;
+  min-height: 2.5rem;
   color: var(--ic-action-default) !important;
   text-decoration: none !important;
 }
@@ -56,7 +56,7 @@
 .list-title {
   display: flex;
   align-items: center;
-  min-height: 40px;
+  min-height: 2.5rem;
   text-decoration: none !important;
 }
 
@@ -64,7 +64,7 @@
   outline: none;
   text-decoration: none !important;
   border-radius: var(--ic-border-radius);
-  box-shadow: 0 0 0 2px #1759bc, 0 0 0 5px rgb(23 89 188 / 52%) !important;
+  box-shadow: 0 0 0 0.125rem #1759bc, 0 0 0 0.313rem rgb(23 89 188 / 52%) !important;
 }
 
 ic-typography[data-class="list-typography"] {
@@ -75,7 +75,7 @@ ic-typography[data-class="list-typography"] {
   list-style: none;
   padding: 0;
   margin: 0;
-  min-height: 40px;
+  min-height: 2.5rem;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -169,8 +169,8 @@ ic-typography[data-class="list-typography"] {
   color: var(--ic-action-default) !important;
   transition: transform var(--ic-easing-transition-slow);
   position: relative;
-  margin-left: 6px;
-  margin-right: 9px;
+  margin-left: 0.375rem;
+  margin-right: 0.563rem;
   font-size: 1.25em !important;
 }
 
@@ -226,40 +226,40 @@ nav.not-mounted .list-item:focus-within .chevron {
 
 @media (forced-colors: active) {
   .list-item a:focus {
-    width: calc(100% - 6px);
-    margin-left: 3px;
+    width: calc(100% - 0.375rem);
+    margin-left: 0.188rem;
     z-index: 1;
     border-radius: var(--ic-border-radius);
     transition: outline var(--ic-easing-transition-fast);
   }
 
   .list-item a:focus ic-typography[data-class="list-typography"] {
-    padding-left: calc(var(--ic-space-md) - 3px);
+    padding-left: calc(var(--ic-space-md) - 0.188rem);
   }
 
   .list-item a:focus.active {
-    width: calc(100% - 38px);
-    margin-left: 11px;
+    width: calc(100% - 2.375rem);
+    margin-left: 0.688rem;
   }
 
   .list-item a:focus.active ic-typography[data-class="list-typography"] {
-    margin-left: -3px;
+    margin-left: -0.188rem;
   }
 
   .list-item .active:focus::before {
-    left: -11px;
+    left: -0.688rem;
   }
 
   .list-root > li.icds-gatsby-lp > a:focus {
-    width: calc(100% - 6px);
+    width: calc(100% - 0.375rem);
   }
 
   .list-root > li.icds-gatsby-lp > a:focus .chevron {
-    margin-right: 6px;
+    margin-right: 0.375rem;
   }
 
   .list-item > ul > li > a:focus > ic-typography[data-class="list-typography"] {
-    padding-left: calc(var(--ic-space-xl) - 3px) !important;
+    padding-left: calc(var(--ic-space-xl) - 0.188rem) !important;
   }
 
   .list-item

--- a/src/components/WrappedCode/index.css
+++ b/src/components/WrappedCode/index.css
@@ -3,8 +3,8 @@
   display: inline-table;
   background: rgba(0, 0, 0, 0.02);
   border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
-  padding: 0 7px;
+  border-radius: 0.25rem;
+  padding: 0 0.438rem;
   color: black;
   font-weight: 500;
 }

--- a/src/content/structured/patterns/components/ErrorSummaryEx/index.css
+++ b/src/content/structured/patterns/components/ErrorSummaryEx/index.css
@@ -1,5 +1,5 @@
 .form {
-  padding: 20px;
+  padding: 1.25rem;
 }
 
 .text-field {

--- a/src/content/structured/styles/components/ColourTable/index.css
+++ b/src/content/structured/styles/components/ColourTable/index.css
@@ -1,6 +1,6 @@
 .circle {
-  height: 38px;
-  width: 38px;
+  height: 2.375rem;
+  width: 2.375rem;
   border-radius: 50%;
   padding: 0 !important;
 }
@@ -20,11 +20,11 @@
 }
 
 .color-row div {
-  padding: 0 6px;
+  padding: 0 0.375rem;
 }
 
 .color-circle {
-  flex-basis: 60px;
+  flex-basis: 3.75rem;
 }
 
 .color-name {

--- a/src/content/structured/styles/components/IconFinder/index.css
+++ b/src/content/structured/styles/components/IconFinder/index.css
@@ -1,7 +1,7 @@
 .icons-container {
   display: flex;
-  box-shadow: 0 -1px 3px rgb(0 0 0 / 12%), 0 3px 1px rgb(0 0 0 / 15%),
-    0 3px 6px rgb(0 0 0 / 11%);
+  box-shadow: 0 -1px 0.188rem rgb(0 0 0 / 12%), 0 0.188rem 1px rgb(0 0 0 / 15%),
+    0 0.188rem 0.375rem rgb(0 0 0 / 11%);
 }
 
 .panel-container {
@@ -9,7 +9,7 @@
 }
 
 .icon-group-links {
-  min-width: 200px;
+  min-width: 12.5rem;
   background: var(--ic-architectural-20);
   border-right: 1px solid var(--ic-architectural-200);
   padding: var(--ic-space-sm) var(--ic-space-md) var(--ic-space-lg);
@@ -25,7 +25,7 @@
 
 .icon-group-links ic-link {
   display: table;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .panel {
@@ -42,9 +42,9 @@ ic-typography[data-class="heading"] {
   flex-basis: 28%;
   flex-shrink: 0;
   border-radius: var(--ic-border-radius);
-  width: 150px;
-  height: 100px;
-  margin: 10px;
+  width: 9.375rem;
+  height: 6.25rem;
+  margin: 0.625rem;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/content/structured/styles/components/TypographicScale/index.css
+++ b/src/content/structured/styles/components/TypographicScale/index.css
@@ -11,7 +11,7 @@ ic-button[data-class="additional-padding"] {
 
 .caption {
   opacity: 1;
-  margin-bottom: 6px;
+  margin-bottom: 0.375rem;
 }
 
 ic-typography[data-class="internal-caption"] {

--- a/src/pages/404.css
+++ b/src/pages/404.css
@@ -1,6 +1,6 @@
 #container-404 {
-  padding-top: 48px;
+  padding-top: 3rem;
 }
 #container-404 img {
-  margin-bottom: 24px;
+  margin-bottom: 1.5rem;
 }

--- a/src/templates/CoreTemplate/index.css
+++ b/src/templates/CoreTemplate/index.css
@@ -13,9 +13,9 @@ ic-alert {
 .force > p:first-of-type {
   font-weight: 600;
   font-size: 19;
-  line-height: 38px;
+  line-height: 2.375rem;
   margin-bottom: var(--ic-space-lg);
-  margin-top: 36px;
+  margin-top: 2.25rem;
   letter-spacing: -0.1;
 }
 
@@ -34,7 +34,7 @@ ic-alert {
 }
 
 .storybook {
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .page-container {
@@ -53,7 +53,7 @@ ic-alert {
 
 .content-container {
   grid-area: content;
-  max-width: 800px;
+  max-width: 50rem;
 }
 
 @media screen and (max-width: 768px) {
@@ -69,7 +69,7 @@ ic-alert {
 
 @media screen and (min-width: 769px) and (max-width: 992px) {
   .page-container {
-    margin-bottom: 60px;
+    margin-bottom: 3.75rem;
   }
 }
 
@@ -93,6 +93,6 @@ ic-alert {
 
 @media screen and (min-width: 1385px) {
   .content-container {
-    width: 800px;
+    width: 50rem;
   }
 }

--- a/src/templates/Homepage/index.css
+++ b/src/templates/Homepage/index.css
@@ -44,12 +44,12 @@
 }
 
 .ic-typography[data-class="text-content"] {
-  max-width: 864px;
+  max-width: 54rem;
 }
 
 .hero-card {
   color: var(--ic-theme-text);
-  width: 300px;
+  width: 18.75rem;
 }
 
 .hero .ic-typography-h4 .MuiSvgIcon-root {

--- a/src/templates/Standard/index.css
+++ b/src/templates/Standard/index.css
@@ -47,7 +47,7 @@
 
 @media screen and (min-width: 769px) and (max-width: 1200px) {
   .page-content-container {
-    grid-template-columns: 256px auto;
+    grid-template-columns: 16rem auto;
     grid-template-areas:
       "sidebar content"
       "sidebar content"
@@ -57,7 +57,7 @@
 
 @media screen and (min-width: 1201px) {
   .page-content-container {
-    grid-template-columns: 256px auto;
+    grid-template-columns: 16rem auto;
     grid-template-areas:
       "sidebar content"
       "sidebar content"


### PR DESCRIPTION
## Summary of the changes

PX values changed to REM excluding screen sizes, @media, 1px borders and gatsby-reset.css

## Related issue

#217 

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
