### PR TITLE
fix(root): removed font size and weight from css-token

### DIFF
--- a/src/styles/gatsby-reset.css
+++ b/src/styles/gatsby-reset.css
@@ -227,8 +227,6 @@ td:last-child {
 
  .css-token {
     font-family: monospace;
-    font-size: 0.8rem;
-    font-weight: 700;
  }
  
  


### PR DESCRIPTION
## Summary of the changes

Ticket requests that elevation page z index tokens be consistent with colour tokens. 
Removing the css styling allows consistency with minimal code disruption, but unsure if this is acceptable. 

If ic-typography is required in the mdx, happy to change this and work on the ticket further.


## Related issue

#385 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
