### PR TITLE
fix(root): changed return type of AnchorNav

### DIFF
--- a/src/components/AnchorNav/index.tsx
+++ b/src/components/AnchorNav/index.tsx
@@ -101,23 +101,21 @@ const AnchorNav: React.FC<AnchorNavProps> = ({ allHeadings, currentPage }) => {
       .replace("/components/", "");
   }
 
-  return (
-    headings.length > 0 && (
-      <div className="side-nav">
-        <nav
-          aria-label={`${currentPageName} ${currTab} page contents`}
-          className="nav"
-        >
-          <div className="contents-header">
-            <ic-typography variant="subtitle-large">Contents</ic-typography>
-          </div>
-          <ul className="nav-item-list">
-            {headings.map(({ value }, index) => getNavListItem(value, index))}
-          </ul>
-        </nav>
-      </div>
-    )
-  );
+  return headings.length > 0 ? (
+    <div className="side-nav">
+      <nav
+        aria-label={`${currentPageName} ${currTab} page contents`}
+        className="nav"
+      >
+        <div className="contents-header">
+          <ic-typography variant="subtitle-large">Contents</ic-typography>
+        </div>
+        <ul className="nav-item-list">
+          {headings.map(({ value }, index) => getNavListItem(value, index))}
+        </ul>
+      </nav>
+    </div>
+  ) : null;
 };
 
 export default AnchorNav;


### PR DESCRIPTION
## Summary of the changes
Ensured that AnchorNav returns null rather than false when now headings are provided

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
