### PR TITLE
fix(root): update colour toxen to have # so that it appears correctly

### DIFF
--- a/src/content/structured/styles/components/ColourTable/colours.config.ts
+++ b/src/content/structured/styles/components/ColourTable/colours.config.ts
@@ -190,7 +190,7 @@ export const ColoursStatus = [
       {
         name: "Error dark",
         token: "--ic-status-error-dark",
-        hex: "610A05",
+        hex: "#610A05",
       },
       { name: "Information", token: "--ic-status-info", hex: "#124DB3" },
       {


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update colour toxen to have # so that it appears correctly with the colour circle like the others.

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
