### PR TITLE
docs(docs): adds ui-kit links on contribution page

### DIFF
--- a/src/content/structured/community/contribute.mdx
+++ b/src/content/structured/community/contribute.mdx
@@ -19,7 +19,7 @@ contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/struc
 - You should contribute in [StencilJS](https://stenciljs.com/) where you can. If that is not possible there will be a delay in the contribution.
 - We’ve adopted the [Contributor Covenant](https://www.contributor-covenant.org/), as expanded on in our [Code of Conduct](https://github.com/mi6/ic-design-system/tree/main/CODE_OF_CONDUCT.md). The core team, Working Group and contributors should always keep it in mind.
 - Read the [contribution criteria](/community/contribute-criteria).
-- For internal users, you can talk to us on the internal platforms, or [raise an issue on GitHub](https://github.com/mi6/ic-design-system/issues).
+- For internal users, you can talk to us on the internal platforms, or raise an issue on GitHub for either our [Design System](https://github.com/mi6/ic-design-system/issues) or [UI Kit](https://github.com/mi6/ic-ui-kit/issues).
 
 ## Raise a bug or suggest an improvement
 
@@ -33,11 +33,11 @@ Raise a bug or suggest improvements including brand new proposals to the UI Kit.
 
 You can help us speed up the development of our Design System by contributing new components and patterns or making improvements to existing ones.
 
-1. Select a ticket from the [backlog](https://github.com/mi6/ic-design-system/issues).
-2. [Claim a ticket](https://github.com/mi6/ic-design-system/issues), according to our [contribution guide](https://github.com/mi6/ic-design-system/tree/main/CONTRIBUTING.md), if you can help contribute code.
-3. If a backlog ticket doesn’t exist for your contribution, you can suggest it [through GitHub issues](https://github.com/mi6/ic-design-system/issues), or our internal Service Desk.
+1. Select a ticket from the [Design System](https://github.com/mi6/ic-design-system/issues) or the [UI Kit](https://github.com/mi6/ic-ui-kit/issues) backlog.
+2. Claim a ticket for our [Design System](https://github.com/mi6/ic-design-system/issues) or [UI Kit](https://github.com/mi6/ic-ui-kit/issues), according to our [Design System](https://github.com/mi6/ic-design-system/tree/main/CONTRIBUTING.md) or [UI Kit](https://github.com/mi6/ic-ui-kit/blob/main/CONTRIBUTING.md) contribution guide, if you can help contribute code.
+3. If a backlog ticket doesn’t exist for your contribution, you can suggest it through GitHub [Design System](https://github.com/mi6/ic-design-system/issues) or [UI Kit](https://github.com/mi6/ic-ui-kit/issues) issues, or our internal Service Desk.
 4. If you're an internal user, we will arrange a kickoff meeting to discuss the scope, plan and agree any support. For any external users, we'll work with you through GitHub issues.
-5. Refer to the technical instructions for [repository coding standards and practices](https://github.com/mi6/ic-design-system/tree/main/CONTRIBUTING.md).
+5. Refer to the technical instructions for [Design System](https://github.com/mi6/ic-design-system/tree/main/CONTRIBUTING.md) or the [UI Kit repository](https://github.com/mi6/ic-ui-kit/blob/main/CONTRIBUTING.md) coding standards and practices.
 6. Create a pull request to the develop branch for review.
 
 ## Contribute to the Figma UI Kit
@@ -50,9 +50,9 @@ You can help us speed up the development of our Design System by contributing ne
 
 If you're an internal user, you can contribute designs for a new component or an improvement to an existing one in the UI Kit using Figma.
 
-1. Select a design ticket from the [backlog](https://github.com/mi6/ic-design-system/issues).
-2. [Claim a ticket](https://github.com/mi6/ic-design-system/issues), according to our [contribution guide](https://github.com/mi6/ic-design-system/tree/main/CONTRIBUTING.md), if you can help design a component or pattern.
-3. If a backlog ticket doesn’t exist for your contribution, you can suggest it [through GitHub issues](https://github.com/mi6/ic-design-system/issues), or our internal Service Desk.
+1. Select a design ticket from the [Design System](https://github.com/mi6/ic-design-system/issues) or the [UI Kit](https://github.com/mi6/ic-ui-kit/issues) backlog.
+2. Claim a ticket from our [Design System](https://github.com/mi6/ic-design-system/issues) or [UI Kit](https://github.com/mi6/ic-ui-kit/issues), according to our [Design System](https://github.com/mi6/ic-design-system/tree/main/CONTRIBUTING.md) or [UI Kit](https://github.com/mi6/ic-ui-kit/tree/main/CONTRIBUTING.md) contribution guides, if you can help design a component or pattern.
+3. If a backlog ticket doesn’t exist for your contribution, you can suggest it through GitHub [Design System](https://github.com/mi6/ic-design-system/issues) or [UI Kit](https://github.com/mi6/ic-ui-kit/issues) issues, or our internal Service Desk.
 4. Complete the Figma contribution template with.
 5. We will arrange a kickoff meeting to discuss the scope, plan and agree any support.
 6. Let us know when your contribution is ready for review.


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

adds links to UI-Kit repo and issues board, where previously links only pointed to Design System

## Related issue

#352 

## Checklist


- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
