### PR TITLE
[github-action]: Bugfix/6 concurrency update

### DIFF
--- a/.github/workflows/ic-design-system-branches.yml
+++ b/.github/workflows/ic-design-system-branches.yml
@@ -6,6 +6,10 @@ on:
       - main
       - gh-pages
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ic-design-system-static-analysis-tests:
     name: "Static Analysis Tests"
@@ -18,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci --legacy-peer-deps --also=dev
+          npm ci --legacy-peer-deps
 
       - name: Lint site
         run: |
@@ -26,9 +30,6 @@ jobs:
 
   ic-design-system-deploy:
     needs: [ic-design-system-static-analysis-tests]
-    concurrency:
-      group: ci-${{ github.ref }}
-      cancel-in-progress: false
     name: "Deploy"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Concurrency action has been moved from the deployment step to the overall action. This will make sure the latest codebase of the branch is being built. As part of the investigation, there was a requirement to update the concurrency property on `pages-build-deployment` action provided by GitHub Pages by default but it is not accessible.

## Related issue

#6 

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
