### PR TITLE
fix(root): updated accesible labels for anchor and left hand navs

### DIFF
--- a/src/components/AnchorNav/index.tsx
+++ b/src/components/AnchorNav/index.tsx
@@ -10,14 +10,9 @@ const { slug } = require("github-slugger");
 interface AnchorNavProps {
   allHeadings: Heading[];
   currentPage: string;
-  section: string;
 }
 
-const AnchorNav: React.FC<AnchorNavProps> = ({
-  allHeadings,
-  currentPage,
-  section,
-}) => {
+const AnchorNav: React.FC<AnchorNavProps> = ({ allHeadings, currentPage }) => {
   const headings = allHeadings.filter(({ depth }) => depth === 2);
 
   const headingIds = headings.map(({ value }) => slug(value));
@@ -70,8 +65,8 @@ const AnchorNav: React.FC<AnchorNavProps> = ({
       const tabId = sessionStorage.getItem("currTab");
       if (tabId !== "") {
         document
-          .querySelector(`#${tabId}`)!
-          .firstElementChild!.classList.add("active");
+          .querySelector(`#${tabId}`)
+          ?.firstElementChild!.classList.add("active");
       }
     }, 300);
   };
@@ -96,18 +91,33 @@ const AnchorNav: React.FC<AnchorNavProps> = ({
     );
   };
 
-  return headings.length > 0 ? (
-    <div className="side-nav">
-      <nav aria-label={`${section} section contents`} className="nav">
-        <div className="contents-header">
-          <ic-typography variant="subtitle-large">Contents</ic-typography>
-        </div>
-        <ul className="nav-item-list">
-          {headings.map(({ value }, index) => getNavListItem(value, index))}
-        </ul>
-      </nav>
-    </div>
-  ) : null;
+  let currentPageName = currentPage.substring(currentPage.lastIndexOf("/") + 1);
+  let currTab = "guidance";
+
+  if (currentPageName === "code" || currentPageName === "accessibility") {
+    currTab = currentPageName;
+    currentPageName = currentPage
+      .replace(`/${currentPageName}`, "")
+      .replace("/components/", "");
+  }
+
+  return (
+    headings.length > 0 && (
+      <div className="side-nav">
+        <nav
+          aria-label={`${currentPageName} ${currTab} page contents`}
+          className="nav"
+        >
+          <div className="contents-header">
+            <ic-typography variant="subtitle-large">Contents</ic-typography>
+          </div>
+          <ul className="nav-item-list">
+            {headings.map(({ value }, index) => getNavListItem(value, index))}
+          </ul>
+        </nav>
+      </div>
+    )
+  );
 };
 
 export default AnchorNav;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -37,9 +37,9 @@ const Header: React.FC<HeaderProps> = ({
     }
 
     const getActiveLinkEl = () => {
-      const el = document.querySelector(`#${tabId}`)!
-        .firstElementChild as HTMLElement;
-      el.classList.add("active");
+      const el = document.querySelector(`#${tabId}`)
+        ?.firstElementChild as HTMLElement;
+      el?.classList.add("active");
       return el;
     };
 

--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -258,6 +258,9 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
     }
   };
 
+  const accessibleLabel =
+    section.slice(-1).toLowerCase() === "s" ? section.slice(0, -1) : section;
+
   return (
     <>
       <ic-link id="skip-page-content-link" href="#page-contents">
@@ -286,7 +289,7 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
       </ic-button>
       <nav
         id="icds-section-nav"
-        aria-label={`${section} section`}
+        aria-label={`${accessibleLabel} pages`}
         className={clsx(
           "scroll",
           "large-only",

--- a/src/templates/CoreTemplate/index.tsx
+++ b/src/templates/CoreTemplate/index.tsx
@@ -63,11 +63,7 @@ const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({
           location={location}
         />
         <ic-section-container aligned="center" id="page-section-container">
-          <AnchorNav
-            currentPage={mdx.fields.slug}
-            allHeadings={mdx.headings}
-            section={mdx.fields.navSection}
-          />
+          <AnchorNav currentPage={mdx.fields.slug} allHeadings={mdx.headings} />
           <div className="content-container">
             <MDXRenderer>{children}</MDXRenderer>
           </div>


### PR DESCRIPTION
## Summary of the changes
Updated accessible labels for the left hand nav and anchor nav to be more descriptive regarding what a user is focused on, giving them more information

## Related issue
#610 

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
