### PR TITLE
fix(root): removed nav item from example

### DIFF
--- a/src/content/structured/components/top-nav/code.mdx
+++ b/src/content/structured/components/top-nav/code.mdx
@@ -64,7 +64,6 @@ export const snippetsDefault = [
   <ic-navigation-item slot="navigation" label="Styles" href="#"></ic-navigation-item>
   <ic-navigation-item slot="navigation" label="Components" href="#" selected="true"></ic-navigation-item>
   <ic-navigation-item slot="navigation" label="Patterns" href="#"></ic-navigation-item>
-  <ic-navigation-item slot="navigation" label="Community" href="#"></ic-navigation-item>
 </ic-top-navigation>`,
   },
   {
@@ -99,7 +98,6 @@ export const snippetsDefault = [
   <IcNavigationItem slot="navigation" label="Styles" href="#" />
   <IcNavigationItem slot="navigation" label="Components" href="#" selected />
   <IcNavigationItem slot="navigation" label="Patterns" href="#" />
-  <IcNavigationItem slot="navigation" label="Community" href="#" />
 </IcTopNavigation>`,
   },
 ];
@@ -135,7 +133,6 @@ export const snippetsDefault = [
     <IcNavigationItem slot="navigation" label="Styles" href="#" />
     <IcNavigationItem slot="navigation" label="Components" href="#" selected />
     <IcNavigationItem slot="navigation" label="Patterns" href="#" />
-    <IcNavigationItem slot="navigation" label="Community" href="#" />
   </IcTopNavigation>
 </ComponentPreview>
 

--- a/src/content/structured/components/top-nav/guidance.mdx
+++ b/src/content/structured/components/top-nav/guidance.mdx
@@ -70,7 +70,6 @@ Use a standard top navigation for apps with eight or fewer navigation options.
       selected="true"
     />
     <IcNavigationItem slot="navigation" label="Patterns" href="#" />
-    <IcNavigationItem slot="navigation" label="Community" href="#" />
   </IcTopNavigation>
 </ComponentPreview>
 


### PR DESCRIPTION
removed nav item from top nav code preview to prevent flickering on certain screen sizes

## Summary of the changes
The flickering identified on the guidance site is caused by the scroll buttons appearing and changing the size of the navigation, which triggers an infinite loop in the resize observer. The changing size stretches the top navigation component in the code preview, which shouldn't be the case.

Because the top navigation will never be used in this way in the real world, the fix for the moment is to remove one of the nav items that triggers the overflow and raise another ticket to investigate this behaviour.

## Related issue
#425 

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
