### PR TITLE
fix(root): implementation of gatsby-plugin-image and GatsbyImage

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -149,5 +149,24 @@ module.exports = {
       },
     },
     `gatsby-plugin-fix-fouc`,
+    `gatsby-plugin-image`,
+    `gatsby-plugin-sharp`,
+    `gatsby-transformer-sharp`,
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `src`,
+        path: `${__dirname}/src/`,
+        ignore: [`\.(tsx|ts|jsx|js|css|md|mdx)$`],
+      },
+    },
+    {
+      resolve: `gatsby-source-filesystem`,
+      options: {
+        name: `static`,
+        path: `${__dirname}/static/`,
+        ignore: [`\.(doc|doc|html)$`],
+      },
+    },
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "gatsby": "^4.2.0",
         "gatsby-plugin-catch-links": "^4.2.0",
         "gatsby-plugin-fix-fouc": "^1.0.5",
+        "gatsby-plugin-image": "^3.13.1",
         "gatsby-plugin-local-search": "^2.0.1",
         "gatsby-plugin-manifest": "^4.2.0",
         "gatsby-plugin-mdx": "^3.20.0",
@@ -43,7 +44,7 @@
         "gatsby-plugin-react-helmet": "^5.2.0",
         "gatsby-plugin-react-svg": "^3.1.0",
         "gatsby-plugin-robots-txt": "^1.8.0",
-        "gatsby-plugin-sharp": "^4.2.0",
+        "gatsby-plugin-sharp": "^4.25.1",
         "gatsby-plugin-sitemap": "^6.13.1",
         "gatsby-plugin-stencil": "^0.2.0",
         "gatsby-remark-copy-linked-files": "^5.2.0",
@@ -52,7 +53,7 @@
         "gatsby-remark-prismjs": "^6.2.0",
         "gatsby-source-filesystem": "^4.25.0",
         "gatsby-transformer-remark": "^6.12.0",
-        "gatsby-transformer-sharp": "^4.2.0",
+        "gatsby-transformer-sharp": "^4.25.0",
         "github-slugger": "^1.4.0",
         "lodash.kebabcase": "^4.1.1",
         "lodash.startcase": "^4.4.0",
@@ -7895,6 +7896,11 @@
         "dequal": "^2.0.3"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg=="
+    },
     "node_modules/babel-eslint": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
@@ -7957,6 +7963,11 @@
       "peerDependencies": {
         "@babel/core": "^7.8.0"
       }
+    },
+    "node_modules/babel-jsx-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-jsx-utils/-/babel-jsx-utils-1.1.0.tgz",
+      "integrity": "sha512-Mh1j/rw4xM9T3YICkw22aBQ78FhsHdsmlb9NEk4uVAFBOg+Ez9ZgXXHugoBPCZui3XLomk/7/JBBH4daJqTkQQ=="
     },
     "node_modules/babel-loader": {
       "version": "8.3.0",
@@ -8333,6 +8344,38 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/bare-events": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.2.2.tgz",
+      "integrity": "sha512-h7z00dWdG0PYOQEvChhOSWvOfkIKsdZGkWr083FgN/HyoQuebSew/cgirYqh9SCuy/hRvxc5Vy6Fw8xAmYHLkQ==",
+      "optional": true
+    },
+    "node_modules/bare-fs": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.2.3.tgz",
+      "integrity": "sha512-amG72llr9pstfXOBOHve1WjiuKKAMnebcmMbPWDZ7BCevAoJLpugjuAPRsDINEyjT0a6tbaVx3DctkXIRbLuJw==",
+      "optional": true,
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-path": "^2.0.0",
+        "streamx": "^2.13.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.2.1.tgz",
+      "integrity": "sha512-OwPyHgBBMkhC29Hl3O4/YfxW9n7mdTr2+SsO29XBWKKJsbgj3mnorDB80r5TiCQgQstgE5ga1qNYrpes6NvX2w==",
+      "optional": true
+    },
+    "node_modules/bare-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.1.tgz",
+      "integrity": "sha512-OHM+iwRDRMDBsSW7kl3dO62JyHdBKO3B25FB9vNQBPcGHMo4+eA8Yj41Lfbk3pS/seDY+siNge0LdRTulAau/A==",
+      "optional": true,
+      "dependencies": {
+        "bare-os": "^2.1.0"
+      }
     },
     "node_modules/base-x": {
       "version": "3.0.9",
@@ -12741,6 +12784,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ=="
+    },
     "node_modules/fast-glob": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
