### PR TITLE
chore(root): enforce github user email in precommit

### DIFF
--- a/.husky/email-check.sh
+++ b/.husky/email-check.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This script will check for, and reject, non-github email addresses
+
+# Get user email used in git config
+EMAIL=$(git config user.email)
+
+# Regex for a private github email address
+MATCH='[A-Za-z0-9._%+-]+@users\.noreply\.github\.com$'
+
+echo "Checking git config user.email"
+if [[ $EMAIL =~ $MATCH ]]; then
+    echo "user.email is a GitHub user email. proceeding."
+    exit 0
+else
+    echo "Your email ($EMAIL) is not a GitHub user email. Please consult the Git Commit heading in CONTRIBUTING.md for information on how to correct this."
+    exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 . "$(dirname "$0")/_/husky.sh"
+
+bash "$(dirname "$0")/email-check.sh"
 
 npm run test
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,16 @@ These tools are ran as part of the pre-commit and can also be ran separately.
 
 Resolve linting and formatting issues via `npm run lint:fix` and `npm run prettier:fix`.
 
+### Git user configuration
+
+As a data protection measure, this repository enforces the use of GitHub user email address in your commit. Please follow these steps:
+
+1. Visit your [GitHub email settings](https://github.com/settings/emails)
+   - Optionally check the settings "Keep my email addresses private" and "Block command line pushes that expose my email"
+2. On this page, under **Primary Email Address** you'll see a user email that follows the pattern `<username>@users.noreply.github.com`.
+3. Inside your developer environment, open a command line in the directory of the ic-ui-kit repository
+4. Enter the command `git config user.email <EMAIL>` where you replace `<EMAIL>` with the address from step 3. This will be applied to commits made in this repository.
+
 ### Git commit
 
 For automated versioning, we use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).


### PR DESCRIPTION
## Summary of the changes

Added a email checking script to husky precommit hook that enforces git email to be set to github user email address. Added guidance to contributing.md

## Related issue

#584

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
