### PR TITLE
fix(root): add scroll margin to navigation headings

### DIFF
--- a/src/components/AnchorNav/index.tsx
+++ b/src/components/AnchorNav/index.tsx
@@ -29,7 +29,7 @@ const AnchorNav: React.FC<AnchorNavProps> = ({ allHeadings, currentPage }) => {
           }
         });
       },
-      { rootMargin: `10% 0% -80% 0%` }
+      { rootMargin: `20% 0% -70% 0%` }
     );
 
     headingIds.forEach((id) => {

--- a/src/components/WrappedH2/index.css
+++ b/src/components/WrappedH2/index.css
@@ -6,3 +6,9 @@ ic-typography[data-class="h2"] h4 {
   display: inline-flex;
   align-items: center;
 }
+
+@media screen and (min-width: 1201px) {
+  ic-typography[data-class="h2"] h3 {
+    scroll-margin-top: 12rem;
+  }
+}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add scroll margin to navigation headings to ensure heading doesn't hide behind the page header when anchor nav link is clicked

## Related issue

#728 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
