### PR TITLE
feat(root): changes top-nav version number to take @ukic version from…

### DIFF
--- a/src/components/TopNavWrapper/index.tsx
+++ b/src/components/TopNavWrapper/index.tsx
@@ -22,10 +22,9 @@ const TopNavItem: React.FC<any> = ({ props, text }) => (
 
 const TopNavWrapper: React.FC<TopNavWrapperProps> = ({
   appTitle,
-  status,
   version,
 }) => (
-  <ic-top-navigation status={status} version={version} app-title={appTitle}>
+  <ic-top-navigation version={version} app-title={appTitle}>
     <GatsbyLink slot="app-title" to={withPrefix("/")}>
       {appTitle}
     </GatsbyLink>

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,8 @@ const SITE_URL = process.env.GATSBY_ICDS_WEBSITE_BASE
   ? process.env.GATSBY_ICDS_WEBSITE_BASE
   : "https://design.sis.gov.uk/";
 
+const pkg = require("../package.json");
+
 module.exports = {
   author: `ICDS`,
 
@@ -16,7 +18,7 @@ module.exports = {
   META_DESCRIPTION:
     "Use the UK Intelligence Community's Design System to create accessible, usable, and consistent capabilities for complex and specialised needs",
 
-  VERSION: "V2.0.7",
+  VERSION: pkg.dependencies["@ukic/web-components"].replace("^", ""),
   STATUS: "BETA",
 
   FOOTER_PROPS: {


### PR DESCRIPTION
## Summary of the changes

Top-nav version number is now no longer hard coded but taken from the @ukic dependencies in package.json

## Related issue

https://github.com/mi6/ic-design-system/issues/361

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [ ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
