### PR TITLE
fix(root): update prop description cell to not show details if deprecated

### DIFF
--- a/src/components/ComponentDetails/PropTable/PropDescription/index.tsx
+++ b/src/components/ComponentDetails/PropTable/PropDescription/index.tsx
@@ -9,11 +9,11 @@ const PropDescription: React.FC<{
   deprecation: string | undefined;
 }> = ({ description, type, required, deprecation }) => (
   <div className="prop-description">
-    <ic-typography>{description}</ic-typography>
+    {!!description && <ic-typography>{description}</ic-typography>}
     {required && (
       <ic-typography variant="subtitle-small">Required</ic-typography>
     )}
-    <CodeAttribute label={`type: ${type}`} />
+    {!deprecation && <CodeAttribute label={`type: ${type}`} />}
     {deprecation && (
       <>
         <ic-typography>{deprecation}</ic-typography>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update prop description cell to not show description/type if prop is deprecated. There was previously a gap where description would've been had the prop not been deprecated.

## Related issue

#467 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
