### PR TITLE
Updates to colour theme guidance

### DIFF
--- a/src/content/structured/get-started/custom-theme.mdx
+++ b/src/content/structured/get-started/custom-theme.mdx
@@ -3,7 +3,7 @@ path: "/get-started/install-components/custom-theme"
 
 navPriority: 9
 
-date: "2022-11-15"
+date: "2024-02-05"
 
 title: "Custom theme"
 
@@ -16,9 +16,11 @@ contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/struc
 
 Some components can have their theme colour changed by using either of the methods below. When the theme colour is changed, components will automatically update.
 
-Other styles on affected components will also adapt accordingly, such as text colour and focus border indicators.
+Other styles on affected components will also adapt accordingly, such as the colour of text or icons.
 
 ## CSS variables
+
+You can set the theme colour by using the three CSS variables (one for each of the RGB values for the colour) shown below:
 
 ```css
 :root {


### PR DESCRIPTION
## Summary of the changes

Added sentence to update guidance about using CSS variables to set the theme colour, making it clearer that you need to use the three separate variables as shown. (From a conversation with a customer, it seems there may have been some confusion about this method).

Also updated sentence about focus indicators changing as it no longer happens since we use the same focus indicator for everything.

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
