### PR TITLE
730 add information alert to angular page

### DIFF
--- a/src/content/structured/get-started/angular.mdx
+++ b/src/content/structured/get-started/angular.mdx
@@ -11,8 +11,9 @@ subTitle: "To use the components follow the relevant framework instructions."
 
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/angular.mdx"
 ---
+import {IcAlert} from "@ukic/react"
 
-These instructions were used with Angular version 13.2.5.
+<IcAlert variant="info" heading="Version check" message="These instructions were used with Angular version 13.2.5."/>
 
 ## Step one
 

--- a/src/content/structured/get-started/svelte.mdx
+++ b/src/content/structured/get-started/svelte.mdx
@@ -11,8 +11,9 @@ subTitle: "To use the components follow the relevant framework instructions."
 
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/svelte.mdx"
 ---
+import {IcAlert} from "@ukic/react"
 
-These instructions were used with Svelte version 3.50.1.
+<IcAlert variant="info" heading="Version check" message="These instructions were used with Svelte version 3.50.1."/>
 
 ## Step one
 

--- a/src/content/structured/get-started/vue.mdx
+++ b/src/content/structured/get-started/vue.mdx
@@ -11,8 +11,9 @@ subTitle: "To use the components follow the relevant framework instructions."
 
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/vue.mdx"
 ---
+import {IcAlert} from "@ukic/react"
 
-These instructions were used with Vue version 3.2.31.
+<IcAlert variant="info" heading="Version check" message="These instructions were used with Vue version 3.2.31."/>
 
 ## Step one
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Removed the lone lines of text indicating version at the top of Get Started -> Angular/Svelte/Vue, and placed information into IcAlert components for increased cohesion on the page. 

## Related issue

#730

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
