### PR TITLE
fix(root): update copy code button to use left-icon slot

### DIFF
--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -52,7 +52,7 @@ const CodeSnippet: React.FC<{ code: string }> = ({ code }) => (
           onClick={() => navigator.clipboard.writeText(code)}
         >
           Copy code
-          <SlottedSVG path={mdiContentCopy} slot="icon" />
+          <SlottedSVG path={mdiContentCopy} slot="left-icon" />
         </ic-button>
       </ic-tooltip>
     </div>

--- a/src/content/structured/components/buttons/code.mdx
+++ b/src/content/structured/components/buttons/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/button/code"
 
-date: "2023-02-06"
+date: "2023-10-03"
 
 title: "Button"
 
@@ -92,7 +92,7 @@ export const snippetsWithIcon = [
     language: "Web component",
     snippet: `<ic-button variant="primary">
   <svg
-    slot="icon"
+    slot="left-icon"
     xmlns="http://www.w3.org/2000/svg"
     height="24px"
     viewBox="0 0 24 24"
@@ -120,7 +120,7 @@ export const snippetsWithIcon = [
     language: "React",
     snippet: `<IcButton variant="primary">
   <SlottedSVG
-    slot="icon"
+    slot="left-icon"
     xmlns="http://www.w3.org/2000/svg"
     height="24px"
     viewBox="0 0 24 24"
@@ -151,7 +151,7 @@ export const snippetsWithIcon = [
   <IcButton variant="primary">
     Icon button
     <svg
-      slot="icon"
+      slot="left-icon"
       xmlns="http://www.w3.org/2000/svg"
       height="24px"
       viewBox="0 0 24 24"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update copy code button to use left-icon slot and update button docs

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
