### PR TITLE
Place status icons in front of GatsbyImage

### DIFF
--- a/src/components/DoDontCaution/index.css
+++ b/src/components/DoDontCaution/index.css
@@ -36,6 +36,7 @@
   border-radius: 50%;
   box-shadow: var(--ic-elevation-overlay);
   text-align: center;
+  z-index: 1;
 }
 
 .do-dont-caution-containers > svg {


### PR DESCRIPTION
## Summary of the changes

The `GatsbyImage` components were forcing the status icons behind the component example image, like below:
<img width="828" alt="Screenshot 2024-05-03 at 17 16 36" src="https://github.com/mi6/ic-design-system/assets/157390789/3bc56be4-717d-495c-a22e-7265ce3c891e">

This fix just sets `z-index: 1` on the `.do-dont-caution-containers` css class to make the icon visible again, like below:
<img width="825" alt="Screenshot 2024-05-03 at 17 33 15" src="https://github.com/mi6/ic-design-system/assets/157390789/7c049162-be5b-46ce-a15a-e2887183b499">

## Related issue

No ticket just a fix

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