@@ -13909,6 +13957,239 @@
       "peerDependencies": {
         "gatsby": "^3 || ^4 || ^5"
       }
+    },
+    "node_modules/gatsby-plugin-image": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.13.1.tgz",
+      "integrity": "sha512-v5jGXxjr//iLk7LzpW6RW/9H4KNVezxee2Sgy9mxvdvekTuFQLYoQmtk2jOZINMZMP3Vm+Rl3MqWWVMfhHuWFw==",
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.13",
+        "@babel/runtime": "^7.20.13",
+        "@babel/traverse": "^7.20.13",
+        "babel-jsx-utils": "^1.1.0",
+        "babel-plugin-remove-graphql-queries": "^5.13.1",
+        "camelcase": "^6.3.0",
+        "chokidar": "^3.5.3",
+        "common-tags": "^1.8.2",
+        "fs-extra": "^11.1.1",
+        "gatsby-core-utils": "^4.13.1",
+        "gatsby-plugin-utils": "^4.13.1",
+        "objectFitPolyfill": "^2.3.5",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.3",
+        "gatsby": "^5.0.0-next",
+        "gatsby-plugin-sharp": "^5.0.0-next",
+        "gatsby-source-filesystem": "^5.0.0-next",
+        "react": "^18.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^0.0.0"
+      },
+      "peerDependenciesMeta": {
+        "gatsby-plugin-sharp": {
+          "optional": true
+        },
+        "gatsby-source-filesystem": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/babel-plugin-remove-graphql-queries": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.13.1.tgz",
+      "integrity": "sha512-yncJ/W6Un48aBRpK/rmdpQOMcr4+EmJ3oi2Wq1zXKu8WLlw+j93KTbejf7fg2msm8GUskb/+9Nnpz7oMCqO9aA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@babel/types": "^7.20.7",
+        "gatsby-core-utils": "^4.13.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0",
+        "gatsby": "^5.0.0-next"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/gatsby-core-utils": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-4.13.1.tgz",
+      "integrity": "sha512-w7G6SsQr8T2q+AJ1MxvRNGocCt+wjc22MiRLj2Zi3Ijpjszbr818JxwI4+aPt8WOSHlKT5SYCHICnEvcYPm9gg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "ci-info": "2.0.0",
+        "configstore": "^5.0.1",
+        "fastq": "^1.15.0",
+        "file-type": "^16.5.4",
+        "fs-extra": "^11.1.1",
+        "got": "^11.8.6",
+        "hash-wasm": "^4.9.0",
+        "import-from": "^4.0.0",
+        "lmdb": "2.5.3",
+        "lock": "^1.1.0",
+        "node-object-hash": "^2.3.10",
+        "proper-lockfile": "^4.1.2",
+        "resolve-from": "^5.0.0",
+        "tmp": "^0.2.1",
+        "xdg-basedir": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/gatsby-plugin-utils": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-4.13.1.tgz",
+      "integrity": "sha512-dQ8cZyUENWHqZOOSBBYWCJ8yG3zSYnHYk0mKQbgZblUS30Sp7ZFM4r0/+lsvUkEYaBOnzFBQjSSQtTa0xu9QWA==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "fastq": "^1.15.0",
+        "fs-extra": "^11.1.1",
+        "gatsby-core-utils": "^4.13.1",
+        "gatsby-sharp": "^1.13.0",
+        "graphql-compose": "^9.0.10",
+        "import-from": "^4.0.0",
+        "joi": "^17.9.2",
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^5.0.0-next",
+        "graphql": "^16.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/gatsby-sharp": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.13.0.tgz",
+      "integrity": "sha512-DviUtgm7tatSd1Hm54o/orHimOcyXBO9OJkSfzEchPFClvOza+2Qe/lqZShio0gFDxmG0Jgn0XCLzG7uH5VyJQ==",
+      "dependencies": {
+        "sharp": "^0.32.6"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/graphql": {
+      "version": "16.8.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
+      "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA=="
+    },
+    "node_modules/gatsby-plugin-image/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/tar-fs": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.5.tgz",
+      "integrity": "sha512-JOgGAmZyMgbqpLwct7ZV8VzkEB6pxXFBVErLtb+XCOqzc6w1xiWKI9GVd6bwk68EX7eJ4DWmfXVmq8K2ziZTGg==",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^2.1.1",
+        "bare-path": "^2.1.0"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/gatsby-plugin-image/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/gatsby-plugin-local-search": {
       "version": "2.0.1",
@@ -23239,6 +23520,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/objectFitPolyfill": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.5.tgz",
+      "integrity": "sha512-8Quz071ZmGi0QWEG4xB3Bv5Lpw6K0Uca87FLoLMKMWjB6qIq9IyBegP3b/VLNxv2WYvIMGoeUQ+c6ibUkNa8TA=="
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -25111,6 +25397,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -28759,6 +29050,18 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.16.1.tgz",
+      "integrity": "sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==",
+      "dependencies": {
+        "fast-fifo": "^1.1.0",
+        "queue-tick": "^1.0.1"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/strict-uri-encode": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gatsby": "^4.2.0",
     "gatsby-plugin-catch-links": "^4.2.0",
     "gatsby-plugin-fix-fouc": "^1.0.5",
+    "gatsby-plugin-image": "^3.13.1",
     "gatsby-plugin-local-search": "^2.0.1",
     "gatsby-plugin-manifest": "^4.2.0",
     "gatsby-plugin-mdx": "^3.20.0",
@@ -38,7 +39,7 @@
     "gatsby-plugin-react-helmet": "^5.2.0",
     "gatsby-plugin-react-svg": "^3.1.0",
     "gatsby-plugin-robots-txt": "^1.8.0",
-    "gatsby-plugin-sharp": "^4.2.0",
+    "gatsby-plugin-sharp": "^4.25.1",
     "gatsby-plugin-sitemap": "^6.13.1",
     "gatsby-plugin-stencil": "^0.2.0",
     "gatsby-remark-copy-linked-files": "^5.2.0",
@@ -47,7 +48,7 @@
     "gatsby-remark-prismjs": "^6.2.0",
     "gatsby-source-filesystem": "^4.25.0",
     "gatsby-transformer-remark": "^6.12.0",
-    "gatsby-transformer-sharp": "^4.2.0",
+    "gatsby-transformer-sharp": "^4.25.0",
     "github-slugger": "^1.4.0",
     "lodash.kebabcase": "^4.1.1",
     "lodash.startcase": "^4.4.0",
@@ -157,6 +158,13 @@
     },
     "gatsby-transformer-remark": {
       "gatsby": "$gatsby"
+    },
+    "gatsby-plugin-image": {
+      "gatsby": "$gatsby",
+      "gatsby-plugin-sharp": "$gatsby-plugin-sharp",
+      "gatsby-source-filesystem": "$gatsby-source-filesystem",
+      "react": "$react",
+      "react-dom": "$react-dom"
     }
   }
 }

