### PR TITLE
Fix skip to content links not moving virtual cursor

### DIFF
--- a/src/components/Layout/index.css
+++ b/src/components/Layout/index.css
@@ -1,13 +1,13 @@
-#skip-content-link {
+#skip-main-content-link {
   position: absolute;
   left: -9999px;
 }
 
-#skip-content-link:hover {
+#skip-main-content-link:hover {
   text-decoration: none;
 }
 
-#skip-content-link:focus {
+#skip-main-content-link:focus {
   background: var(--ic-architectural-white);
   position: absolute;
   z-index: 100;

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -239,7 +239,7 @@ const Layout: React.FC<LayoutProps> = ({
           )}
         </ClientOnly>
         <div className="main-page-container">
-          <ic-link href="#main" id="skip-content-link">
+          <ic-link href="#main-content" id="skip-main-content-link">
             Skip to main content
           </ic-link>
           <TopNavWrapper
@@ -249,6 +249,7 @@ const Layout: React.FC<LayoutProps> = ({
             shortTitle={SHORT_TITLE}
           />
           <main id="main" className="homepage-wrapper">
+            <a id="main-content" tabIndex={-1}></a>
             {cloneElement(children, { location: location.pathname })}
             <ic-back-to-top target="main" />
           </main>

--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -263,7 +263,7 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
 
   return (
     <>
-      <ic-link id="skip-page-content-link" href="#page-contents">
+      <ic-link id="skip-page-content-link" href="#page-content">
         Skip to page content
       </ic-link>
       <ic-button

--- a/src/templates/CoreTemplate/index.tsx
+++ b/src/templates/CoreTemplate/index.tsx
@@ -54,7 +54,7 @@ const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({
 
   return (
     <MDXProvider components={shortcodes}>
-      <div className={clsx("force", "page-container")} id="page-contents">
+      <div className={clsx("force", "page-container")}>
         <Header
           heading={mdx.frontmatter.title}
           subheading={mdx.frontmatter.subTitle}

--- a/src/templates/Standard/index.tsx
+++ b/src/templates/Standard/index.tsx
@@ -53,6 +53,11 @@ const Template: React.FC<TemplateProps> = ({
           </div>
         </div>
         <div className="page-content">
+          <a
+            id="page-content"
+            aria-label={`${mdx.frontmatter.title} page content`}
+            tabIndex={-1}
+          ></a>
           <CoreMDXLayout mdx={mdx} location={location}>
             {mdx.body}
           </CoreMDXLayout>


### PR DESCRIPTION
## Summary of the changes

Added fixes to get "Skip to main content" and "Skip to page content" links moving the virtual cursor rather than just keyboard focus. 

You can test this by doing the following with VoiceOver enabled:
1. Tab to the links ("Skip to _main_ content" is just before the home link on the top navigation, "Skip to _page_ content" is just before the left hand navigation items).
2. Press Enter.
3. Use a keyboard shortcut which moves the virtual cursor. See the [VoiceOver shortcuts](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts) for these - "VO" stated here is Caps Lock by default. I have tended to use VO + Right Arrow or VO + A.

See [my comment on the ticket](https://github.com/mi6/ic-design-system/issues/616#issuecomment-1944296650) if you would like to find out about the research I did and how I came to this solution.

## Related issue

#616 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
