### PR TITLE
fix(root): added slottedsvg import for top-navigation

### DIFF
--- a/src/content/structured/components/top-nav/code.mdx
+++ b/src/content/structured/components/top-nav/code.mdx
@@ -25,6 +25,7 @@ import {
   IcNavigationButton,
   IcNavigationItem,
   IcNavigationGroup,
+  SlottedSVG,
 } from "@ukic/react";
 
 import { MemoryRouter, NavLink } from "react-router-dom";


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes
The app-title and navigation button icon was not appearing for the component demo in ic-top-navigation code tab. This has been fixed with the additional SlottedSVG import.

## Related issue
N/A

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
