### PR TITLE
feat(root): add code examples for page header using slots

### DIFF
--- a/src/content/structured/components/page-header/code.mdx
+++ b/src/content/structured/components/page-header/code.mdx
@@ -31,6 +31,7 @@ import {
   IcBreadcrumbGroup,
   IcSectionContainer,
   IcChip,
+  IcTypography,
 } from "@ukic/react";
 
 import { NavLink, MemoryRouter } from "react-router-dom";
@@ -479,4 +480,71 @@ export const withReactRouter = [
     </IcPageHeader>
     <IcSectionContainer />
   </MemoryRouter>
+</ComponentPreview>
+
+### With Slots
+
+export const withSlots = [
+  {
+    language: "Web component",
+    snippet: `<ic-page-header>
+  <ic-typography variant="h1" slot="heading">Latte recipe</ic-typography>
+  <ic-typography slot="subheading">A Latte is a popular Italian coffee, made with espresso, steamed milk and a thin layer of foam.</ic-typography>
+  <ic-chip slot="heading-adornment" label="BETA" size="large"></ic-chip>
+  <ic-breadcrumb-group slot="breadcrumbs">
+    <ic-breadcrumb current="true" page-title="Drinks" href="#"></ic-breadcrumb>
+    <ic-breadcrumb page-title="Coffees" href="#"></ic-breadcrumb>
+    <ic-breadcrumb page-title="Latte" href="#"></ic-breadcrumb>
+  </ic-breadcrumb-group>
+  <ic-text-field slot="input" placeholder="Search for ingredients…" label="Input" hide-label="true" />
+</ic-page-header>`,
+  },
+  {
+    language: "React",
+    snippet: `<IcPageHeader>
+  <IcTypography variant="h1" slot="heading">
+    Latte recipe
+  </IcTypography>
+  <IcTypography slot="subheading">
+    A Latte is a popular Italian coffee, made with espresso, steamed milk and
+    a thin layer of foam.
+  </IcTypography>
+  <IcChip slot="heading-adornment" label="BETA" size="large" />
+  <IcBreadcrumbGroup slot="breadcrumbs">
+    <IcBreadcrumb pageTitle="Drinks" href="#" />
+    <IcBreadcrumb pageTitle="Coffees" href="#" />
+    <IcBreadcrumb current pageTitle="Latte" href="#" />
+  </IcBreadcrumbGroup>
+  <IcTextField
+    slot="input"
+    placeholder="Search for ingredients…"
+    label="Input"
+    hideLabel
+  />
+</IcPageHeader>`,
+  },
+];
+
+<ComponentPreview snippets={withSlots} style={{ flexDirection: "column" }}>
+  <IcPageHeader>
+    <IcTypography variant="h1" slot="heading">
+      Latte recipe
+    </IcTypography>
+    <IcTypography slot="subheading">
+      A Latte is a popular Italian coffee, made with espresso, steamed milk and
+      a thin layer of foam.
+    </IcTypography>
+    <IcChip slot="heading-adornment" label="BETA" size="large" />
+    <IcBreadcrumbGroup slot="breadcrumbs">
+      <IcBreadcrumb pageTitle="Drinks" href="#" />
+      <IcBreadcrumb pageTitle="Coffees" href="#" />
+      <IcBreadcrumb current pageTitle="Latte" href="#" />
+    </IcBreadcrumbGroup>
+    <IcTextField
+      slot="input"
+      placeholder="Search for ingredients…"
+      label="Input"
+      hideLabel
+    />
+  </IcPageHeader>
 </ComponentPreview>


### PR DESCRIPTION
## Summary of the changes

Code example added in for changing slots within the page header, changing the typography of a page header semantically.

## Related issue

#632 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
