### PR TITLE
fix(root): update top nav to use short-app-title slot and app-icon to slot a link

### DIFF
--- a/src/components/TopNavWrapper/index.tsx
+++ b/src/components/TopNavWrapper/index.tsx
@@ -26,17 +26,16 @@ const TopNavWrapper: React.FC<TopNavWrapperProps> = ({
   version,
   shortTitle,
 }) => (
-  <ic-top-navigation
-    version={version}
-    app-title={appTitle}
-    short-app-title={shortTitle}
-  >
+  <ic-top-navigation version={version}>
     <GatsbyLink slot="app-title" to={withPrefix("/")}>
       {appTitle}
     </GatsbyLink>
-    <span slot="app-icon">
+    <GatsbyLink slot="short-app-title" to={withPrefix("/")}>
+      {shortTitle}
+    </GatsbyLink>
+    <a slot="app-icon" href={withPrefix("/")}>
       <ICDSLogo role="img" aria-labelledby="ICDS Logo" className="icds-logo" />
-    </span>
+    </a>
     {textLinks.map(({ key, ...rest }) => (
       <TopNavItem {...rest} key={key} />
     ))}

--- a/src/content/structured/components/top-nav/code.mdx
+++ b/src/content/structured/components/top-nav/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/top-navigation/code"
 
-date: "2023-10-11"
+date: "2023-11-23"
 
 title: "Top navigation"
 
@@ -809,25 +809,29 @@ export const snippetsShortTitle = [
 
 ### With React Router (using slots)
 
-The following example also demonstrates using a slotted app title link.
+The following example also demonstrates using a slotted link for app title, short app title, and app icon.
+
+To guarantee the correct styling for non-svg content slotted into app-icon, set `width`, `height` and `fill` to `inherit`.
 
 export const withReactRouter = [
   {
     language: "React",
     snippet: `<MemoryRouter initialEntries={["/"]}>
-  <IcTopNavigation appTitle="ICDS" status="alpha" version="v0.0.7">
-    <NavLink to="/" slot="app-title">ICDS</NavLink>
-    <SlottedSVG
-      slot="app-icon"
-      xmlns="http://www.w3.org/2000/svg"
-      height="24px"
-      viewBox="0 0 24 24"
-      width="24px"
-      fill="#000000"
-    >
-      <path d="M0 0h24v24H0V0z" fill="none" />
-      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
-    </SlottedSVG>
+  <IcTopNavigation version="v0.0.7">
+    <NavLink to="/" slot="app-title">ICDS Title</NavLink>
+    <NavLink to="/" slot="short-app-title">ICDS</NavLink>
+    <NavLink to="/" slot="app-icon">
+      <SlottedSVG
+        xmlns="http://www.w3.org/2000/svg"
+        height="inherit"
+        viewBox="0 0 24 24"
+        width="inherit"
+        fill="inherit"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+      </SlottedSVG>
+    </NavLink>
   <IcSearchBar slot="search" placeholder="Search" label="Search" />
   <IcNavigationButton label="button1" slot="buttons" onClick={() => alert('test')}>
     <SlottedSVG
@@ -867,21 +871,25 @@ export const withReactRouter = [
   style={{ display: "flex", flexDirection: "column" }}
 >
   <MemoryRouter initialEntries={["/"]}>
-    <IcTopNavigation appTitle="ICDS" status="alpha" version="v0.0.7">
+    <IcTopNavigation version="v0.0.7">
       <NavLink to="/" slot="app-title">
+        ICDS Title
+      </NavLink>
+      <NavLink to="/" slot="short-app-title">
         ICDS
       </NavLink>
-      <svg
-        slot="app-icon"
-        xmlns="http://www.w3.org/2000/svg"
-        height="24px"
-        viewBox="0 0 24 24"
-        width="24px"
-        fill="#000000"
-      >
-        <path d="M0 0h24v24H0V0z" fill="none" />
-        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
-      </svg>
+      <NavLink to="/" slot="app-icon">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="inherit"
+          viewBox="0 0 24 24"
+          width="inherit"
+          fill="inherit"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+        </svg>
+      </NavLink>
       <IcSearchBar slot="search" placeholder="Search" label="Search" />
       <IcNavigationButton
         label="button1"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update top nav to use short-app-title slot and app-icon to slot a link in order to correctly route around the site. Added guidance to the top nav code page to show users how to do this too.

Will need to be built locally until https://github.com/mi6/ic-ui-kit/pull/1282 is in main.

## Related issue

#693

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
