### PR TITLE
fix(root): fix content overlapping page header

### DIFF
--- a/src/components/CodePreview/index.css
+++ b/src/components/CodePreview/index.css
@@ -17,6 +17,12 @@
 
 .comp-preview ic-side-navigation {
   height: 43.75rem;
+  z-index: 0;
+}
+
+.comp-preview ic-page-header,
+.comp-preview ic-classification-banner {
+  z-index: 0;
 }
 
 .offscreen {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Fixes some components in preview overlapping the sticky page header on scroll. Affected components were:
ic-page-header
ic-side-navigation
ic-classification-banner

## Related issue
N/A

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
