### PR TITLE
docs(root): remove inline prop for icLink on alerts code page

### DIFF
--- a/src/components/Metadata/index.tsx
+++ b/src/components/Metadata/index.tsx
@@ -7,9 +7,7 @@ interface MetadataProps {
   publishDate?: string;
 }
 
-const Metadata: React.FC<MetadataProps> = ({
-  publishDate = null,
-}) => (
+const Metadata: React.FC<MetadataProps> = ({ publishDate = null }) => (
   <div>
     <hr className="bottom-line" />
     <ic-section-container>

--- a/src/content/structured/components/alerts/code.mdx
+++ b/src/content/structured/components/alerts/code.mdx
@@ -206,13 +206,13 @@ export const snippetsCustomMessage = [
   {
     language: "Web component",
     snippet: `<ic-alert variant="info" heading="Want to know more about our coffee?">
-  <span slot="message"> Go to our <ic-link href="/" inline="">coffee page</ic-link> to learn more.</span>
+  <span slot="message"> Go to our <ic-link href="/">coffee page</ic-link> to learn more.</span>
 </ic-alert>`,
   },
   {
     language: "React",
     snippet: `<IcAlert variant="info" heading="Want to know more about our coffee?">
-  <span slot="message"> Go to our <IcLink href="/" inline>coffee page</IcLink> to learn more.</span>
+  <span slot="message"> Go to our <IcLink href="/">coffee page</IcLink> to learn more.</span>
 </IcAlert>`,
   },
 ];
@@ -227,7 +227,7 @@ export const snippetsCustomMessage = [
       }}
     >
       Got to our{" "}
-      <IcLink href="#" onClick={(e) => e.preventDefault()} inline="">
+      <IcLink href="#" onClick={(e) => e.preventDefault()}>
         coffee page
       </IcLink>{" "}
       to learn more.


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Remove inline prop for icLink on alerts code page as there is no inline prop on icLink.

Also a small prettier change.

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
