### PR TITLE
fix(root): update wrapped typography to use logical heading structure

### DIFF
--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -69,7 +69,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
   state = "none",
 }) => (
   <div className="comp-preview">
-    <h3 className="offscreen">Interactive example</h3>
+    <h4 className="offscreen">Interactive example</h4>
     <div
       className={clsx(
         "comp-zone",

--- a/src/components/ComponentDetails/EventTable/index.tsx
+++ b/src/components/ComponentDetails/EventTable/index.tsx
@@ -52,7 +52,7 @@ const EventTable: React.FC<EventTableProps> = ({ eventData }) => {
   return (
     <>
       <ic-typography variant="h3" apply-vertical-margins>
-        <h3>Events</h3>
+        <h4>Events</h4>
       </ic-typography>
       <AttributeTable columns={columns} data={data} />
       <AttributeCards data={data} />

--- a/src/components/ComponentDetails/MethodTable/index.tsx
+++ b/src/components/ComponentDetails/MethodTable/index.tsx
@@ -47,7 +47,7 @@ const EventTable: React.FC<MethodTableProps> = ({ methodData }) => {
   return (
     <>
       <ic-typography variant="h3" apply-vertical-margins>
-        <h3>Methods</h3>
+        <h4>Methods</h4>
       </ic-typography>
       <AttributeTable columns={columns} data={data} />
       <AttributeCards data={data} />

--- a/src/components/ComponentDetails/PropTable/index.tsx
+++ b/src/components/ComponentDetails/PropTable/index.tsx
@@ -76,7 +76,7 @@ const PropTable: React.FC<PropTableProps> = ({ propData }) => {
   return (
     <>
       <ic-typography variant="h3" apply-vertical-margins>
-        <h3>Props</h3>
+        <h4>Props</h4>
       </ic-typography>
       <AttributeTable columns={columns} data={data} />
       <AttributeCards data={data} />

--- a/src/components/ComponentDetails/SlotTable/index.tsx
+++ b/src/components/ComponentDetails/SlotTable/index.tsx
@@ -35,7 +35,7 @@ const PropTable: React.FC<PropTableProps> = ({ slotData }) => {
   return (
     <>
       <ic-typography variant="h3" apply-vertical-margins>
-        <h3>Slots</h3>
+        <h4>Slots</h4>
       </ic-typography>
       <ic-typography apply-vertical-margins>
         <p>

--- a/src/components/ComponentDetails/StyleTable/index.tsx
+++ b/src/components/ComponentDetails/StyleTable/index.tsx
@@ -35,7 +35,7 @@ const StyleTable: React.FC<StyleTableProps> = ({ styleData }) => {
   return (
     <>
       <ic-typography variant="h3" apply-vertical-margins>
-        <h3>CSS Custom Properties</h3>
+        <h4>CSS Custom Properties</h4>
       </ic-typography>
       <AttributeTable columns={columns} data={data} />
       <AttributeCards data={data} />

--- a/src/components/WrappedH1/index.tsx
+++ b/src/components/WrappedH1/index.tsx
@@ -9,7 +9,7 @@ const WrappedH1: React.FC = (props: any) => (
     data-class="heading-extra-large"
   >
     {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-    <h3 {...props} />
+    <h2 {...props} />
   </ic-typography>
 );
 

--- a/src/components/WrappedH2/index.tsx
+++ b/src/components/WrappedH2/index.tsx
@@ -13,10 +13,10 @@ interface WrappedH2Props {
 const WrappedH2: React.FC<WrappedH2Props> = ({ children }) => (
   <ic-typography variant="h2" apply-vertical-margins data-class="h2">
     {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-    <h4 id={slug(children)}>
+    <h3 id={slug(children)}>
       {children}
       <Permalink title={children} sluggedTitle={slug(children)} />
-    </h4>
+    </h3>
   </ic-typography>
 );
 

--- a/src/components/WrappedH3/index.tsx
+++ b/src/components/WrappedH3/index.tsx
@@ -13,10 +13,10 @@ interface WrappedH3Props {
 const WrappedH3: React.FC<WrappedH3Props> = ({ children }) => (
   <ic-typography variant="h3" apply-vertical-margins data-class="h3">
     {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-    <h5 id={slug(children)}>
+    <h4 id={slug(children)}>
       {children}
       <Permalink title={children?.toString()} sluggedTitle={slug(children)} />
-    </h5>
+    </h4>
   </ic-typography>
 );
 

--- a/src/components/WrappedH4/index.tsx
+++ b/src/components/WrappedH4/index.tsx
@@ -5,7 +5,7 @@ import "./index.css";
 const WrappedH4: React.FC = (props: any) => (
   <ic-typography variant="h4" apply-vertical-margins data-class="h4">
     {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-    <h6 {...props} />
+    <h5 {...props} />
   </ic-typography>
 );
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update wrapped typography to use logical heading structure, so that top level headings on page content are h3 instead of h4 etc.

## Related issue

#611

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
