### PR TITLE
style: change typography variant for token names from caption to body…

### DIFF
--- a/src/content/structured/styles/components/ColourTable/index.tsx
+++ b/src/content/structured/styles/components/ColourTable/index.tsx
@@ -52,7 +52,7 @@ const PaletteRow: React.FC<PaletteRowProps> = ({ color }) => {
       </div>
       <div className="color-name">{name}</div>
       <div className="color-token color-class">
-        <ic-typography variant="caption">{token}</ic-typography>
+        <ic-typography variant="body">{token}</ic-typography>
       </div>
       <div className="color-class">
         <ic-typography variant="body">


### PR DESCRIPTION
## Summary of the changes

Change typography variant for token names from caption to body in ColourTable
## Related issue

#325 

## Checklist

- [Y] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [Y] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