--- a/src/components/DoDontCaution/index.tsx
+++ b/src/components/DoDontCaution/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import clsx from "clsx";
+import { graphql, useStaticQuery } from "gatsby";
+import { GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image";
 
 import "./index.css";
 
@@ -13,6 +15,15 @@ interface DoDontCautionProps {
   caption?: string;
   videoSrc?: string;
 }
+interface ImageFile {
+  node: {
+    relativePath: string;
+    ext: string;
+    childImageSharp: {
+      gatsbyImageData: IGatsbyImageData;
+    };
+  };
+}
 const STATE_VALUES = {
   good: { icon: mdiCheck, classPrefix: "do" },
   bad: { icon: mdiClose, classPrefix: "dont" },
@@ -25,37 +36,99 @@ const DoDontCaution: React.FC<DoDontCautionProps> = ({
   imageAlt,
   state = "none",
   caption = "",
-}) => (
-  <div
-    className={clsx(state === "none" ? state : STATE_VALUES[state].classPrefix)}
-  >
-    {state !== "none" && (
-      <div
-        slot="icon"
-        className={clsx(
-          "do-dont-caution-containers",
-          `${STATE_VALUES[state].classPrefix}-icon`
-        )}
-      >
-        <Icon path={STATE_VALUES[state].icon} aria-hidden="true" />
-      </div>
-    )}
-    {imageSrc && (
-      <img
-        src={imageSrc}
-        alt={imageAlt}
-        className="image-wide"
-        loading="lazy"
-      />
-    )}
-    {videoSrc && (
-      // eslint-disable-next-line jsx-a11y/media-has-caption
-      <video controls loop className="image-wide">
-        <source src={videoSrc} type="video/mp4" />
-      </video>
-    )}
-    {caption && <ic-typography variant="label">{caption}</ic-typography>}
-  </div>
-);
+}) => {
+  const imageData = useStaticQuery(graphql`
+    query {
+      allFile(filter: { ext: { in: [".jpg", ".png"] } }) {
+        edges {
+          node {
+            relativePath
+            ext
+            childImageSharp {
+              gatsbyImageData
+            }
+          }
+        }
+      }
+    }
+  `);
+  const isBase64: boolean = imageSrc.includes("data:image/png;base64");
+  const imageObject: ImageFile[] = imageData.allFile.edges;
+
+  const filterImageData: any = (imagePath: string) => {
+    if (imagePath !== "" && imageObject !== undefined) {
+      const croppedImagePath = imagePath.substring(
+        imagePath.lastIndexOf("/"),
+        imagePath.lastIndexOf("-")
+      );
+
+      const gatsbyFileObj: ImageFile | undefined = imageObject.find(
+        (image: ImageFile) => image.node.relativePath.includes(croppedImagePath)
+      );
+
+      if (gatsbyFileObj !== undefined) {
+        return gatsbyFileObj.node.childImageSharp.gatsbyImageData;
+      }
+
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Image file could not be found by gatsby-source-filesystem."
+      );
+      return undefined;
+    }
+
+    if (imageObject === undefined) {
+      // eslint-disable-next-line no-console
+      console.warn("No images found by gatsby-source-filesystem.");
+    }
+    if (imagePath === "") {
+      // eslint-disable-next-line no-console
+      console.warn("No image path given to DoDontCaution");
+    }
+    return undefined;
+  };
+
+  return (
+    <div
+      className={clsx(
+        state === "none" ? state : STATE_VALUES[state].classPrefix
+      )}
+    >
+      {state !== "none" && (
+        <div
+          slot="icon"
+          className={clsx(
+            "do-dont-caution-containers",
+            `${STATE_VALUES[state].classPrefix}-icon`
+          )}
+        >
+          <Icon path={STATE_VALUES[state].icon} aria-hidden="true" />
+        </div>
+      )}
+      {imageSrc &&
+        (isBase64 ? (
+          <img
+            src={imageSrc}
+            alt={imageAlt}
+            className="image-wide"
+            loading="lazy"
+          />
+        ) : (
+          <GatsbyImage
+            image={filterImageData(imageSrc)}
+            alt={imageAlt}
+            className="image-wide"
+          />
+        ))}
+      {videoSrc && (
+        // eslint-disable-next-line jsx-a11y/media-has-caption
+        <video controls loop className="image-wide">
+          <source src={videoSrc} type="video/mp4" />
+        </video>
+      )}
+      {caption && <ic-typography variant="label">{caption}</ic-typography>}
+    </div>
+  );
+};
 
 export default DoDontCaution;


### PR DESCRIPTION
## Summary of the changes

Imports and uses `gatsby-plugin-image` lib and the `GatsbyImage` (dynamic image) component within the `DoDontCaution` class to replace (suitable) `<img>` with `<GatsbyImage>`. Uses the `gatsby-source-filesystem` to source all the jpgs/pngs within `src` and `static`, which are then queried into `gatsbyImageData` object format with GraphQL and used within `<GatsbyImage>`. Around 10% of the images on the site aren't compatible with this due to this [Gatsby Optimisation](https://www.gatsbyjs.com/docs/how-to/images-and-media/importing-assets-into-files/#importing-assets-with-webpack), which converts the file path into a data URI, so will revert back to use of `<img>` in this case.

## Related issue

#726 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
