### PR TITLE
docs(root): update get started guides to have a page of next.js

### DIFF
--- a/src/content/structured/get-started/custom-theme.mdx
+++ b/src/content/structured/get-started/custom-theme.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/get-started/install-components/custom-theme"
 
-navPriority: 10
+navPriority: 9
 
 date: "2022-11-15"
 

--- a/src/content/structured/get-started/nextjs.mdx
+++ b/src/content/structured/get-started/nextjs.mdx
@@ -1,0 +1,63 @@
+---
+path: "/get-started/install-components/nextJS"
+
+navPriority: 8
+
+date: "2024-01-17"
+
+title: "Next.js"
+
+subTitle: "How to use the components in a Next.js project."
+
+contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/nextJS.mdx"
+---
+
+## Transpile react package
+
+The `@ukic/react` package will need to be transpiled for use with Next.js. The steps required will depend on the version of Next.js you are using.
+
+### Next.js 13
+
+Set the following in the `next.config.js` file.
+
+```jsx
+const nextConfig = {
+  //other configuration
+  transpilePackages: ["@ukic/react"],
+};
+
+module.exports = nextConfig;
+```
+
+### Next.js 12 and earlier
+
+#### Step one
+
+Install the `next-transpile-modules` package in the root of your project.
+
+```shell
+// using npm
+npm install next-transpile-modules
+
+// using yarn
+yarn add next-transpile-modules
+```
+
+#### Step two
+
+Set the following in the `next.config.js` file.
+
+```jsx
+const nextConfig = {
+  //other configuration
+};
+
+const withTM = require("next-transpile-modules")(["@ukic/react"]);
+module.exports = withTM(nextConfig);
+```
+
+## Web components limitations
+
+While our component library is built with web components, which offer numerous benefits, there may be limitations when using them with Next.js or other Server-Side Rendering (SSR) frameworks due to current limitations in web component support.
+
+This may result in slower performance and manual workarounds. We're actively working to provide more information and update on this topic as it evolves.

--- a/src/content/structured/get-started/react.mdx
+++ b/src/content/structured/get-started/react.mdx
@@ -3,7 +3,7 @@ path: "/get-started/install-components/react"
 
 navPriority: 2
 
-date: "2023-01-13"
+date: "2024-01-17"
 
 title: "React"
 
@@ -60,50 +60,6 @@ Import the component(s) in your React files.
 
 ```jsx
 import { IcComponent } from "@ukic/react";
-```
-
-## Using NextJS
-
-The `@ukic/react` package will need to be transpiled for use with NextJS. The steps required will depend on the version of NextJS you are using.
-
-### NextJS 13
-
-Set the following in the `next.config.js` file.
-
-```jsx
-const nextConfig = {
-  //other configuration
-  transpilePackages: ["@ukic/react"],
-};
-
-module.exports = nextConfig;
-```
-
-### NextJS 12 and earlier
-
-#### Step one
-
-Install the `next-transpile-modules` package in the root of your project.
-
-```shell
-// using npm
-npm install next-transpile-modules
-
-// using yarn
-yarn add next-transpile-modules
-```
-
-#### Step two
-
-Set the following in the `next.config.js` file.
-
-```jsx
-const nextConfig = {
-  //other configuration
-};
-
-const withTM = require("next-transpile-modules")(["@ukic/react"]);
-module.exports = withTM(nextConfig);
 ```
 
 ## Working with slotted SVGs


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update get started guides to have a page of next.js, this includes explaining the limitations with web components and moving the existing information about transpiling the react package.

## Related issue

#749

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
