### PR TITLE
fix(root): fix errors picked up by A11y Insights FastPass and WAVE tool

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -271,15 +271,15 @@ const Layout: React.FC<LayoutProps> = ({
             ))}
             <div slot="logo" className="logo-wrapper">
               <ic-footer-link href="https://sis.gov.uk">
-                <SISLogo aria-labelledby="SIS Logo" />
-                <span className="link-text">Go to SIS website</span>
+                <SISLogo aria-hidden="true" />
+                <span className="link-text">Go to S.I.S. website</span>
               </ic-footer-link>
               <ic-footer-link href="https://www.mi5.gov.uk">
-                <MI5Logo aria-labelledby="MI5 Logo" />
+                <MI5Logo aria-hidden="true" />
                 <span className="link-text">Go to MI5 website</span>
               </ic-footer-link>
               <ic-footer-link href="https://gchq.gov.uk">
-                <GCHQLogo aria-labelledby="GCHQ Logo" />
+                <GCHQLogo aria-hidden="true" />
                 <span className="link-text">Go to GCHQ website</span>
               </ic-footer-link>
             </div>

--- a/src/components/TopNavWrapper/index.tsx
+++ b/src/components/TopNavWrapper/index.tsx
@@ -27,14 +27,14 @@ const TopNavWrapper: React.FC<TopNavWrapperProps> = ({
   shortTitle,
 }) => (
   <ic-top-navigation version={version}>
-    <GatsbyLink slot="app-title" to={withPrefix("/")}>
+    <GatsbyLink id="icds-link" slot="app-title" to={withPrefix("/")}>
       {appTitle}
     </GatsbyLink>
     <GatsbyLink slot="short-app-title" to={withPrefix("/")}>
       {shortTitle}
     </GatsbyLink>
     <a slot="app-icon" href={withPrefix("/")}>
-      <ICDSLogo role="img" aria-labelledby="ICDS Logo" className="icds-logo" />
+      <ICDSLogo role="img" aria-labelledby="icds-link" className="icds-logo" />
     </a>
     {textLinks.map(({ key, ...rest }) => (
       <TopNavItem {...rest} key={key} />


### PR DESCRIPTION
## Summary of the changes

Fixed a few errors which I noticed were being picked up when running the Accessibility Insights FastPass tool and WAVE plug-in.

- Updated ICDS logo `aria-labelledby` usage.
- Added `aria-hidden` to footer logos. These can be hidden and don't need `aria-labelledby` because they are just used to visually represent the links, and the text in the spans (describing the links) were already being read out.
- Added full stops to "SIS" to make it clearer for screen reader users, being read out as separate letters rather than "sis".

WAVE also mentions another error about cards on the home page not having discernible text but I think this is a shadow DOM issue. I have checked with VoiceOver and they get read out fine.

## Related issue

(N/A)

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
