### PR TITLE
docs(root): add alert to react and gatsby installation pages

### DIFF
--- a/src/components/ComponentGallery/index.tsx
+++ b/src/components/ComponentGallery/index.tsx
@@ -110,7 +110,11 @@ const ComponentGallery: React.FC = () => {
             <GatsbyLink to={`${item.path}`}>
               <ic-card message={item.subTitle} full-width clickable>
                 <img
-                  src={ComponentImages[item.title.replace(/ /g, "")] == null ? PlaceHolder : ComponentImages[item.title.replace(/ /g, "")]}
+                  src={
+                    ComponentImages[item.title.replace(/ /g, "")] == null
+                      ? PlaceHolder
+                      : ComponentImages[item.title.replace(/ /g, "")]
+                  }
                   slot="image-top"
                   alt={item.title}
                   width="100%"

--- a/src/content/structured/get-started/gatsby.mdx
+++ b/src/content/structured/get-started/gatsby.mdx
@@ -3,7 +3,7 @@ path: "/get-started/install-components/gatsby"
 
 navPriority: 7
 
-date: "2023-01-19"
+date: "2024-04-24"
 
 title: "Gatsby"
 
@@ -11,6 +11,15 @@ subTitle: "How to use the components in a Gatsby project."
 
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/gatsby.mdx"
 ---
+
+import { IcAlert } from "@ukic/react";
+
+<IcAlert
+  heading="Locking packages"
+  variant="info"
+  message="If you lock the React components to a particular version, you should also install and lock the corresponding web components package."
+  dismissible
+/>
 
 ## Step one
 

--- a/src/content/structured/get-started/react.mdx
+++ b/src/content/structured/get-started/react.mdx
@@ -3,7 +3,7 @@ path: "/get-started/install-components/react"
 
 navPriority: 2
 
-date: "2024-01-17"
+date: "2024-04-24"
 
 title: "React"
 
@@ -11,6 +11,15 @@ subTitle: "How to use the components in a React-based framework."
 
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/react.mdx"
 ---
+
+import { IcAlert } from "@ukic/react";
+
+<IcAlert
+  heading="Locking packages"
+  variant="info"
+  message="If you lock the React components to a particular version, you should also install and lock the corresponding web components package."
+  dismissible
+/>
 
 ## Step one
 


### PR DESCRIPTION


<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add alert to react and gatsby installation pages to advise locking web components package if they lock react package.
Also ran prettier:fix which has caused formatting changes to component gallery.

## Related issue

https://github.com/mi6/ic-ui-kit/issues/1089

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
