### PR TITLE
fix(docs): correct duplicate pronouns typo

### DIFF
--- a/src/content/structured/get-started/a-design-system.mdx
+++ b/src/content/structured/get-started/a-design-system.mdx
@@ -40,7 +40,7 @@ Inclusion and accessibility is core to our Design System. We’ve put a lot of e
 
 ## What now?
 
-We’re interested to see the potential of our work and where it we can go now, sharing it with more and more people. Open sourcing is a big step, and opportunity, for MI6, MI5, and GCHQ.
+We’re interested to see the potential of our work and where it can go now, sharing it with more and more people. Open sourcing is a big step, and opportunity, for MI6, MI5, and GCHQ.
 
 We hope our experiences can support your efforts in improving accessibility and usability of complex government, enterprise, and specialist technology.
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Correct duplicate pronouns typo, presumed _it_, but it could be _we_ as well.

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
