### PR TITLE
fix(root): fix the popover open and close state

### DIFF
--- a/src/content/structured/components/popover-menu/code.mdx
+++ b/src/content/structured/components/popover-menu/code.mdx
@@ -48,7 +48,7 @@ export const snippets = [
 <script>
   var icPopover = document.querySelector("#popover-menu");
   function handleClick() {
-    icPopover.open = true;
+    icPopover.open = !icPopover.open;
   }
 </script>
 <div>
@@ -71,7 +71,7 @@ export const snippets = [
     language: "React",
     snippet: `const popoverEl = useRef(null);
 const handleClick = () => {
-  popoverEl.current.open = true;
+  popoverEl.current.open = !popoverEl.current.open;
 };
 return (
   <>
@@ -111,7 +111,7 @@ return (
 export const DemoPopover = () => {
   const popoverEl = useRef(null);
   const handleClick = () => {
-    popoverEl.current.open = true;
+    popoverEl.current.open = !popoverEl.current.open;
   };
   return (
     <>
@@ -197,7 +197,7 @@ export const snippetsButtons = [
 <script>
   var icPopover = document.querySelector("#popover-menu-2");
   function handleClick() {
-    icPopover.open = true;
+    icPopover.open = !icPopover.open;
   }
 </script>
 <div>
@@ -229,7 +229,7 @@ export const snippetsButtons = [
     language: "React",
     snippet: `const popoverEl = useRef(null);
 const handleClick = () => {
-  popoverEl.current.open = true;
+  popoverEl.current.open = !popoverEl.current.open;
 };
 return (
   <>
@@ -281,7 +281,7 @@ return (
 export const ButtonsPopover = () => {
   const popoverEl = useRef(null);
   const handleClick = () => {
-    popoverEl.current.open = true;
+    popoverEl.current.open = !popoverEl.current.open;
   };
   return (
     <>
@@ -366,7 +366,7 @@ export const snippetsGroups = [
 <script>
   var icPopover = document.querySelector("#popover-menu-3");
   function handleClick() {
-    icPopover.open = true;
+    icPopover.open = !icPopover.open;
   }
 </script>
 <div>
@@ -386,7 +386,7 @@ export const snippetsGroups = [
     language: "React",
     snippet: `const popoverEl = useRef(null);
 const handleClick = () => {
-  popoverEl.current.open = true;
+  popoverEl.current.open = !popoverEl.current.open;
 };
 return (
   <>
@@ -426,7 +426,7 @@ return (
 export const GroupsPopover = () => {
   const popoverEl = useRef(null);
   const handleClick = () => {
-    popoverEl.current.open = true;
+    popoverEl.current.open = !popoverEl.current.open;
   };
   return (
     <>

--- a/src/content/structured/components/popover-menu/guidance.mdx
+++ b/src/content/structured/components/popover-menu/guidance.mdx
@@ -41,7 +41,7 @@ Click on the 'More Information' button below to view an example of the popover m
 export const IntroPopover = () => {
   const popoverEl = useRef(null);
   const handleClick = () => {
-    popoverEl.current.open = true;
+    popoverEl.current.open = !popoverEl.current.open;
   };
   return (
     <>


### PR DESCRIPTION
## Summary of the changes

These changes fix the issues on the guidance site with the open and closed state for the IcPopoverMenu.

## Related issue

#807 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
