### PR TITLE
fix(root): remove negative margin around heading on component gallery cards

### DIFF
--- a/src/components/ComponentGallery/index.css
+++ b/src/components/ComponentGallery/index.css
@@ -27,14 +27,6 @@ ic-page-header[heading="Components"] + ic-section-container .content-container {
     margin-right: calc(var(--ic-space-xs) * -1);
     grid-gap: var(--ic-space-xs);
   }
-
-  ic-page-header[heading="Components"]
-    + ic-section-container
-    .content-container
-    ic-typography {
-    margin-left: calc(var(--ic-space-xs) * -1);
-    margin-right: calc(var(--ic-space-xs) * -1);
-  }
 }
 
 @media screen and (min-width: 577px) and (max-width: 993px) {
@@ -44,14 +36,6 @@ ic-page-header[heading="Components"] + ic-section-container .content-container {
 }
 
 @media screen and (min-width: 577px) and (max-width: 768px) {
-  ic-page-header[heading="Components"]
-    + ic-section-container
-    .content-container
-    ic-typography {
-    margin-left: calc(var(--ic-space-sm) * -1);
-    margin-right: calc(var(--ic-space-sm) * -1);
-  }
-
   .card-container {
     margin: var(--ic-space-xs) calc(var(--ic-space-sm) * -1) var(--ic-space-xl);
   }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Remove negative margin around heading on component gallery cards

## Related issue

#827

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
