### PR TITLE
fix(root): fixed broken link for VPAT

### DIFF
--- a/src/content/structured/accessibility/documenting/conformance-report.mdx
+++ b/src/content/structured/accessibility/documenting/conformance-report.mdx
@@ -38,7 +38,7 @@ A common checklist for testing and reporting is the [Voluntary Product Accessibi
 
 Use the correct VPAT® depending on the type of app or service:
 
-- Use the [WCAG (VPAT®) template](/blank-accessibility-conformance-report-vpat-wcag-24rev.doc) for apps and services with only a user interface (browser-based or otherwise).
+- Use the [WCAG (VPAT®) template](/blank-accessibility-conformance-report-vpat-wcag-24.doc) for apps and services with only a user interface (browser-based or otherwise).
 
 - Use the [EN 301 549 (VPAT®) template](/blank-accessibility-conformance-report-vpat-en301549-24rev.doc) for apps and services which includes hardware. It includes all the WCAG criteria, so only one Report is needed.
 


### PR DESCRIPTION
Fixed a typo in the link to the VPAT doc

476

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes
Fixed a typo in the link to the VPAT doc which was giving a 404.

## Related issue

[476](https://github.com/mi6/ic-design-system/issues/476)
## Checklist

- [X] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [X] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
