### PR TITLE
fix(root): update cards to use h4 element as slotted heading

### DIFF
--- a/src/components/ComponentGallery/index.tsx
+++ b/src/components/ComponentGallery/index.tsx
@@ -32,12 +32,15 @@ const ComponentGallery: React.FC = () => {
         uniqueComponentDetails.map((item: ComponentDetails) => (
           <li>
             <GatsbyLink to={`${item.path}`}>
-              <ic-card
-                heading={item.title}
-                message={item.subTitle}
-                full-width
-                clickable
-              />
+              <ic-card message={item.subTitle} full-width clickable>
+                <ic-typography
+                  slot="heading"
+                  variant="h4"
+                  aria-label={`${item.title} component.`}
+                >
+                  <h4>{item.title}</h4>
+                </ic-typography>
+              </ic-card>
             </GatsbyLink>
           </li>
         ))}

--- a/src/templates/Homepage/index.tsx
+++ b/src/templates/Homepage/index.tsx
@@ -82,11 +82,14 @@ const Homepage: React.FC = () => {
               homepage.cards.content.map((item: homepageCardItem) => (
                 <li>
                   <GatsbyLink to={item.path}>
-                    <ic-card
-                      heading={item.title}
-                      message={item.description}
-                      full-width
-                    >
+                    <ic-card message={item.description} full-width>
+                      <ic-typography
+                        slot="heading"
+                        variant="h4"
+                        aria-label={`${item.title}.`}
+                      >
+                        <h4>{item.title}</h4>
+                      </ic-typography>
                       {renderIcon(item.icon)}
                     </ic-card>
                   </GatsbyLink>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update cards to use h4 element as slotted heading with aria label to fix lack of pause for screen readers.

## Related issue

#607 
#718 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
