### PR TITLE
fix(root): turns on sticky page header for desktop

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -59,6 +59,7 @@ const Header: React.FC<HeaderProps> = ({
       subheading={subheading}
       aligned="center"
       data-class="page-header"
+      sticky-desktop-only
     >
       {adornment && (
         <ic-status-tag


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Sets sticky-desktop-only prop to fix page header on larger viewports

## Related issue
#168 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
