### PR TITLE
feat(root): added new code examples to top nav code page

### DIFF
--- a/src/content/structured/components/top-nav/code.mdx
+++ b/src/content/structured/components/top-nav/code.mdx
@@ -30,9 +30,12 @@ import {
   IcNavigationGroup,
   SlottedSVG,
   IcBadge,
+  IcButton,
 } from "@ukic/react";
 
 import { MemoryRouter, NavLink } from "react-router-dom";
+import { Link as GatsbyLink } from "gatsby";
+import { useState } from "react";
 
 ## Component demo
 
@@ -804,9 +807,97 @@ export const snippetsShortTitle = [
   </IcTopNavigation>
 </ComponentPreview>
 
+### Conditional tabs
+
+export const ConditionalTabsExample = () => {
+  const [showTabs, setShowTabs] = useState(false);
+  return (
+    <>
+      <IcTopNavigation
+        appTitle="ApplicationName"
+        status="alpha"
+        version="v0.0.7"
+      >
+        <SlottedSVG
+          slot="app-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 0 24 24"
+          width="24px"
+          fill="#000000"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+        </SlottedSVG>
+        <IcNavigationItem
+          label="One"
+          href="/"
+          selected="true"
+          slot="navigation"
+        />
+        <IcNavigationItem label="Two" href="/" slot="navigation" />
+        <IcNavigationItem label="Three" href="/" slot="navigation" />
+        {showTabs && (
+          <>
+            <IcNavigationItem label="Four" href="/" slot="navigation" />
+            <IcNavigationItem label="Five" href="/" slot="navigation" />
+          </>
+        )}
+      </IcTopNavigation>
+      <IcButton onClick={() => setShowTabs(!showTabs)}>Show/Hide tabs</IcButton>
+    </>
+  );
+};
+
+export const conditionalTabs = [
+  {
+    language: "React",
+    snippet: `const [showTabs, setShowTabs] = useState(false);
+return (
+  <>
+    <IcTopNavigation appTitle="ApplicationName" status="alpha" version="v0.0.7">
+      <SlottedSVG
+        slot="app-icon"
+        xmlns="http://www.w3.org/2000/svg"
+        height="24px"
+        viewBox="0 0 24 24"
+        width="24px"
+        fill="#000000"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+      </SlottedSVG>
+      <IcNavigationItem 
+        label="One"
+        href="/"
+        selected="true"
+        slot="navigation"
+      />
+      <IcNavigationItem label="Two" href="/" slot="navigation" />
+      <IcNavigationItem label="Three" href="/" slot="navigation" />
+      {showTabs && (
+        <>
+          <IcNavigationItem label="Four" href="/" slot="navigation" />
+          <IcNavigationItem label="Five" href="/" slot="navigation" />
+        </>
+      )}
+    </IcTopNavigation>
+    <IcButton onClick={() => setShowTabs(!showTabs)}>Show/Hide tabs</IcButton>
+  </>
+);`,
+  },
+];
+
+<ComponentPreview
+  snippets={conditionalTabs}
+  style={{ display: "flex", flexDirection: "column" }}
+>
+  <ConditionalTabsExample />
+</ComponentPreview>
+
 ### With React Router (using slots)
 
-The following example also demonstrates using a slotted link for app title, short app title, and app icon.
+The following examples also demonstrate using a slotted link for app title, short app title, and app icon.
 
 To guarantee the correct styling for non-svg content slotted into app-icon, set `width`, `height` and `fill` to `inherit`.
 
@@ -917,4 +1008,70 @@ export const withReactRouter = [
       </IcNavigationItem>
     </IcTopNavigation>
   </MemoryRouter>
+</ComponentPreview>
+
+### With Gatsby Links (using slots)
+
+export const withGatsbyLinks = [
+  {
+    language: "React",
+    snippet: `<IcTopNavigation version="v0.0.7">
+  <Link to="/" slot="app-title">ICDS Title</Link>
+  <Link to="/" slot="short-app-title">ICDS</Link>
+  <Link to="/" slot="app-icon">
+    <SlottedSVG
+      xmlns="http://www.w3.org/2000/svg"
+      height="inherit"
+      viewBox="0 0 24 24"
+      width="inherit"
+      fill="inherit"
+    >
+      <path d="M0 0h24v24H0V0z" fill="none" />
+      <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+    </SlottedSVG>
+  </Link>
+  <IcNavigationItem slot="navigation">
+    <Link to="/" slot="navigation-item">Get started</Link>
+  </IcNavigationItem>
+  <IcNavigationItem slot="navigation">
+    <Link to="/accessibility" slot="navigation-item">Accessibility</Link>
+  </IcNavigationItem>
+</IcTopNavigation>`,
+  },
+];
+
+<ComponentPreview
+  snippets={withGatsbyLinks}
+  style={{ display: "flex", flexDirection: "column" }}
+>
+  <IcTopNavigation version="v0.0.7">
+    <GatsbyLink to="/" slot="app-title">
+      ICDS Title
+    </GatsbyLink>
+    <GatsbyLink to="/" slot="short-app-title">
+      ICDS
+    </GatsbyLink>
+    <GatsbyLink to="/" slot="app-icon">
+      <SlottedSVG
+        xmlns="http://www.w3.org/2000/svg"
+        height="inherit"
+        viewBox="0 0 24 24"
+        width="inherit"
+        fill="inherit"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+      </SlottedSVG>
+    </GatsbyLink>
+    <IcNavigationItem slot="navigation">
+      <GatsbyLink to="/" slot="navigation-item">
+        Get started
+      </GatsbyLink>
+    </IcNavigationItem>
+    <IcNavigationItem slot="navigation">
+      <GatsbyLink to="/accessibility" slot="navigation-item">
+        Accessibility
+      </GatsbyLink>
+    </IcNavigationItem>
+  </IcTopNavigation>
 </ComponentPreview>


### PR DESCRIPTION
## Summary of the changes
Added new code examples to top nav to show off:
- Conditionally rendering tabs #910 
- Using GatsbyLinks https://github.com/mi6/ic-ui-kit/issues/1244

Accompanies an ic-ui-kit PR aiming to bring ic-top-navigation in line with the PR checklist (https://github.com/mi6/ic-ui-kit/pull/1872)

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
