### PR TITLE
fix(root): fixed table width issues on mobile

### DIFF
--- a/src/content/structured/styles/components/ColourTable/index.css
+++ b/src/content/structured/styles/components/ColourTable/index.css
@@ -35,6 +35,25 @@
   flex-basis: 40%;
 }
 
+@media screen and (max-width: 576px) {
+  .circle {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+  .color-circle {
+    flex-basis: 0.5rem;
+  }
+  .color-row div {
+    padding-right: 0;
+  }
+  .color-token {
+    flex-basis: 30%;
+  }
+  .color-name {
+    flex-basis: 25%;
+  }
+}
+
 @media (forced-colors: active) {
   .circle {
     forced-color-adjust: none;

--- a/src/content/structured/styles/elevation.mdx
+++ b/src/content/structured/styles/elevation.mdx
@@ -33,20 +33,20 @@ There are three layers:
 
 Tokens are provided for the z-index values of components which sit above the base layer as well as the base z-index itself:
 
-| <span style={{width: '5vw', display: 'inline-block'}}>**Token**</span> | **Component**                                                                                              | **Calculated z-index** |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------- |
-| <span class="css-token">--ic-z-index-base-value</span>                 | Base z-index value. Used to calculate z-index of other ic components that sit above the base layer.        | 0 (Base)               |
-| <span class="css-token">--ic-z-index-page-header</span>                | [Page header](/components/page-header)                                                                     | Base + 10              |
-| <span class="css-token">--ic-z-index-back-to-top</span>                | [Back to top](/components/back-to-top)                                                                     | Base + 20              |
-| <span class="css-token">--ic-z-index-menu</span>                       | Menu for [select](/components/select) and [search bar](/components/search-bar)                             | Base + 50              |
-| <span class="css-token">--ic-z-index-popover</span>                    | [Popover menu](/components/popover-menu)                                                                   | Base + 50              |
-| <span class="css-token">--ic-z-index-navigation-item</span>            | Navigation item used in [top navigation](/components/top-nav) and [side navigation](/components/side-nav). | Base + 50              |
-| <span class="css-token">--ic-z-index-navigation-menu</span>            | Navigation menu used in [top navigation](/components/top-nav) at smaller breakpoints.                      | Base + 60              |
-| <span class="css-token">--ic-z-index-side-navigation</span>            | [Side navigation](/components/side-nav)                                                                    | Base + 60              |
-| <span class="css-token">--ic-z-index-dialog</span>                     | [Dialog](/components/dialog)                                                                               | Base + 100             |
-| <span class="css-token">--ic-z-index-tooltip</span>                    | [Tooltip](/components/tooltip)                                                                             | Base + 110             |
-| <span class="css-token">--ic-z-index-toast</span>                      | [Toast](/components/toast)                                                                                 | Base + 110             |
-| <span class="css-token">--ic-z-index-classification-banner</span>      | [Classification banner](/components/classification-banner)                                                 | Base + 200             |
+| <span class="css-token-header">**Token**</span>                   | **Component**                                                                                              | **Calculated z-index** |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------- |
+| <span class="css-token">--ic-z-index-base-value</span>            | Base z-index value. Used to calculate z-index of other ic components that sit above the base layer.        | 0 (Base)               |
+| <span class="css-token">--ic-z-index-page-header</span>           | [Page header](/components/page-header)                                                                     | Base + 10              |
+| <span class="css-token">--ic-z-index-back-to-top</span>           | [Back to top](/components/back-to-top)                                                                     | Base + 20              |
+| <span class="css-token">--ic-z-index-menu</span>                  | Menu for [select](/components/select) and [search bar](/components/search-bar)                             | Base + 50              |
+| <span class="css-token">--ic-z-index-popover</span>               | [Popover menu](/components/popover-menu)                                                                   | Base + 50              |
+| <span class="css-token">--ic-z-index-navigation-item</span>       | Navigation item used in [top navigation](/components/top-nav) and [side navigation](/components/side-nav). | Base + 50              |
+| <span class="css-token">--ic-z-index-navigation-menu</span>       | Navigation menu used in [top navigation](/components/top-nav) at smaller breakpoints.                      | Base + 60              |
+| <span class="css-token">--ic-z-index-side-navigation</span>       | [Side navigation](/components/side-nav)                                                                    | Base + 60              |
+| <span class="css-token">--ic-z-index-dialog</span>                | [Dialog](/components/dialog)                                                                               | Base + 100             |
+| <span class="css-token">--ic-z-index-tooltip</span>               | [Tooltip](/components/tooltip)                                                                             | Base + 110             |
+| <span class="css-token">--ic-z-index-toast</span>                 | [Toast](/components/toast)                                                                                 | Base + 110             |
+| <span class="css-token">--ic-z-index-classification-banner</span> | [Classification banner](/components/classification-banner)                                                 | Base + 200             |
 
 Users can change the base value in their css:
 

--- a/src/styles/gatsby-reset.css
+++ b/src/styles/gatsby-reset.css
@@ -23,7 +23,8 @@ table {
   line-height: 1.45rem;
   width: 100%;
 }
-ul, ol {
+ul,
+ol {
   margin-left: 1.5rem;
   margin-right: 0;
   margin-top: 0;
@@ -69,7 +70,8 @@ p *:last-child {
 li > p {
   margin-bottom: calc(1.45rem / 2);
 }
-pre, code {
+pre,
+code {
   font-size: 1rem;
 }
 thead {
@@ -97,8 +99,6 @@ td:last-child {
   padding-right: 0;
 }
 
-
-
 /**
  * a11y-dark theme for JavaScript, CSS, and HTML
  * Based on the okaidia theme: https://github.com/PrismJS/prism/blob/gh-pages/themes/prism-okaidia.css
@@ -108,192 +108,214 @@ td:last-child {
 /*
  Theme
  */
- code[class*="language-"],
- pre[class*="language-"] {
-   color: #f8f8f2;
-   background: none;
-   font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-   text-align: left;
-   white-space: pre;
-   word-spacing: normal;
-   word-break: normal;
-   word-wrap: normal;
-   line-height: 1.65rem;
- 
-   -moz-tab-size: 4;
-   -o-tab-size: 4;
-   tab-size: 4;
- 
-   -webkit-hyphens: none;
-   -moz-hyphens: none;
-   -ms-hyphens: none;
-   hyphens: none;
- }
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #f8f8f2;
+  background: none;
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.65rem;
 
- /* Inline */
- p code[class*="language-"],
- p pre[class*="language-"] {
-  color: var(--ic-color-primary-text)!important;
-  background-color: var(--ic-architectural-60)!important;
- }
- /* Code blocks */
- pre[class*="language-"] {
-   padding: 1em;
-   margin: 0.5em 0;
-   overflow: auto;
-   border-radius: 0.3em;
- }
- 
- :not(pre) > code[class*="language-"],
- pre[class*="language-"] {
-   background: #2b2b2b;
- }
- 
- /* Inline code */
- :not(pre) > code[class*="language-"] {
-   padding: 0.1em;
-   border-radius: 0.3em;
-   white-space: normal;
- }
- 
- .token.comment,
- .token.prolog,
- .token.doctype,
- .token.cdata {
-   color: #d4d0ab;
- }
- 
- .token.punctuation {
-   color: #fefefe;
- }
- 
- .token.property,
- .token.tag,
- .token.constant,
- .token.symbol,
- .token.deleted {
-   color: #ffa07a;
- }
- 
- .token.boolean,
- .token.number {
-   color: #00e0e0;
- }
- 
- .token.selector,
- .token.attr-name,
- .token.string,
- .token.char,
- .token.builtin,
- .token.inserted {
-   color: #abe338;
- }
- 
- .token.operator,
- .token.entity,
- .token.url,
- .language-css .token.string,
- .style .token.string,
- .token.variable {
-   color: #00e0e0;
- }
- 
- .token.atrule,
- .token.attr-value,
- .token.function {
-   color: #ffd700;
- }
- 
- .token.keyword {
-   color: #00e0e0;
- }
- 
- .token.regex,
- .token.important {
-   color: #ffd700;
- }
- 
- .token.important,
- .token.bold {
-   font-weight: bold;
- }
- .token.italic {
-   font-style: italic;
- }
- 
- .token.entity {
-   cursor: help;
- }
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
 
- .css-token {
-    font-family: monospace;
- }
- 
- 
- /*
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Inline */
+p code[class*="language-"],
+p pre[class*="language-"] {
+  color: var(--ic-color-primary-text) !important;
+  background-color: var(--ic-architectural-60) !important;
+}
+/* Code blocks */
+pre[class*="language-"] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  background: #2b2b2b;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: #d4d0ab;
+}
+
+.token.punctuation {
+  color: #fefefe;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #ffa07a;
+}
+
+.token.boolean,
+.token.number {
+  color: #00e0e0;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #abe338;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #00e0e0;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function {
+  color: #ffd700;
+}
+
+.token.keyword {
+  color: #00e0e0;
+}
+
+.token.regex,
+.token.important {
+  color: #ffd700;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+.css-token {
+  font-family: monospace;
+}
+
+.css-token-header {
+  display: inline-block;
+}
+
+@media screen and (max-width: 576px) {
+  td,
+  th {
+    padding-left: 0.5rem;
+    padding-right: 0;
+  }
+}
+
+@media screen and (max-width: 391px) {
+  .css-token {
+    line-break: anywhere;
+  }
+}
+
+@media screen and (min-width: 392px) {
+  .css-token-header {
+    width: 5vw;
+  }
+}
+
+/*
   Plugin support
   */
- 
- /* Line highlight */
- .line-highlight {
-   background: rgba(255, 217, 0, 0.10);
-   border-top: 1px solid rgba(255, 217, 0, 0.55);
-   border-bottom: 1px solid rgba(255, 217, 0, 0.55);
- }
- 
- /* Line numbers */
- .line-numbers .line-numbers-rows {
-   border-right: 1px solid #F8F8F2;
- }
- 
- .line-numbers-rows > span:before {
-   color: #D4D0AB;
- }
- 
- 
- /*
+
+/* Line highlight */
+.line-highlight {
+  background: rgba(255, 217, 0, 0.1);
+  border-top: 1px solid rgba(255, 217, 0, 0.55);
+  border-bottom: 1px solid rgba(255, 217, 0, 0.55);
+}
+
+/* Line numbers */
+.line-numbers .line-numbers-rows {
+  border-right: 1px solid #f8f8f2;
+}
+
+.line-numbers-rows > span:before {
+  color: #d4d0ab;
+}
+
+/*
   High contrast mode support
  */
- @media screen and (-ms-high-contrast: active) {
-   code[class*="language-"],
-   pre[class*="language-"] {
-     color: windowText;
-     background: window;
-   }
- 
-   :not(pre) > code[class*="language-"],
-   pre[class*="language-"] {
-     background: window;
-   }
- 
-   .token.important {
-     background: highlight;
-     color: window;
-     font-weight: normal;
-   }
- 
-   .token.atrule,
-   .token.attr-value,
-   .token.function,
-   .token.keyword,
-   .token.operator,
-   .token.selector {
-     font-weight: bold;
-   }
- 
-   .token.attr-value,
-   .token.comment,
-   .token.doctype,
-   .token.function,
-   .token.keyword,
-   .token.operator,
-   .token.property,
-   .token.string {
-     color: highlight;
-   }
- 
-   .token.attr-value,
-   .token.url {
-     font-weight: normal;
-   }
- }
+@media screen and (-ms-high-contrast: active) {
+  code[class*="language-"],
+  pre[class*="language-"] {
+    color: windowText;
+    background: window;
+  }
+
+  :not(pre) > code[class*="language-"],
+  pre[class*="language-"] {
+    background: window;
+  }
+
+  .token.important {
+    background: highlight;
+    color: window;
+    font-weight: normal;
+  }
+
+  .token.atrule,
+  .token.attr-value,
+  .token.function,
+  .token.keyword,
+  .token.operator,
+  .token.selector {
+    font-weight: bold;
+  }
+
+  .token.attr-value,
+  .token.comment,
+  .token.doctype,
+  .token.function,
+  .token.keyword,
+  .token.operator,
+  .token.property,
+  .token.string {
+    color: highlight;
+  }
+
+  .token.attr-value,
+  .token.url {
+    font-weight: normal;
+  }
+}

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line import/prefer-default-export
 export function debounce(fn: Function, timeout = 300) {
   let timer: ReturnType<typeof setTimeout>;
-  return function (this: any, ...args: any[]) {
+  return function func(this: any, ...args: any[]) {
     clearTimeout(timer);
     timer = setTimeout(() => {
       fn.apply(this, args);


### PR DESCRIPTION
adjusted table css to not go off screen on mobile devices. also fixed lint warning

## Summary of the changes
Added media queries to the HTML table css and colour table css to reduce the space taken by the table cells on smaller devices. This prevents other page content from stretching off the page on mobile.

## Related issue
#401 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
