### PR TITLE
feat(root): update ICDS app title to use gatsby link, and add update code examples

### DIFF
--- a/src/components/TopNavWrapper/index.tsx
+++ b/src/components/TopNavWrapper/index.tsx
@@ -25,12 +25,10 @@ const TopNavWrapper: React.FC<TopNavWrapperProps> = ({
   status,
   version,
 }) => (
-  <ic-top-navigation
-    app-title={appTitle}
-    status={status}
-    version={version}
-    href={withPrefix("/")}
-  >
+  <ic-top-navigation status={status} version={version}>
+    <GatsbyLink slot="app-title" to={withPrefix("/")}>
+      {appTitle}
+    </GatsbyLink>
     <span slot="app-icon">
       <ICDSLogo role="img" aria-labelledby="ICDS Logo" className="icds-logo" />
     </span>

--- a/src/content/structured/components/side-nav/code.mdx
+++ b/src/content/structured/components/side-nav/code.mdx
@@ -577,16 +577,18 @@ export const snippetsStatic = [
 
 ### With React Router (using slots)
 
+The following example also demonstrates using a slotted app title link.
+
 export const withReactRouter = [
   {
     language: "React",
     snippet: `<MemoryRouter initialEntries={["/"]}>
   <div style={{ display: "flex", flexDirection: "row"}}>
     <IcSideNavigation
-      appTitle="ACME"
       version="v0.0.0"
       status="BETA"
     >
+      <NavLink to="/" slot="app-title">ACME</NavLink>
       <SlottedSVG slot="app-icon" ... />
       <IcNavigationItem
         slot="primary-navigation"
@@ -647,12 +649,14 @@ export const withReactRouter = [
   <MemoryRouter initialEntries={["/"]}>
     <div style={{ display: "flex", flexDirection: "row" }}>
       <IcSideNavigation
-        appTitle="ACME"
         version="v0.0.0"
         status="BETA"
         inline
         disableAutoParentStyling
       >
+        <NavLink to="/" slot="app-title">
+          ACME
+        </NavLink>
         <svg
           slot="app-icon"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/content/structured/components/top-nav/code.mdx
+++ b/src/content/structured/components/top-nav/code.mdx
@@ -391,13 +391,16 @@ export const snippetsLeftAligned = [
   </IcTopNavigation>
 </ComponentPreview>
 
-### With React Router
+### With React Router (using slots)
+
+The following example also demonstrates using a slotted app title link.
 
 export const withReactRouter = [
   {
     language: "React",
     snippet: `<MemoryRouter initialEntries={["/"]}>
-  <IcTopNavigation appTitle="ICDS" status="alpha" version="v0.0.7">
+  <IcTopNavigation status="alpha" version="v0.0.7">
+    <NavLink to="/" slot="app-title">ICDS</NavLink>
     <SlottedSVG slot="app-icon" ... />
     <IcSearchBar slot="search" placeholder="Search" label="Search" />
     <IcNavigationButton label="button1" slot="buttons" onClick={() => alert('test')}>
@@ -428,7 +431,10 @@ export const withReactRouter = [
   style={{ display: "flex", flexDirection: "column" }}
 >
   <MemoryRouter initialEntries={["/"]}>
-    <IcTopNavigation appTitle="ICDS" status="alpha" version="v0.0.7">
+    <IcTopNavigation status="alpha" version="v0.0.7">
+      <NavLink to="/" slot="app-title">
+        ICDS
+      </NavLink>
       <svg
         slot="app-icon"
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update ICDS app title to use gatsby link, and add update code examples for top nav and side nav to show slotted app title link examples in existing React Router examples.

Needs to wait for the latest ui-kit component changes, so will have to be merged after the packages are updated for complete confidence it all works. Or to test locally, run npm pack. **Ideally this needs to be merged before we do the next develop -> main** so that developers have examples of how to use slotted app title links as the functionality will be available for them. 

When viewed with the latest changes there appears to be a bug in the side nav, but [a separate ticket has been raised](https://github.com/mi6/ic-ui-kit/issues/444) for that in the ui-kit. 

## Related issue

#293

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
