### PR TITLE
fix(root): remove div around <li> so that it passes accessibility checks

### DIFF
--- a/src/components/AnchorNav/index.css
+++ b/src/components/AnchorNav/index.css
@@ -40,9 +40,10 @@
   margin: 0 0 0 var(--ic-space-xs);
 }
 
-.list {
+.nav-item-list {
   list-style: none;
   margin: 0;
+  border-left: 0.063rem solid var(--ic-architectural-300);
 }
 
 .nav-list-item {
@@ -65,10 +66,6 @@
   display: block;
   width: var(--ic-space-xs);
   background: var(--ic-action-default);
-}
-
-.nav-list-items-container {
-  border-left: 1px solid var(--ic-architectural-300);
 }
 
 @media screen and (max-width: 576px) {
@@ -112,7 +109,7 @@
     padding: var(--ic-space-md) var(--ic-space-md) var(--ic-space-xs);
   }
 
-  .nav-list-items-container {
+  .nav-item-list {
     border-left: none;
     padding-bottom: var(--ic-space-lg);
   }

--- a/src/components/AnchorNav/index.tsx
+++ b/src/components/AnchorNav/index.tsx
@@ -93,10 +93,8 @@ const AnchorNav: React.FC<AnchorNavProps> = ({
           <div className="contents-header">
             <ic-typography variant="subtitle-large">Contents</ic-typography>
           </div>
-          <ul className="list">
-            <div className="nav-list-items-container">
-              {headings.map((heading) => getNavListItem(heading))}
-            </div>
+          <ul className="nav-item-list">
+            {headings.map((heading) => getNavListItem(heading))}
           </ul>
         </nav>
       </div>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Remove div around `<li>` so that it passes accessibility checks as div is not a valid child of a `<ul>`

## Related issue

#405

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
