### PR TITLE
875 typo in toggle button component preview

### DIFF
--- a/src/content/structured/components/toggle-buttons/code.mdx
+++ b/src/content/structured/components/toggle-buttons/code.mdx
@@ -510,7 +510,7 @@ export const snippetsIconTopGroup = [
         >
             <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
       </svg>
-    </ic-toggle-button>s
+    </ic-toggle-button>
     </ic-toggle-button-group>
 `,
   },


### PR DESCRIPTION
Fixed typo 's' in toggle button component preview
- [X ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
