### PR TITLE
fix(root): update export of RouteAnnouncerProps so it can be accessed by gatsby

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -21,6 +21,7 @@
     "GHSA-gxpj-cx7g-858c",
     "GHSA-wf5p-g6vw-rhxx",
     "GHSA-54xq-cgqr-rpm3",
-    "GHSA-prr3-c3m5-p7q2"
+    "GHSA-prr3-c3m5-p7q2",
+    "GHSA-7hpj-7hhx-2fgx"
   ]
 }

--- a/gatsby-overrides.js
+++ b/gatsby-overrides.js
@@ -1,8 +1,7 @@
-const RouteAnnouncerProps = {
+// eslint-disable-next-line import/prefer-default-export
+export const RouteAnnouncerProps = {
   id: `icds-override-hide-route-announcer`,
   style: {
     display: "none",
   },
 };
-
-export default RouteAnnouncerProps;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update export of RouteAnnouncerProps so it can be accessed by gatsby and apply `display: "none"` instead of showing below footer

## Related issue

#657

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
