### PR TITLE
fix(root): changed tab behaviour on component pages

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,29 +1,24 @@
 import "@ukic/fonts/dist/fonts.css";
 import "@ukic/web-components/dist/core/core.css";
 import "@ukic/web-components/dist/core/normalize.css";
-import "./src/styles/gatsby-reset.css";
 import "./src/styles/gatsby-override.css";
+import "./src/styles/gatsby-reset.css";
 
-import paths from "./src/utils/paths";
 import React from "react";
 import Layout from "./src/components/Layout";
+import paths from "./src/utils/paths";
 
 const { defineCustomElements } = require("@ukic/web-components/loader");
 
 defineCustomElements();
 
 // eslint-disable-next-line import/prefer-default-export
-export const wrapPageElement = ({ element, props }) => {
-  if (
-    paths.some((el) => {
-      return props.path === el;
-    })
-  ) {
-    return <>{element}</>;
-  } else {
-    return <Layout {...props}>{element}</Layout>;
-  }
-};
+export const wrapPageElement = ({ element, props }) =>
+  paths.some((el) => props.path === el) ? (
+    element
+  ) : (
+    <Layout {...props}>{element}</Layout>
+  );
 
 // eslint-disable-next-line import/prefer-default-export
 export const onInitialClientRender = () => {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -32,7 +32,6 @@ const createPosts = ({ createPage, createRedirect, edges }) => {
       component: path.resolve(pagesConfig.defaultTemplateComponent),
       context: {
         id: node.id,
-        returnBodies: node.fields.navSection === "components",
         navSection: node.fields.navSection,
         pageType: templateType,
       },

--- a/gatsby-overrides.js
+++ b/gatsby-overrides.js
@@ -1,6 +1,8 @@
-export const RouteAnnouncerProps = {
+const RouteAnnouncerProps = {
   id: `icds-override-hide-route-announcer`,
   style: {
     display: "none",
   },
 };
+
+export default RouteAnnouncerProps;

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,26 +1,21 @@
 import "@ukic/fonts/dist/fonts.css";
 import "@ukic/web-components/dist/core/core.css";
 import "@ukic/web-components/dist/core/normalize.css";
-import "./src/styles/gatsby-reset.css";
 import "./src/styles/gatsby-override.css";
+import "./src/styles/gatsby-reset.css";
 
-import paths from "./src/utils/paths";
 import React from "react";
 import Layout from "./src/components/Layout";
+import paths from "./src/utils/paths";
 
 const { defineCustomElements } = require("@ukic/web-components/loader");
 
 defineCustomElements();
 
 // eslint-disable-next-line import/prefer-default-export
-export const wrapPageElement = ({ element, props }) => {
-  if (
-    paths.some((el) => {
-      return props.path === el;
-    })
-  ) {
-    return <>{element}</>;
-  } else {
-    return <Layout {...props}>{element}</Layout>;
-  }
-};
+export const wrapPageElement = ({ element, props }) =>
+  paths.some((el) => props.path === el) ? (
+    element
+  ) : (
+    <Layout {...props}>{element}</Layout>
+  );

--- a/src/components/AnchorNav/index.tsx
+++ b/src/components/AnchorNav/index.tsx
@@ -57,13 +57,23 @@ const AnchorNav: React.FC<AnchorNavProps> = ({
   const handleLinkSelect = (
     e: React.MouseEvent | React.KeyboardEvent,
     headingId: string
-  ) => {
+  ): void => {
     // Move focus to heading when link is selected using Enter key
     if (e.detail === 0) {
       document
         .querySelector<HTMLAnchorElement>(`a[href='#${headingId}`)
         ?.focus();
     }
+
+    // reset the active class on current tab
+    setTimeout(() => {
+      const tabId = sessionStorage.getItem("currTab");
+      if (tabId !== "") {
+        const el = document.querySelector(`#${tabId}`)!
+          .firstElementChild as HTMLElement;
+        el.classList.add("active");
+      }
+    }, 300);
   };
 
   const getNavListItem = (heading: Heading) => {
@@ -76,7 +86,6 @@ const AnchorNav: React.FC<AnchorNavProps> = ({
           className={clsx("nav-link", isActive && "active-nav-link")}
           to={`#${headingId}`}
           onClick={(e) => handleLinkSelect(e, headingId)}
-          onKeyPress={(e) => handleLinkSelect(e, headingId)}
         >
           <ic-typography variant={isActive ? "subtitle-large" : "body"}>
             {heading.value}

--- a/src/components/AttributeCards/index.tsx
+++ b/src/components/AttributeCards/index.tsx
@@ -10,7 +10,7 @@ const AttributeCards: React.FC<AttributeCardsProps> = ({ data }) => (
   <table className="attribute-cards">
     <tbody>
       {data.map((cell) => (
-        <tr className="attribute-cards-row">
+        <tr key={cell.name} className="attribute-cards-row">
           <td className="attribute-cards-cell">
             {cell.name}
             {cell.description}

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from "react";
+import React, { ReactElement, useState } from "react";
 import { withPrefix } from "gatsby";
 
 import { Helmet } from "react-helmet";
@@ -28,7 +28,7 @@ interface RouteAnnouncerProps {
 }
 
 interface LayoutProps {
-  children: ReactNode;
+  children: ReactElement;
   imageUrl?: string;
   imageAltText?: string;
   data: {
@@ -38,6 +38,9 @@ interface LayoutProps {
       frontmatter: MdxFrontMatter;
       headings: Heading[];
     };
+  };
+  location: {
+    pathname: string;
   };
 }
 
@@ -72,6 +75,7 @@ const Layout: React.FC<LayoutProps> = ({
   imageAltText = "Intelligence Community Design System",
   children,
   data,
+  location,
 }) => {
   let canonicalUrl: string = "";
   if (typeof window !== "undefined") {
@@ -259,7 +263,7 @@ const Layout: React.FC<LayoutProps> = ({
             shortTitle={SHORT_TITLE}
           />
           <main id="main" className="homepage-wrapper">
-            {children}
+            {React.cloneElement(children, { location: location.pathname })}
             <ic-back-to-top target="main" />
           </main>
         </div>

--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -117,6 +117,7 @@ const WrappedListItem: React.FC<WrappedListItemProps> = ({
       to={url}
       title={label}
       partiallyActive={tabs && true}
+      onClick={() => sessionStorage.setItem("navlinkclick", "true")}
     >
       <ic-typography data-class="list-typography" variant="body">
         {text}
@@ -223,6 +224,16 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
 
   useEffect(() => {
     setHasMounted(true);
+    const linkClick = sessionStorage.getItem("navlinkclick");
+    sessionStorage.setItem("navlinkclick", "false");
+    if (linkClick === "true") {
+      setTimeout(() => {
+        const currentEl = document.querySelector(
+          "li.list-item a.active"
+        ) as HTMLElement;
+        if (currentEl) currentEl.focus();
+      }, 300);
+    }
   }, []);
 
   const handleBlur = (e: FocusEvent<HTMLElement>) => {

--- a/src/content/structured/components/dialog/guidance.mdx
+++ b/src/content/structured/components/dialog/guidance.mdx
@@ -60,7 +60,8 @@ export const DialogExample = () => {
         ]}
       >
         <IcTypography>
-          You are about to add 'Americano' to your basket. Are you sure you want to continue?
+          You are about to add 'Americano' to your basket. Are you sure you want
+          to continue?
         </IcTypography>
       </IcDialog>
     </>

--- a/src/sharedTypes.tsx
+++ b/src/sharedTypes.tsx
@@ -15,8 +15,6 @@ export interface NavigationObject {
   id: string;
   frontmatter: FrontMatter;
   fields: Fields;
-  body: string;
-  headings: Heading[];
 }
 
 export interface Icon {

--- a/src/templates/CoreTemplate/index.tsx
+++ b/src/templates/CoreTemplate/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { MDXRenderer } from "gatsby-plugin-mdx";
 import clsx from "clsx";
 
@@ -20,16 +20,19 @@ import WrappedLi from "../../components/WrappedLi";
 import WrappedLink from "../../components/WrappedLink";
 import WrappedP from "../../components/WrappedP";
 
-import { NavigationObject } from "../../sharedTypes";
-
 const { MDXProvider } = require("@mdx-js/react");
 
 interface CoreMDXLayoutProps {
   mdx: any;
-  tabContent: NavigationObject[];
+  children: string & React.ReactNode;
+  location: string;
 }
 
-const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({ mdx, tabContent }) => {
+const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({
+  mdx,
+  children,
+  location,
+}) => {
   const shortcodes = {
     h1: WrappedH1,
     h2: WrappedH2,
@@ -46,7 +49,6 @@ const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({ mdx, tabContent }) => {
     DoDontCaution,
     DoubleDoDontCaution,
   };
-  const [pageContent, setPageContent] = useState(mdx);
 
   return (
     <MDXProvider components={shortcodes}>
@@ -56,18 +58,16 @@ const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({ mdx, tabContent }) => {
           subheading={mdx.frontmatter.subTitle}
           adornment={mdx.frontmatter.status}
           tabs={mdx.frontmatter.tabs}
-          tabContent={tabContent}
-          currentPage={pageContent.fields.slug}
-          setPageContent={setPageContent}
+          location={location}
         />
         <ic-section-container aligned="center" id="page-section-container">
           <AnchorNav
-            currentPage={pageContent.fields.slug}
-            allHeadings={pageContent.headings}
-            section={pageContent.fields.navSection}
+            currentPage={mdx.fields.slug}
+            allHeadings={mdx.headings}
+            section={mdx.fields.navSection}
           />
           <div className="content-container">
-            <MDXRenderer>{pageContent.body}</MDXRenderer>
+            <MDXRenderer>{children}</MDXRenderer>
           </div>
         </ic-section-container>
       </div>

--- a/src/templates/Standard/index.tsx
+++ b/src/templates/Standard/index.tsx
@@ -27,17 +27,16 @@ interface TemplateProps {
       headings: Heading[];
     };
   };
+  location: string;
 }
 
 const Template: React.FC<TemplateProps> = ({
   pageContext: { pageType },
   data: { mdx, allMdx },
+  location,
 }) => {
-  const { title, date, contribute } = mdx.frontmatter;
+  const { date, contribute } = mdx.frontmatter;
   const allStructuredNav = allMdx.nodes;
-  const tabContent = allStructuredNav.filter(
-    (page) => page.frontmatter.title === title
-  );
 
   return (
     <ic-section-container aligned="full-width" full-height id="main-container">
@@ -54,7 +53,9 @@ const Template: React.FC<TemplateProps> = ({
           </div>
         </div>
         <div className="page-content">
-          <CoreMDXLayout mdx={mdx} tabContent={tabContent} />
+          <CoreMDXLayout mdx={mdx} location={location}>
+            {mdx.body}
+          </CoreMDXLayout>
           <Metadata publishDate={date} contribute={contribute} />
         </div>
       </div>
@@ -65,7 +66,7 @@ const Template: React.FC<TemplateProps> = ({
 export default Template;
 
 export const pageQuery = graphql`
-  query ($id: String!, $navSection: String, $returnBodies: Boolean!) {
+  query ($id: String!, $navSection: String) {
     mdx(id: { eq: $id }) {
       body
       fields {
@@ -102,11 +103,6 @@ export const pageQuery = graphql`
           tabs {
             path
           }
-        }
-        body @include(if: $returnBodies)
-        headings {
-          depth
-          value
         }
       }
     }


### PR DESCRIPTION
## Summary of the changes
Removed previous code that involved updating the tab content manually on component pages, so that they now function using Gatsby Links to preserve the url and Anchor Nav behaviour.

Added some additional code to focus the clicked tab when moving between the code, guidance and accessibility content, to preserve position on the page for keyboard users

## Related issue
#563 

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
