### PR TITLE
fix(root): added missing slash to cookie banner link

### DIFF
--- a/src/components/CookieBanner/cookies.helper.ts
+++ b/src/components/CookieBanner/cookies.helper.ts
@@ -10,20 +10,17 @@ export const setCookie = (value: string) => {
   }
 };
 
-export const consentCookieActioned = () => {
-  if (typeof document !== "undefined") {
-    return document.cookie.indexOf("ICDSPREF") !== -1;
-  }
-  return false;
-};
+export const consentCookieActioned = () =>
+  typeof document !== "undefined"
+    ? document.cookie.indexOf("ICDSPREF") !== -1
+    : false;
 
 export const consentCookieApproved = () =>
   consentCookieActioned() && document.cookie.indexOf("ICDSPREF=true") !== -1;
 
 const deleteDomainCookies = () => {
   if (typeof window !== "undefined") {
-    const cookies = document.cookie.split("; ");
-    cookies.forEach((cookie) => {
+    document.cookie.split("; ").forEach((cookie) => {
       const d = window.location.hostname.split(".");
       while (d.length > 0) {
         const cookieBase = `${encodeURIComponent(
@@ -56,10 +53,7 @@ export const isBotOrDoNotTrack = () => {
 
   // Check if DoNotTrack is activated
   const dnt = navigator.doNotTrack; // || window.doNotTrack;
-  const isToTrack =
-    dnt !== null && dnt !== undefined
-      ? dnt && dnt !== "yes" && dnt !== "1"
-      : true;
+  const isToTrack = dnt ? dnt !== "yes" && dnt !== "1" : true;
 
   return isBot || !isToTrack;
 };

--- a/src/components/CookieBanner/index.tsx
+++ b/src/components/CookieBanner/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { createRef, useState, useEffect, useContext } from "react";
 
 import "./cookies.css";
 import {
@@ -12,8 +12,8 @@ import CookieConsentContext from "../../context/CookieConsentContext";
 const CookieBanner: React.FC = () => {
   const [visible, setVisible] = useState(!consentCookieActioned());
   const [submitted, setSubmitted] = useState(false);
-  const banner: React.RefObject<HTMLDivElement> = React.createRef();
-  const { handleCookieConsent } = React.useContext(CookieConsentContext);
+  const banner: React.RefObject<HTMLDivElement> = createRef();
+  const { handleCookieConsent } = useContext(CookieConsentContext);
 
   const handleConsent = (consent: boolean) => {
     setConsent(consent);
@@ -22,10 +22,7 @@ const CookieBanner: React.FC = () => {
   };
 
   useEffect(() => {
-    // set focus to cookies banner when submitted, to focus on message
-    if (banner.current) {
-      banner.current.focus();
-    }
+    banner.current?.focus(); // set focus to cookies banner when submitted, to focus on message
   }, [submitted]);
 
   if (!visible || isBotOrDoNotTrack()) {
@@ -39,12 +36,12 @@ const CookieBanner: React.FC = () => {
       role="region"
       ref={banner}
     >
-      {(submitted && (
+      {submitted ? (
         <ic-section-container full-height aligned="full-width" tab-index="-1">
           <ic-typography role="alert" variant="body">
             You’ve {consentCookieApproved() ? "accepted" : "rejected"} analytics
             cookies. You can{" "}
-            <ic-link href="icds/cookies-policy">
+            <ic-link href="/icds/cookies-policy">
               change your cookie settings
             </ic-link>{" "}
             at any time.
@@ -55,7 +52,7 @@ const CookieBanner: React.FC = () => {
             </ic-button>
           </div>
         </ic-section-container>
-      )) || (
+      ) : (
         <ic-section-container full-height aligned="full-width">
           <ic-typography variant="h2">Cookies on this site</ic-typography>
           <ic-typography variant="body">
@@ -69,7 +66,7 @@ const CookieBanner: React.FC = () => {
             <ic-button variant="secondary" onClick={() => handleConsent(false)}>
               Decline
             </ic-button>
-            <ic-link href="icds/cookies-policy">Manage cookies</ic-link>
+            <ic-link href="/icds/cookies-policy">Manage cookies</ic-link>
           </div>
         </ic-section-container>
       )}


### PR DESCRIPTION
## Summary of the changes
Added slash at beginning of manage cookies link to ensure it directs based of the root url rather than the current url

## Related issue
#789 

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
