### PR TITLE
fix(root): add gatsby plugin which improves flash of unstyled content issue

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -148,5 +148,6 @@ module.exports = {
         resolvePages: (data) => data.allSitePage.edges.map((edge) => edge.node),
       },
     },
+    `gatsby-plugin-fix-fouc`,
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "fs-extra": "^11.1.1",
         "gatsby": "^4.2.0",
         "gatsby-plugin-catch-links": "^4.2.0",
+        "gatsby-plugin-fix-fouc": "^1.0.5",
         "gatsby-plugin-local-search": "^2.0.1",
         "gatsby-plugin-manifest": "^4.2.0",
         "gatsby-plugin-mdx": "^3.20.0",
@@ -13982,6 +13983,17 @@
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/gatsby-plugin-fix-fouc": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-fix-fouc/-/gatsby-plugin-fix-fouc-1.0.5.tgz",
+      "integrity": "sha512-cs1JBMWZ5St3XimEHJMyeHd66lMHQDYTJzm/zn9omBI4tliBbNh3aF0bob/xVxykPLfWJZ5H6t38QidiKTb9Vw==",
+      "dependencies": {
+        "camel-case": "^4"
+      },
+      "peerDependencies": {
+        "gatsby": "^3 || ^4 || ^5"
       }
     },
     "node_modules/gatsby-plugin-local-search": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "fs-extra": "^11.1.1",
     "gatsby": "^4.2.0",
     "gatsby-plugin-catch-links": "^4.2.0",
+    "gatsby-plugin-fix-fouc": "^1.0.5",
     "gatsby-plugin-local-search": "^2.0.1",
     "gatsby-plugin-manifest": "^4.2.0",
     "gatsby-plugin-mdx": "^3.20.0",


### PR DESCRIPTION
## Summary of the changes

Add Gatsby plugin ([gatsby-plugin-fix-fouc](https://www.npmjs.com/package/gatsby-plugin-fix-fouc)) which helps with the FOUC issue (which happens when you first load the page or refresh).

As stated in the docs, the plugin adds styling to the <body> element that hides the page until the initial render of the app is done on the client.

-----

Despite having read a lot of documentation online, I was having difficulty working out what changes I could make to the badge component itself to improve the flashing, and I know that this is just hiding the issue (and other FOUC issues) rather than actually fixing it but it at least makes things a bit better!

## Related issue

mi6/ic-ui-kit#1216

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
