### PR TITLE
Add z-index tokens and guidance to elevation page

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -8,6 +8,7 @@
     "GHSA-w5p7-h5w8-2hfq",
     "GHSA-3rfm-jhwj-7488",
     "GHSA-hhq3-ff78-jv3g",
-    "GHSA-76p3-8jx3-jpfq"
+    "GHSA-76p3-8jx3-jpfq",
+    "GHSA-p8p7-x288-28g6"
   ]
 }

--- a/src/content/structured/styles/elevation.mdx
+++ b/src/content/structured/styles/elevation.mdx
@@ -31,16 +31,70 @@ There are three layers:
   caption="An example of an application showing the different layers of interaction. This includes the base layer with some raised content, the overlay layer and the modal layer."
 />
 
+Tokens are provided for the z-index values of components which sit above the base layer as well as the base z-index itself:
+
+| <span style={{width: '5vw', display: 'inline-block'}}>**Token**</span>         | **Component**                                                                                              | **Calculated z-index** |
+| ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------------- |
+| <span class="css-token">--ic-z-index-base-value</span>                         | Base z-index value. Used to calculate z-index of other ic components that sit above the base layer.        | 0 (Base)               |
+| <span class="css-token">--ic-z-index-page-header</span>                        | [Page header](/components/page-header)                                                                     | Base + 10              |
+| <span class="css-token">--ic-z-index-back-to-top</span>                        | [Back to top](/components/back-to-top)                                                                     | Base + 20              |
+| <span class="css-token">--ic-z-index-menu</span>                               | Menu for [select](/components/select) and [search bar](/components/search-bar)                             | Base + 50              |
+| <span class="css-token">--ic-z-index-popover</span>                            | Popover menu                                                                                               | Base + 50              |
+| <span class="css-token">--ic-z-index-navigation-item</span>                    | Navigation item used in [top navigation](/components/top-nav) and [side navigation](/components/side-nav). | Base + 50              |
+| <span class="css-token">--ic-z-index-navigation-menu</span>                    | Navigation menu used in [top navigation](/components/top-nav) at smaller breakpoints.                      | Base + 60              |
+| <span class="css-token">--ic-z-index-side-navigation</span>                    | [Side navigation](/components/side-nav)                                                                    | Base + 60              |
+| <span class="css-token">--ic-z-index-dialog</span>                             | Dialog                                                                                                     | Base + 100             |
+| <span class="css-token">--ic-z-index-tooltip</span>                            | [Tooltip](/components/tooltip)                                                                             | Base + 110             |
+| <span class="css-token">--ic-z-index-classification-banner</span>              | [Classification banner](/components/classification-banner)                                                 | Base + 200             |
+
+Users can change the base value in their css:
+
+```css
+:root {
+  --ic-z-index-base-value: 1000;
+}
+```
+
+Which will cause all other z-index tokens to be calculated from this new value.
+
+Additionally, users can change the z-index value for a specific component, either globally:
+
+```css
+:root {
+  --ic-z-index-tooltip: 200;
+}
+```
+
+Or for a specific instance or instances of a component:
+
+<!-- prettier-ignore-start -->
+```html
+<ic-tooltip id="my-tooltip-id">...</ic-tooltip>
+
+#my-tooltip-id {
+  --ic-z-index-tooltip: 300;
+}
+```
+
+```html
+<ic-tooltip class="my-tooltip-class">...</ic-tooltip>
+
+.my-tooltip-class {
+  --ic-z-index-tooltip: 300;
+}
+```
+<!-- prettier-ignore-end -->
+
 ## Shadows
 
 Each interaction layer has a defined shadow to provide the sense of depth.
 
-| <span style={{width: '5vw', display: 'inline-block'}}>**Token**</span> | **Description**                                                                  | **Perceived depth** |
-| ---------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------- |
-| none                                                                   | Components on the base layer cast no shadow.                                     | 0px                 |
-| --ic-elevation-raised                                                  | Raised components sit on the base layer and cast a slight shadow.                | 1px                 |
-| --ic-elevation-overlay                                                 | Components that sit in the overlay layer cast a small shadow.                    | 4px                 |
-| --ic-elevation-modal                                                   | The modal layer contains components that appear highest and cast a large shadow. | 8px                 |
+| <span style={{width: '5vw', display: 'inline-block'}}>**Token**</span>  | **Description**                                                                  | **Perceived depth** |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------- |
+| none                                                                    | Components on the base layer cast no shadow.                                     | 0px                 |
+| <span class="css-token">--ic-elevation-raised</span>                    | Raised components sit on the base layer and cast a slight shadow.                | 1px                 |
+| <span class="css-token">--ic-elevation-overlay</span>                   | Components that sit in the overlay layer cast a small shadow.                    | 4px                 |
+| <span class="css-token">--ic-elevation-modal</span>                     | The modal layer contains components that appear highest and cast a large shadow. | 8px                 |
 
 ## Accessibility considerations
 

--- a/src/styles/gatsby-reset.css
+++ b/src/styles/gatsby-reset.css
@@ -224,6 +224,12 @@ td:last-child {
  .token.entity {
    cursor: help;
  }
+
+ .css-token {
+    font-family: monospace;
+    font-size: 0.8rem;
+    font-weight: 700;
+ }
  
  
  /*


### PR DESCRIPTION
## Summary of the changes

Adds the z-index tokens and descriptions of use to the elevation page.

## Related issue

#313 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
