### PR TITLE
fix(root): updated and fixed small typos on code examples

### DIFF
--- a/src/content/structured/components/breadcrumbs/code.mdx
+++ b/src/content/structured/components/breadcrumbs/code.mdx
@@ -43,7 +43,7 @@ export const snippets = [
     language: "React",
     snippet: `<IcBreadcrumbGroup>
   <IcBreadcrumb pageTitle="Home" href="#" />
-  <IcBreadcrumb pageTitle="Beverages" href="# " />
+  <IcBreadcrumb pageTitle="Beverages" href="#" />
   <IcBreadcrumb 
     current 
     pageTitle="Coffee"
@@ -56,7 +56,7 @@ export const snippets = [
 <ComponentPreview snippets={snippets}>
   <IcBreadcrumbGroup>
     <IcBreadcrumb pageTitle="Home" href="#" />
-    <IcBreadcrumb pageTitle="Beverages" href="# " />
+    <IcBreadcrumb pageTitle="Beverages" href="#" />
     <IcBreadcrumb current pageTitle="Coffee" href="#" />
   </IcBreadcrumbGroup>
 </ComponentPreview>

--- a/src/content/structured/components/breadcrumbs/guidance.mdx
+++ b/src/content/structured/components/breadcrumbs/guidance.mdx
@@ -34,7 +34,7 @@ An example of the breadcrumbs component.
 <ComponentPreview>
   <IcBreadcrumbGroup>
     <IcBreadcrumb pageTitle="Home" href="#" />
-    <IcBreadcrumb pageTitle="Beverages" href="# " />
+    <IcBreadcrumb pageTitle="Beverages" href="#" />
     <IcBreadcrumb current="true" pageTitle="Coffee" href="#" />
   </IcBreadcrumbGroup>
 </ComponentPreview>

--- a/src/content/structured/components/select/code.mdx
+++ b/src/content/structured/components/select/code.mdx
@@ -897,7 +897,7 @@ export const customFiltering = [
   { label: "Macchiato", value: "Mac" },
 ];
 const [results, setResults] = useState([]);
-const [selectedValue, setSelectedValue] = useState(null);
+const [selectedValue, setSelectedValue] = useState("");
 const changeHandler = (event) => {
   const newValue = event.detail.value;
   console.log(newValue);
@@ -943,7 +943,7 @@ export const CustomFilterExample = () => {
     { label: "Macchiato", value: "Mac" },
   ];
   const [results, setResults] = React.useState([]);
-  const [selectedValue, setSelectedValue] = React.useState(null);
+  const [selectedValue, setSelectedValue] = React.useState("");
   const changeHandler = (event) => {
     const newValue = event.detail.value;
     console.log(newValue);

--- a/src/content/structured/components/skeleton/code.mdx
+++ b/src/content/structured/components/skeleton/code.mdx
@@ -34,7 +34,7 @@ export const snippets = [
   },
   {
     language: "React",
-    snippet: `<IcSkeleton variant="circle" height="20" />
+    snippet: `<IcSkeleton variant="circle" />
 <IcTypography variant="caption">
   <IcSkeleton variant="text" />
 </IcTypography>
@@ -44,7 +44,7 @@ export const snippets = [
 
 <ComponentPreview snippets={snippets}>
   <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-    <IcSkeleton variant="circle" height="20" />
+    <IcSkeleton variant="circle" />
     <IcTypography variant="caption">
       <IcSkeleton variant="text" />
     </IcTypography>
@@ -166,7 +166,7 @@ export const snippetsLight = [
 
 <ComponentPreview snippets={snippetsLight}>
   <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
-    <IcSkeleton variant="circle" height="20" light="true" />
+    <IcSkeleton variant="circle" light="true" />
     <IcTypography variant="caption">
       <IcSkeleton variant="text" light="true" />
     </IcTypography>

--- a/src/content/structured/components/text-input/code.mdx
+++ b/src/content/structured/components/text-input/code.mdx
@@ -91,7 +91,7 @@ export const snippetsIconValueMaxLength = [
   {
     language: "React",
     snippet: `<IcTextField 
-  maxLength="25" 
+  maxLength={25} 
   value="Arabica" 
   label="What is your favourite coffee?" 
   required 
@@ -115,7 +115,7 @@ export const snippetsIconValueMaxLength = [
 
 <ComponentPreview snippets={snippetsIconValueMaxLength}>
   <IcTextField
-    maxLength="25"
+    maxLength={25}
     value="Arabica"
     label="What is your favourite coffee?"
     required
@@ -249,7 +249,7 @@ export const snippetsValidation = [
   {
     language: "React",
     snippet: `<IcTextField 
-    maxLength="25" 
+    maxLength={25} 
     value="Arabica" 
     label="What is your favourite coffee?" 
     required 
@@ -257,7 +257,7 @@ export const snippetsValidation = [
     validationStatus="success" 
     validationText="Good choice!" />
 <IcTextField 
-  maxLength="25" 
+  maxLength={25} 
   value="Arabica" 
   label="What is your favourite coffee?" 
   required 
@@ -266,7 +266,7 @@ export const snippetsValidation = [
   validationText="Good choice!" 
   validationInline />
 <IcTextField 
-  maxLength="25" 
+  maxLength={25} 
   value="Arabica" 
   label="What is your favourite coffee?" 
   required 
@@ -274,7 +274,7 @@ export const snippetsValidation = [
   validationStatus="warning" 
   validationText="A very long warning message to test if wrapping works" />
 <IcTextField 
-  maxLength="25" 
+  maxLength={25} 
   value="Tea" 
   label="What is your favourite coffee?" 
   required helperText="Such as Arabica, Robusta or Liberica" 
@@ -286,7 +286,7 @@ export const snippetsValidation = [
 <ComponentPreview snippets={snippetsValidation}>
   <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
     <IcTextField
-      maxLength="25"
+      maxLength={25}
       value="Arabica"
       label="What is your favourite coffee?"
       required
@@ -295,7 +295,7 @@ export const snippetsValidation = [
       validationText="Good choice!"
     />
     <IcTextField
-      maxLength="25"
+      maxLength={25}
       value="Arabica"
       label="What is your favourite coffee?"
       required
@@ -305,7 +305,7 @@ export const snippetsValidation = [
       validationInline
     />
     <IcTextField
-      maxLength="25"
+      maxLength={25}
       value="Arabica"
       label="What is your favourite coffee?"
       required
@@ -314,7 +314,7 @@ export const snippetsValidation = [
       validationText="A very long warning message to test if wrapping works"
     />
     <IcTextField
-      maxLength="25"
+      maxLength={25}
       value="Tea"
       label="What is your favourite coffee?"
       required
@@ -331,7 +331,7 @@ export const snippetsTextArea = [
   {
     language: "Web component",
     snippet: `<ic-text-field 
-    rows="6" 
+    rows="6"
     resize="true" 
     label="What is your favourite coffee?" 
     placeholder="Placeholder" 
@@ -341,7 +341,7 @@ export const snippetsTextArea = [
   {
     language: "React",
     snippet: `<IcTextField 
-    rows="6" 
+    rows={6} 
     resize 
     label="What is your favourite coffee?" 
     placeholder="Placeholder" 
@@ -351,7 +351,7 @@ export const snippetsTextArea = [
 
 <ComponentPreview snippets={snippetsTextArea}>
   <IcTextField
-    rows="6"
+    rows={6}
     resize
     label="What is your favourite coffee?"
     placeholder="Placeholder"


### PR DESCRIPTION
## Summary of the changes

Corrected small typos in code examples stated on issue #252 and following small changes were made:

- In the react example of breadcrumbs, the second breadcrumb href has an extra space, removed extra spaces to fix the issue

- Skeleton contains height="20" but height doesn't exist, removed height from react example IcSkeleton

- Textfield example comes with maxLength="25" but a string isn't assignable to a number so it would only accept maxLength={25} - changed maxLength="25" to {25}

- The Select react example has const [value, setValue] = useState(null); however in typescript projects where is needed, null causes errors. Updated typescript code with: const [value, setValue] = useState("");

- The prop rows on the react component IcTextField is a number type. The react examples with the prop rows should be in brackets instead of speech marks

(There was an issue with the previous PR for this issue, all the changes were lost after rebasing, however it is updated and typos fixed ready to be merged if there are no other issues)

## Related issue

#252

## Checklist

- [Y] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [Y] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)