### PR TITLE
fix(root): remove classification banner guidance for when exporting o…

### DIFF
--- a/src/content/structured/components/classification-banner/guidance.mdx
+++ b/src/content/structured/components/classification-banner/guidance.mdx
@@ -46,8 +46,6 @@ All apps, except public ones, require a classification banner. When multiple pie
 
 Place a single banner at the bottom of the viewport. The banner is always fixed and should not scroll with the page.
 
-When printing or exporting a page, the protective marking must appear at the top and bottom of each page in the printed or exported document.
-
 ## Content
 
 If there is information on a single page that has multiple different classifications, display the maximum classification with the text prefix of `UP TO`.


### PR DESCRIPTION
<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Remove classification banner guidance that is not required.

## Related issue

#721 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
