### PR TITLE
add hyphen for Multi-select on site 

### DIFF
--- a/src/content/structured/components/multi-select/code.mdx
+++ b/src/content/structured/components/multi-select/code.mdx
@@ -1,9 +1,9 @@
 ---
 path: "/components/multi-select/code"
 
-date: "2024-05-02"
+date: "2024-06-05"
 
-title: "Multi select"
+title: "Multi-select"
 
 status: "CANARY"
 

--- a/src/content/structured/components/multi-select/guidance.mdx
+++ b/src/content/structured/components/multi-select/guidance.mdx
@@ -3,9 +3,9 @@ path: "/components/multi-select"
 
 navPriority: 21
 
-date: "2024-05-02"
+date: "2024-06-05"
 
-title: "Multi select"
+title: "Multi-select"
 
 status: "CANARY"
 

--- a/src/icds-pages-data.json
+++ b/src/icds-pages-data.json
@@ -26,8 +26,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/alt-text.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\alt-text.mdx",
-        "createdAt": "2024-06-04T07:48:34.937Z",
-        "lastModified": "2024-06-04T07:48:34.937Z",
+        "createdAt": "2024-06-05T09:22:54.271Z",
+        "lastModified": "2024-06-05T09:22:54.271Z",
         "size": 1791,
         "formattedSize": "1.7 KB"
       }
@@ -43,8 +43,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/aria.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\aria.mdx",
-        "createdAt": "2024-06-04T07:48:34.939Z",
-        "lastModified": "2024-06-04T07:48:34.939Z",
+        "createdAt": "2024-06-05T09:22:54.274Z",
+        "lastModified": "2024-06-05T09:22:54.274Z",
         "size": 3758,
         "formattedSize": "3.7 KB"
       }
@@ -60,8 +60,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/css.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\css.mdx",
-        "createdAt": "2024-06-04T07:48:34.940Z",
-        "lastModified": "2024-06-04T07:48:34.940Z",
+        "createdAt": "2024-06-05T09:22:54.275Z",
+        "lastModified": "2024-06-05T09:22:54.275Z",
         "size": 1430,
         "formattedSize": "1.4 KB"
       }
@@ -77,8 +77,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/documenting/index.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\doctype.mdx",
-        "createdAt": "2024-05-20T13:20:43.254Z",
-        "lastModified": "2024-05-20T13:20:43.254Z",
+        "createdAt": "2024-05-30T15:54:25.479Z",
+        "lastModified": "2024-05-30T15:54:25.479Z",
         "size": 1396,
         "formattedSize": "1.4 KB"
       }
@@ -94,8 +94,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/document-structure.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\document-structure.mdx",
-        "createdAt": "2024-06-04T07:48:34.941Z",
-        "lastModified": "2024-06-04T07:48:34.941Z",
+        "createdAt": "2024-06-05T09:22:54.276Z",
+        "lastModified": "2024-06-05T09:22:54.276Z",
         "size": 1890,
         "formattedSize": "1.8 KB"
       }
@@ -111,8 +111,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/headings.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\headings.mdx",
-        "createdAt": "2024-06-04T07:48:34.942Z",
-        "lastModified": "2024-06-04T07:48:34.942Z",
+        "createdAt": "2024-06-05T09:22:54.277Z",
+        "lastModified": "2024-06-05T09:22:54.277Z",
         "size": 1328,
         "formattedSize": "1.3 KB"
       }
@@ -128,8 +128,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/index.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\index.mdx",
-        "createdAt": "2024-04-04T12:41:43.701Z",
-        "lastModified": "2024-04-04T12:41:43.701Z",
+        "createdAt": "2024-05-30T15:54:25.482Z",
+        "lastModified": "2024-05-30T15:54:25.482Z",
         "size": 5398,
         "formattedSize": "5.3 KB"
       }
@@ -145,8 +145,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/semantic-html.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\semantic-html.mdx",
-        "createdAt": "2024-06-04T07:48:34.943Z",
-        "lastModified": "2024-06-04T07:48:34.943Z",
+        "createdAt": "2024-06-05T09:22:54.278Z",
+        "lastModified": "2024-06-05T09:22:54.278Z",
         "size": 1976,
         "formattedSize": "1.9 KB"
       }
@@ -162,8 +162,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/semantic-layout.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\semantic-layout.mdx",
-        "createdAt": "2024-06-04T07:48:34.944Z",
-        "lastModified": "2024-06-04T07:48:34.944Z",
+        "createdAt": "2024-06-05T09:22:54.279Z",
+        "lastModified": "2024-06-05T09:22:54.279Z",
         "size": 1406,
         "formattedSize": "1.4 KB"
       }
@@ -179,8 +179,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/tables.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\tables.mdx",
-        "createdAt": "2024-06-04T07:48:34.945Z",
-        "lastModified": "2024-06-04T07:48:34.945Z",
+        "createdAt": "2024-06-05T09:22:54.280Z",
+        "lastModified": "2024-06-05T09:22:54.280Z",
         "size": 2616,
         "formattedSize": "2.6 KB"
       }
@@ -196,8 +196,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/coding/title.mdx",
       "meta": {
         "relativePath": "accessibility\\coding\\title.mdx",
-        "createdAt": "2024-06-04T07:48:34.946Z",
-        "lastModified": "2024-06-04T07:48:34.946Z",
+        "createdAt": "2024-06-05T09:22:54.281Z",
+        "lastModified": "2024-06-05T09:22:54.281Z",
         "size": 1306,
         "formattedSize": "1.3 KB"
       }
@@ -213,8 +213,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/definition.mdx",
       "meta": {
         "relativePath": "accessibility\\definition.mdx",
-        "createdAt": "2024-06-04T07:48:34.947Z",
-        "lastModified": "2024-06-04T07:48:34.947Z",
+        "createdAt": "2024-06-05T09:22:54.282Z",
+        "lastModified": "2024-06-05T09:22:54.282Z",
         "size": 3280,
         "formattedSize": "3.2 KB"
       }
@@ -230,8 +230,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/discussing.mdx",
       "meta": {
         "relativePath": "accessibility\\discussing.mdx",
-        "createdAt": "2024-04-04T12:41:43.717Z",
-        "lastModified": "2024-04-04T12:41:43.717Z",
+        "createdAt": "2024-05-30T15:54:25.488Z",
+        "lastModified": "2024-05-30T15:54:25.488Z",
         "size": 2040,
         "formattedSize": "2.0 KB"
       }
@@ -247,8 +247,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/documenting/accessibility-statements-guidance.mdx",
       "meta": {
         "relativePath": "accessibility\\documenting\\accessibility-statements-guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.948Z",
-        "lastModified": "2024-06-04T07:48:34.948Z",
+        "createdAt": "2024-06-05T09:22:54.289Z",
+        "lastModified": "2024-06-05T09:22:54.289Z",
         "size": 10892,
         "formattedSize": "10.6 KB"
       }
@@ -264,8 +264,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/documenting/accessibility-statements.mdx",
       "meta": {
         "relativePath": "accessibility\\documenting\\accessibility-statements.mdx",
-        "createdAt": "2024-06-04T07:48:34.949Z",
-        "lastModified": "2024-06-04T07:48:34.949Z",
+        "createdAt": "2024-06-05T09:22:54.289Z",
+        "lastModified": "2024-06-05T09:22:54.289Z",
         "size": 2253,
         "formattedSize": "2.2 KB"
       }
@@ -281,8 +281,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/documenting/conformance-reports.mdx",
       "meta": {
         "relativePath": "accessibility\\documenting\\conformance-report.mdx",
-        "createdAt": "2024-06-04T07:48:34.950Z",
-        "lastModified": "2024-06-04T07:48:34.950Z",
+        "createdAt": "2024-06-05T09:22:54.290Z",
+        "lastModified": "2024-06-05T09:22:54.290Z",
         "size": 4126,
         "formattedSize": "4.0 KB"
       }
@@ -298,8 +298,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/documenting/index.mdx",
       "meta": {
         "relativePath": "accessibility\\documenting\\index.mdx",
-        "createdAt": "2024-06-04T07:48:34.951Z",
-        "lastModified": "2024-06-04T07:48:34.951Z",
+        "createdAt": "2024-06-05T09:22:54.292Z",
+        "lastModified": "2024-06-05T09:22:54.292Z",
         "size": 1947,
         "formattedSize": "1.9 KB"
       }
@@ -315,8 +315,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/documenting/when-to-create-and-update.mdx",
       "meta": {
         "relativePath": "accessibility\\documenting\\when-to-create-and-update.mdx",
-        "createdAt": "2024-04-04T12:41:43.717Z",
-        "lastModified": "2024-04-04T12:41:43.717Z",
+        "createdAt": "2024-05-30T15:54:25.493Z",
+        "lastModified": "2024-05-30T15:54:25.493Z",
         "size": 1731,
         "formattedSize": "1.7 KB"
       }
@@ -332,8 +332,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/index.mdx",
       "meta": {
         "relativePath": "accessibility\\index.mdx",
-        "createdAt": "2024-06-04T07:48:34.952Z",
-        "lastModified": "2024-06-04T07:48:34.952Z",
+        "createdAt": "2024-06-05T09:22:54.294Z",
+        "lastModified": "2024-06-05T09:22:54.294Z",
         "size": 2268,
         "formattedSize": "2.2 KB"
       }
@@ -349,8 +349,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/introduction.mdx",
       "meta": {
         "relativePath": "accessibility\\introduction.mdx",
-        "createdAt": "2024-06-04T07:48:34.953Z",
-        "lastModified": "2024-06-04T07:48:34.953Z",
+        "createdAt": "2024-06-05T09:22:54.295Z",
+        "lastModified": "2024-06-05T09:22:54.295Z",
         "size": 2341,
         "formattedSize": "2.3 KB"
       }
@@ -366,8 +366,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/needs/auditory.mdx",
       "meta": {
         "relativePath": "accessibility\\needs\\auditory.mdx",
-        "createdAt": "2024-04-04T12:41:43.717Z",
-        "lastModified": "2024-04-04T12:41:43.717Z",
+        "createdAt": "2024-05-30T15:54:25.496Z",
+        "lastModified": "2024-05-30T15:54:25.496Z",
         "size": 3785,
         "formattedSize": "3.7 KB"
       }
@@ -383,8 +383,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/needs/index.mdx",
       "meta": {
         "relativePath": "accessibility\\needs\\index.mdx",
-        "createdAt": "2024-06-04T07:48:34.954Z",
-        "lastModified": "2024-06-04T07:48:34.954Z",
+        "createdAt": "2024-06-05T09:22:54.306Z",
+        "lastModified": "2024-06-05T09:22:54.306Z",
         "size": 3561,
         "formattedSize": "3.5 KB"
       }
@@ -400,8 +400,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/needs/invisible.mdx",
       "meta": {
         "relativePath": "accessibility\\needs\\invisible.mdx",
-        "createdAt": "2024-06-04T07:48:34.955Z",
-        "lastModified": "2024-06-04T07:48:34.955Z",
+        "createdAt": "2024-06-05T09:22:54.309Z",
+        "lastModified": "2024-06-05T09:22:54.309Z",
         "size": 5381,
         "formattedSize": "5.3 KB"
       }
@@ -417,8 +417,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/needs/motor.mdx",
       "meta": {
         "relativePath": "accessibility\\needs\\motor.mdx",
-        "createdAt": "2024-06-04T07:48:34.957Z",
-        "lastModified": "2024-06-04T07:48:34.957Z",
+        "createdAt": "2024-06-05T09:22:54.310Z",
+        "lastModified": "2024-06-05T09:22:54.310Z",
         "size": 4268,
         "formattedSize": "4.2 KB"
       }
@@ -434,8 +434,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/needs/neurodiversity.mdx",
       "meta": {
         "relativePath": "accessibility\\needs\\neurodiversity.mdx",
-        "createdAt": "2024-06-04T07:48:34.958Z",
-        "lastModified": "2024-06-04T07:48:34.958Z",
+        "createdAt": "2024-06-05T09:22:54.311Z",
+        "lastModified": "2024-06-05T09:22:54.311Z",
         "size": 10113,
         "formattedSize": "9.9 KB"
       }
@@ -451,8 +451,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/needs/visual.mdx",
       "meta": {
         "relativePath": "accessibility\\needs\\visual.mdx",
-        "createdAt": "2024-04-04T12:41:43.717Z",
-        "lastModified": "2024-04-04T12:41:43.717Z",
+        "createdAt": "2024-05-30T15:54:25.501Z",
+        "lastModified": "2024-05-30T15:54:25.501Z",
         "size": 4573,
         "formattedSize": "4.5 KB"
       }
@@ -469,8 +469,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/requirement/index.mdx",
       "meta": {
         "relativePath": "accessibility\\requirement\\index.mdx",
-        "createdAt": "2024-06-04T07:48:34.959Z",
-        "lastModified": "2024-06-04T07:48:34.959Z",
+        "createdAt": "2024-06-05T09:22:54.313Z",
+        "lastModified": "2024-06-05T09:22:54.313Z",
         "size": 3739,
         "formattedSize": "3.7 KB"
       }
@@ -487,8 +487,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/requirement/meeting-the-policy.mdx",
       "meta": {
         "relativePath": "accessibility\\requirement\\meeting-the-policy.mdx",
-        "createdAt": "2024-06-04T07:48:34.960Z",
-        "lastModified": "2024-06-04T07:48:34.960Z",
+        "createdAt": "2024-06-05T09:22:54.313Z",
+        "lastModified": "2024-06-05T09:22:54.313Z",
         "size": 4212,
         "formattedSize": "4.1 KB"
       }
@@ -504,8 +504,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/requirement/subtitles-transcripts-captions.mdx",
       "meta": {
         "relativePath": "accessibility\\requirement\\subtitles-transcripts-captions.mdx",
-        "createdAt": "2024-06-04T07:48:34.961Z",
-        "lastModified": "2024-06-04T07:48:34.961Z",
+        "createdAt": "2024-06-05T09:22:54.314Z",
+        "lastModified": "2024-06-05T09:22:54.314Z",
         "size": 4722,
         "formattedSize": "4.6 KB"
       }
@@ -521,8 +521,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/requirement/wcag.mdx",
       "meta": {
         "relativePath": "accessibility\\requirement\\wcag.mdx",
-        "createdAt": "2024-06-04T07:48:34.962Z",
-        "lastModified": "2024-06-04T07:48:34.962Z",
+        "createdAt": "2024-06-05T09:22:54.315Z",
+        "lastModified": "2024-06-05T09:22:54.315Z",
         "size": 3945,
         "formattedSize": "3.9 KB"
       }
@@ -538,8 +538,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/testing/assistive-tech-testing.mdx",
       "meta": {
         "relativePath": "accessibility\\testing\\assistive-tech-testing.mdx",
-        "createdAt": "2024-06-04T07:48:34.963Z",
-        "lastModified": "2024-06-04T07:48:34.963Z",
+        "createdAt": "2024-06-05T09:22:54.316Z",
+        "lastModified": "2024-06-05T09:22:54.316Z",
         "size": 8835,
         "formattedSize": "8.6 KB"
       }
@@ -555,8 +555,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/testing/automated-testing-limitation.mdx",
       "meta": {
         "relativePath": "accessibility\\testing\\automated-testing-limitation.mdx",
-        "createdAt": "2024-06-04T07:48:34.964Z",
-        "lastModified": "2024-06-04T07:48:34.964Z",
+        "createdAt": "2024-06-05T09:22:54.317Z",
+        "lastModified": "2024-06-05T09:22:54.317Z",
         "size": 3812,
         "formattedSize": "3.7 KB"
       }
@@ -572,8 +572,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/testing/automated-testing.mdx",
       "meta": {
         "relativePath": "accessibility\\testing\\automated-testing.mdx",
-        "createdAt": "2024-06-04T07:48:34.965Z",
-        "lastModified": "2024-06-04T07:48:34.965Z",
+        "createdAt": "2024-06-05T09:22:54.318Z",
+        "lastModified": "2024-06-05T09:22:54.318Z",
         "size": 7356,
         "formattedSize": "7.2 KB"
       }
@@ -589,8 +589,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/testing/index.mdx",
       "meta": {
         "relativePath": "accessibility\\testing\\index.mdx",
-        "createdAt": "2024-06-04T07:48:34.966Z",
-        "lastModified": "2024-06-04T07:48:34.966Z",
+        "createdAt": "2024-06-05T09:22:54.319Z",
+        "lastModified": "2024-06-05T09:22:54.319Z",
         "size": 3159,
         "formattedSize": "3.1 KB"
       }
@@ -606,8 +606,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/accessibility/testing/manual-testing.mdx",
       "meta": {
         "relativePath": "accessibility\\testing\\manual-testing.mdx",
-        "createdAt": "2024-06-04T07:48:34.967Z",
-        "lastModified": "2024-06-04T07:48:34.967Z",
+        "createdAt": "2024-06-05T09:22:54.320Z",
+        "lastModified": "2024-06-05T09:22:54.320Z",
         "size": 4637,
         "formattedSize": "4.5 KB"
       }
@@ -623,8 +623,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/community/contribute-criteria.mdx?at=develop",
       "meta": {
         "relativePath": "community\\contribute-criteria.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-05-30T15:54:25.512Z",
+        "lastModified": "2024-05-30T15:54:25.512Z",
         "size": 2875,
         "formattedSize": "2.8 KB"
       }
@@ -640,8 +640,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/community/contribute.mdx?at=develop",
       "meta": {
         "relativePath": "community\\contribute.mdx",
-        "createdAt": "2024-05-20T13:19:26.916Z",
-        "lastModified": "2024-05-20T13:19:26.916Z",
+        "createdAt": "2024-05-30T15:54:25.513Z",
+        "lastModified": "2024-05-30T15:54:25.513Z",
         "size": 3920,
         "formattedSize": "3.8 KB"
       }
@@ -657,8 +657,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/community/glossary-of-terms.mdx?at=develop",
       "meta": {
         "relativePath": "community\\glossary-of-terms.mdx",
-        "createdAt": "2024-05-20T13:19:26.916Z",
-        "lastModified": "2024-05-20T13:19:26.916Z",
+        "createdAt": "2024-05-30T15:54:25.514Z",
+        "lastModified": "2024-05-30T15:54:25.514Z",
         "size": 11707,
         "formattedSize": "11.4 KB"
       }
@@ -673,8 +673,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/community/index.mdx",
       "meta": {
         "relativePath": "community\\index.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-05-30T15:54:25.515Z",
+        "lastModified": "2024-05-30T15:54:25.515Z",
         "size": 925,
         "formattedSize": "925 Bytes"
       }
@@ -690,8 +690,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/community/roadmap.mdx",
       "meta": {
         "relativePath": "community\\roadmap.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-05-30T15:54:25.516Z",
+        "lastModified": "2024-05-30T15:54:25.516Z",
         "size": 2000,
         "formattedSize": "2.0 KB"
       }
@@ -721,8 +721,8 @@
       ],
       "meta": {
         "relativePath": "components\\accordion\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:34.969Z",
-        "lastModified": "2024-06-04T07:48:34.969Z",
+        "createdAt": "2024-06-05T09:22:54.321Z",
+        "lastModified": "2024-06-05T09:22:54.321Z",
         "size": 3357,
         "formattedSize": "3.3 KB"
       }
@@ -752,8 +752,8 @@
       ],
       "meta": {
         "relativePath": "components\\accordion\\code.mdx",
-        "createdAt": "2024-06-04T07:48:34.970Z",
-        "lastModified": "2024-06-04T07:48:34.970Z",
+        "createdAt": "2024-06-05T09:22:54.323Z",
+        "lastModified": "2024-06-05T09:22:54.323Z",
         "size": 9578,
         "formattedSize": "9.4 KB"
       }
@@ -784,8 +784,8 @@
       ],
       "meta": {
         "relativePath": "components\\accordion\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.971Z",
-        "lastModified": "2024-06-04T07:48:34.971Z",
+        "createdAt": "2024-06-05T09:22:54.324Z",
+        "lastModified": "2024-06-05T09:22:54.324Z",
         "size": 10088,
         "formattedSize": "9.9 KB"
       }
@@ -815,8 +815,8 @@
       ],
       "meta": {
         "relativePath": "components\\alerts\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:34.972Z",
-        "lastModified": "2024-06-04T07:48:34.972Z",
+        "createdAt": "2024-06-05T09:22:54.325Z",
+        "lastModified": "2024-06-05T09:22:54.325Z",
         "size": 2295,
         "formattedSize": "2.2 KB"
       }
@@ -846,8 +846,8 @@
       ],
       "meta": {
         "relativePath": "components\\alerts\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.748Z",
-        "lastModified": "2024-04-04T12:41:43.748Z",
+        "createdAt": "2024-06-04T10:55:49.216Z",
+        "lastModified": "2024-06-04T10:55:49.216Z",
         "size": 8205,
         "formattedSize": "8.0 KB"
       }
@@ -878,8 +878,8 @@
       ],
       "meta": {
         "relativePath": "components\\alerts\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.973Z",
-        "lastModified": "2024-06-04T07:48:34.973Z",
+        "createdAt": "2024-06-05T09:22:54.326Z",
+        "lastModified": "2024-06-05T09:22:54.326Z",
         "size": 4749,
         "formattedSize": "4.6 KB"
       }
@@ -909,8 +909,8 @@
       ],
       "meta": {
         "relativePath": "components\\back-to-top\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-05-30T15:54:25.524Z",
+        "lastModified": "2024-05-30T15:54:25.524Z",
         "size": 2941,
         "formattedSize": "2.9 KB"
       }
@@ -940,8 +940,8 @@
       ],
       "meta": {
         "relativePath": "components\\back-to-top\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.748Z",
-        "lastModified": "2024-04-04T12:41:43.748Z",
+        "createdAt": "2024-06-04T10:55:49.218Z",
+        "lastModified": "2024-06-04T10:55:49.218Z",
         "size": 1120,
         "formattedSize": "1.1 KB"
       }
@@ -972,8 +972,8 @@
       ],
       "meta": {
         "relativePath": "components\\back-to-top\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.974Z",
-        "lastModified": "2024-06-04T07:48:34.974Z",
+        "createdAt": "2024-06-05T09:22:54.327Z",
+        "lastModified": "2024-06-05T09:22:54.327Z",
         "size": 4352,
         "formattedSize": "4.3 KB"
       }
@@ -1003,8 +1003,8 @@
       ],
       "meta": {
         "relativePath": "components\\badge\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-05-30T15:54:25.527Z",
+        "lastModified": "2024-05-30T15:54:25.527Z",
         "size": 2498,
         "formattedSize": "2.4 KB"
       }
@@ -1034,8 +1034,8 @@
       ],
       "meta": {
         "relativePath": "components\\badge\\code.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-06-04T10:55:49.218Z",
+        "lastModified": "2024-06-04T10:55:49.218Z",
         "size": 17718,
         "formattedSize": "17.3 KB"
       }
@@ -1066,8 +1066,8 @@
       ],
       "meta": {
         "relativePath": "components\\badge\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.975Z",
-        "lastModified": "2024-06-04T07:48:34.975Z",
+        "createdAt": "2024-06-05T09:22:54.329Z",
+        "lastModified": "2024-06-05T09:22:54.329Z",
         "size": 12912,
         "formattedSize": "12.6 KB"
       }
@@ -1097,8 +1097,8 @@
       ],
       "meta": {
         "relativePath": "components\\breadcrumbs\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-05-30T15:54:25.530Z",
+        "lastModified": "2024-05-30T15:54:25.530Z",
         "size": 2468,
         "formattedSize": "2.4 KB"
       }
@@ -1128,8 +1128,8 @@
       ],
       "meta": {
         "relativePath": "components\\breadcrumbs\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.795Z",
-        "lastModified": "2024-04-04T12:41:43.795Z",
+        "createdAt": "2024-06-04T10:55:49.218Z",
+        "lastModified": "2024-06-04T10:55:49.218Z",
         "size": 10625,
         "formattedSize": "10.4 KB"
       }
@@ -1160,8 +1160,8 @@
       ],
       "meta": {
         "relativePath": "components\\breadcrumbs\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.977Z",
-        "lastModified": "2024-06-04T07:48:34.977Z",
+        "createdAt": "2024-06-05T09:22:54.330Z",
+        "lastModified": "2024-06-05T09:22:54.330Z",
         "size": 5653,
         "formattedSize": "5.5 KB"
       }
@@ -1191,8 +1191,8 @@
       ],
       "meta": {
         "relativePath": "components\\buttons\\accessibility.mdx",
-        "createdAt": "2024-05-21T11:54:23.352Z",
-        "lastModified": "2024-05-21T11:54:23.352Z",
+        "createdAt": "2024-05-30T15:54:25.534Z",
+        "lastModified": "2024-05-30T15:54:25.534Z",
         "size": 1747,
         "formattedSize": "1.7 KB"
       }
@@ -1222,8 +1222,8 @@
       ],
       "meta": {
         "relativePath": "components\\buttons\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.826Z",
-        "lastModified": "2024-04-04T12:41:43.826Z",
+        "createdAt": "2024-06-04T10:55:49.218Z",
+        "lastModified": "2024-06-04T10:55:49.218Z",
         "size": 9898,
         "formattedSize": "9.7 KB"
       }
@@ -1254,8 +1254,8 @@
       ],
       "meta": {
         "relativePath": "components\\buttons\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.978Z",
-        "lastModified": "2024-06-04T07:48:34.978Z",
+        "createdAt": "2024-06-05T09:22:54.331Z",
+        "lastModified": "2024-06-05T09:22:54.331Z",
         "size": 15592,
         "formattedSize": "15.2 KB"
       }
@@ -1285,8 +1285,8 @@
       ],
       "meta": {
         "relativePath": "components\\cards\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-05-30T15:54:25.538Z",
+        "lastModified": "2024-05-30T15:54:25.538Z",
         "size": 3538,
         "formattedSize": "3.5 KB"
       }
@@ -1316,8 +1316,8 @@
       ],
       "meta": {
         "relativePath": "components\\cards\\code.mdx",
-        "createdAt": "2024-05-20T13:20:43.271Z",
-        "lastModified": "2024-05-20T13:20:43.271Z",
+        "createdAt": "2024-06-04T10:55:49.218Z",
+        "lastModified": "2024-06-04T10:55:49.218Z",
         "size": 49654,
         "formattedSize": "48.5 KB"
       }
@@ -1348,8 +1348,8 @@
       ],
       "meta": {
         "relativePath": "components\\cards\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.979Z",
-        "lastModified": "2024-06-04T07:48:34.979Z",
+        "createdAt": "2024-06-05T09:22:54.332Z",
+        "lastModified": "2024-06-05T09:22:54.332Z",
         "size": 10871,
         "formattedSize": "10.6 KB"
       }
@@ -1379,8 +1379,8 @@
       ],
       "meta": {
         "relativePath": "components\\checkboxes\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.286Z",
-        "lastModified": "2024-05-20T13:20:43.286Z",
+        "createdAt": "2024-05-30T15:54:25.542Z",
+        "lastModified": "2024-05-30T15:54:25.542Z",
         "size": 2830,
         "formattedSize": "2.8 KB"
       }
@@ -1410,8 +1410,8 @@
       ],
       "meta": {
         "relativePath": "components\\checkboxes\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.858Z",
-        "lastModified": "2024-04-04T12:41:43.858Z",
+        "createdAt": "2024-06-04T10:55:49.226Z",
+        "lastModified": "2024-06-04T10:55:49.226Z",
         "size": 15949,
         "formattedSize": "15.6 KB"
       }
@@ -1442,8 +1442,8 @@
       ],
       "meta": {
         "relativePath": "components\\checkboxes\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.980Z",
-        "lastModified": "2024-06-04T07:48:34.980Z",
+        "createdAt": "2024-06-05T09:22:54.333Z",
+        "lastModified": "2024-06-05T09:22:54.333Z",
         "size": 8822,
         "formattedSize": "8.6 KB"
       }
@@ -1473,8 +1473,8 @@
       ],
       "meta": {
         "relativePath": "components\\chips\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.286Z",
-        "lastModified": "2024-05-20T13:20:43.286Z",
+        "createdAt": "2024-05-30T15:54:25.546Z",
+        "lastModified": "2024-05-30T15:54:25.546Z",
         "size": 2862,
         "formattedSize": "2.8 KB"
       }
@@ -1504,8 +1504,8 @@
       ],
       "meta": {
         "relativePath": "components\\chips\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.873Z",
-        "lastModified": "2024-04-04T12:41:43.873Z",
+        "createdAt": "2024-06-04T10:55:49.227Z",
+        "lastModified": "2024-06-04T10:55:49.227Z",
         "size": 9311,
         "formattedSize": "9.1 KB"
       }
@@ -1536,8 +1536,8 @@
       ],
       "meta": {
         "relativePath": "components\\chips\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.981Z",
-        "lastModified": "2024-06-04T07:48:34.981Z",
+        "createdAt": "2024-06-05T09:22:54.334Z",
+        "lastModified": "2024-06-05T09:22:54.334Z",
         "size": 6824,
         "formattedSize": "6.7 KB"
       }
@@ -1567,8 +1567,8 @@
       ],
       "meta": {
         "relativePath": "components\\classification-banner\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.286Z",
-        "lastModified": "2024-05-20T13:20:43.286Z",
+        "createdAt": "2024-05-30T15:54:25.549Z",
+        "lastModified": "2024-05-30T15:54:25.549Z",
         "size": 1223,
         "formattedSize": "1.2 KB"
       }
@@ -1598,8 +1598,8 @@
       ],
       "meta": {
         "relativePath": "components\\classification-banner\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.889Z",
-        "lastModified": "2024-04-04T12:41:43.889Z",
+        "createdAt": "2024-06-04T10:55:49.228Z",
+        "lastModified": "2024-06-04T10:55:49.228Z",
         "size": 2691,
         "formattedSize": "2.6 KB"
       }
@@ -1630,8 +1630,8 @@
       ],
       "meta": {
         "relativePath": "components\\classification-banner\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.982Z",
-        "lastModified": "2024-06-04T07:48:34.982Z",
+        "createdAt": "2024-06-05T09:22:54.336Z",
+        "lastModified": "2024-06-05T09:22:54.336Z",
         "size": 2076,
         "formattedSize": "2.0 KB"
       }
@@ -1661,8 +1661,8 @@
       ],
       "meta": {
         "relativePath": "components\\data-entity\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.286Z",
-        "lastModified": "2024-05-20T13:20:43.286Z",
+        "createdAt": "2024-05-30T15:54:25.553Z",
+        "lastModified": "2024-05-30T15:54:25.553Z",
         "size": 2271,
         "formattedSize": "2.2 KB"
       }
@@ -1692,8 +1692,8 @@
       ],
       "meta": {
         "relativePath": "components\\data-entity\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.889Z",
-        "lastModified": "2024-04-04T12:41:43.889Z",
+        "createdAt": "2024-06-04T10:55:49.229Z",
+        "lastModified": "2024-06-04T10:55:49.229Z",
         "size": 16963,
         "formattedSize": "16.6 KB"
       }
@@ -1724,8 +1724,8 @@
       ],
       "meta": {
         "relativePath": "components\\data-entity\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.983Z",
-        "lastModified": "2024-06-04T07:48:34.983Z",
+        "createdAt": "2024-06-05T09:22:54.337Z",
+        "lastModified": "2024-06-05T09:22:54.337Z",
         "size": 4880,
         "formattedSize": "4.8 KB"
       }
@@ -1750,8 +1750,8 @@
       ],
       "meta": {
         "relativePath": "components\\data-table\\code.mdx",
-        "createdAt": "2024-05-20T13:20:43.286Z",
-        "lastModified": "2024-05-20T13:20:43.286Z",
+        "createdAt": "2024-06-04T10:55:49.231Z",
+        "lastModified": "2024-06-04T10:55:49.231Z",
         "size": 16240,
         "formattedSize": "15.9 KB"
       }
@@ -1777,8 +1777,8 @@
       ],
       "meta": {
         "relativePath": "components\\data-table\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.984Z",
-        "lastModified": "2024-06-04T07:48:34.984Z",
+        "createdAt": "2024-06-05T09:22:54.338Z",
+        "lastModified": "2024-06-05T09:22:54.338Z",
         "size": 1787,
         "formattedSize": "1.7 KB"
       }
@@ -1807,8 +1807,8 @@
       ],
       "meta": {
         "relativePath": "components\\date-input\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:34.985Z",
-        "lastModified": "2024-06-04T07:48:34.985Z",
+        "createdAt": "2024-06-05T09:22:54.339Z",
+        "lastModified": "2024-06-05T09:22:54.339Z",
         "size": 3703,
         "formattedSize": "3.6 KB"
       }
@@ -1837,8 +1837,8 @@
       ],
       "meta": {
         "relativePath": "components\\date-input\\code.mdx",
-        "createdAt": "2024-05-20T13:20:43.296Z",
-        "lastModified": "2024-05-20T13:20:43.296Z",
+        "createdAt": "2024-06-04T10:55:49.233Z",
+        "lastModified": "2024-06-04T10:55:49.233Z",
         "size": 12903,
         "formattedSize": "12.6 KB"
       }
@@ -1868,8 +1868,8 @@
       ],
       "meta": {
         "relativePath": "components\\date-input\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.987Z",
-        "lastModified": "2024-06-04T07:48:34.987Z",
+        "createdAt": "2024-06-05T09:22:54.340Z",
+        "lastModified": "2024-06-05T09:22:54.340Z",
         "size": 8492,
         "formattedSize": "8.3 KB"
       }
@@ -1898,8 +1898,8 @@
       ],
       "meta": {
         "relativePath": "components\\date-picker\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:34.988Z",
-        "lastModified": "2024-06-04T07:48:34.988Z",
+        "createdAt": "2024-06-05T09:22:54.341Z",
+        "lastModified": "2024-06-05T09:22:54.341Z",
         "size": 3332,
         "formattedSize": "3.3 KB"
       }
@@ -1928,8 +1928,8 @@
       ],
       "meta": {
         "relativePath": "components\\date-picker\\code.mdx",
-        "createdAt": "2024-06-04T07:48:34.989Z",
-        "lastModified": "2024-06-04T07:48:34.989Z",
+        "createdAt": "2024-06-05T09:22:54.342Z",
+        "lastModified": "2024-06-05T09:22:54.342Z",
         "size": 17040,
         "formattedSize": "16.6 KB"
       }
@@ -1959,8 +1959,8 @@
       ],
       "meta": {
         "relativePath": "components\\date-picker\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.990Z",
-        "lastModified": "2024-06-04T07:48:34.990Z",
+        "createdAt": "2024-06-05T09:22:54.342Z",
+        "lastModified": "2024-06-05T09:22:54.342Z",
         "size": 5395,
         "formattedSize": "5.3 KB"
       }
@@ -1990,8 +1990,8 @@
       ],
       "meta": {
         "relativePath": "components\\dialog\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.302Z",
-        "lastModified": "2024-05-20T13:20:43.302Z",
+        "createdAt": "2024-05-30T15:54:25.567Z",
+        "lastModified": "2024-05-30T15:54:25.567Z",
         "size": 4203,
         "formattedSize": "4.1 KB"
       }
@@ -2021,8 +2021,8 @@
       ],
       "meta": {
         "relativePath": "components\\dialog\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.904Z",
-        "lastModified": "2024-04-04T12:41:43.904Z",
+        "createdAt": "2024-06-04T10:55:49.236Z",
+        "lastModified": "2024-06-04T10:55:49.236Z",
         "size": 42296,
         "formattedSize": "41.3 KB"
       }
@@ -2053,8 +2053,8 @@
       ],
       "meta": {
         "relativePath": "components\\dialog\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.991Z",
-        "lastModified": "2024-06-04T07:48:34.991Z",
+        "createdAt": "2024-06-05T09:22:54.343Z",
+        "lastModified": "2024-06-05T09:22:54.343Z",
         "size": 8791,
         "formattedSize": "8.6 KB"
       }
@@ -2084,8 +2084,8 @@
       ],
       "meta": {
         "relativePath": "components\\empty-state\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:34.992Z",
-        "lastModified": "2024-06-04T07:48:34.992Z",
+        "createdAt": "2024-06-05T09:22:54.344Z",
+        "lastModified": "2024-06-05T09:22:54.344Z",
         "size": 1572,
         "formattedSize": "1.5 KB"
       }
@@ -2115,8 +2115,8 @@
       ],
       "meta": {
         "relativePath": "components\\empty-state\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.920Z",
-        "lastModified": "2024-04-04T12:41:43.920Z",
+        "createdAt": "2024-06-04T10:55:49.238Z",
+        "lastModified": "2024-06-04T10:55:49.238Z",
         "size": 20242,
         "formattedSize": "19.8 KB"
       }
@@ -2147,8 +2147,8 @@
       ],
       "meta": {
         "relativePath": "components\\empty-state\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.993Z",
-        "lastModified": "2024-06-04T07:48:34.993Z",
+        "createdAt": "2024-06-05T09:22:54.346Z",
+        "lastModified": "2024-06-05T09:22:54.346Z",
         "size": 11152,
         "formattedSize": "10.9 KB"
       }
@@ -2178,8 +2178,8 @@
       ],
       "meta": {
         "relativePath": "components\\footer\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.318Z",
-        "lastModified": "2024-05-20T13:20:43.318Z",
+        "createdAt": "2024-05-30T15:54:25.576Z",
+        "lastModified": "2024-05-30T15:54:25.576Z",
         "size": 2074,
         "formattedSize": "2.0 KB"
       }
@@ -2209,8 +2209,8 @@
       ],
       "meta": {
         "relativePath": "components\\footer\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.937Z",
-        "lastModified": "2024-04-04T12:41:43.937Z",
+        "createdAt": "2024-06-04T10:55:49.240Z",
+        "lastModified": "2024-06-04T10:55:49.240Z",
         "size": 17838,
         "formattedSize": "17.4 KB"
       }
@@ -2241,8 +2241,8 @@
       ],
       "meta": {
         "relativePath": "components\\footer\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.994Z",
-        "lastModified": "2024-06-04T07:48:34.994Z",
+        "createdAt": "2024-06-05T09:22:54.347Z",
+        "lastModified": "2024-06-05T09:22:54.347Z",
         "size": 8000,
         "formattedSize": "7.8 KB"
       }
@@ -2272,8 +2272,8 @@
       ],
       "meta": {
         "relativePath": "components\\hero\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:34.995Z",
-        "lastModified": "2024-06-04T07:48:34.995Z",
+        "createdAt": "2024-06-05T09:22:54.348Z",
+        "lastModified": "2024-06-05T09:22:54.348Z",
         "size": 2067,
         "formattedSize": "2.0 KB"
       }
@@ -2303,8 +2303,8 @@
       ],
       "meta": {
         "relativePath": "components\\hero\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.967Z",
-        "lastModified": "2024-04-04T12:41:43.967Z",
+        "createdAt": "2024-06-04T10:55:49.241Z",
+        "lastModified": "2024-06-04T10:55:49.241Z",
         "size": 13409,
         "formattedSize": "13.1 KB"
       }
@@ -2335,8 +2335,8 @@
       ],
       "meta": {
         "relativePath": "components\\hero\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.996Z",
-        "lastModified": "2024-06-04T07:48:34.996Z",
+        "createdAt": "2024-06-05T09:22:54.349Z",
+        "lastModified": "2024-06-05T09:22:54.349Z",
         "size": 8587,
         "formattedSize": "8.4 KB"
       }
@@ -2351,8 +2351,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/components/index.mdx",
       "meta": {
         "relativePath": "components\\index.mdx",
-        "createdAt": "2024-06-04T07:48:34.997Z",
-        "lastModified": "2024-06-04T07:48:34.997Z",
+        "createdAt": "2024-06-05T09:22:54.350Z",
+        "lastModified": "2024-06-05T09:22:54.350Z",
         "size": 614,
         "formattedSize": "614 Bytes"
       }
@@ -2382,8 +2382,8 @@
       ],
       "meta": {
         "relativePath": "components\\links\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:34.998Z",
-        "lastModified": "2024-06-04T07:48:34.998Z",
+        "createdAt": "2024-06-05T09:22:54.351Z",
+        "lastModified": "2024-06-05T09:22:54.351Z",
         "size": 1920,
         "formattedSize": "1.9 KB"
       }
@@ -2413,8 +2413,8 @@
       ],
       "meta": {
         "relativePath": "components\\links\\code.mdx",
-        "createdAt": "2024-04-04T12:41:43.998Z",
-        "lastModified": "2024-04-04T12:41:43.998Z",
+        "createdAt": "2024-06-04T10:55:49.243Z",
+        "lastModified": "2024-06-04T10:55:49.243Z",
         "size": 3764,
         "formattedSize": "3.7 KB"
       }
@@ -2445,8 +2445,8 @@
       ],
       "meta": {
         "relativePath": "components\\links\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:34.999Z",
-        "lastModified": "2024-06-04T07:48:34.999Z",
+        "createdAt": "2024-06-05T09:22:54.352Z",
+        "lastModified": "2024-06-05T09:22:54.352Z",
         "size": 7389,
         "formattedSize": "7.2 KB"
       }
@@ -2476,8 +2476,8 @@
       ],
       "meta": {
         "relativePath": "components\\loading-indicators\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.000Z",
-        "lastModified": "2024-06-04T07:48:35.000Z",
+        "createdAt": "2024-06-05T09:22:54.353Z",
+        "lastModified": "2024-06-05T09:22:54.353Z",
         "size": 2535,
         "formattedSize": "2.5 KB"
       }
@@ -2507,8 +2507,8 @@
       ],
       "meta": {
         "relativePath": "components\\loading-indicators\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.014Z",
-        "lastModified": "2024-04-04T12:41:44.014Z",
+        "createdAt": "2024-06-04T10:55:49.244Z",
+        "lastModified": "2024-06-04T10:55:49.244Z",
         "size": 5235,
         "formattedSize": "5.1 KB"
       }
@@ -2539,8 +2539,8 @@
       ],
       "meta": {
         "relativePath": "components\\loading-indicators\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.002Z",
-        "lastModified": "2024-06-04T07:48:35.002Z",
+        "createdAt": "2024-06-05T09:22:54.354Z",
+        "lastModified": "2024-06-05T09:22:54.354Z",
         "size": 7146,
         "formattedSize": "7.0 KB"
       }
@@ -2549,8 +2549,8 @@
       "id": "components\\multi-select\\codex",
       "contents": "\r\nimport { IcSelectWithMulti } from \"@ukic/canary-react\";\r\n\r\nimport {\r\n  OPTIONS,\r\n  OPTIONS_WITH_DESCRIPTIONS,\r\n  OPTIONS_WITH_DISABLED,\r\n  GROUPED_OPTIONS,\r\n  OPTIONS_WITH_RECOMMENDED,\r\n} from \"./story-data\";\r\n\r\n## Component demo\r\n\r\nexport const snippets = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi >\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\", disabled: true },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil\", disabled: true },\r\n    { label: \"Flat white\", value: \"Fla\", disabled: true },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple\r\noptions={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\nonIcChange={(event) => console.log(event.detail.value)}\r\nonIcOptionSelect={(event) => console.log(event.detail.value)}\r\nonIcOptionDeselect={(event) => console.log(event.detail.value)}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={snippets}>\r\n  <IcSelectWithMulti\r\n    label=\"What are your favourite types of coffee?\"\r\n    options={OPTIONS}\r\n    multiple\r\n  />\r\n</ComponentPreview>\r\n\r\n## Select with multi details\r\n\r\n<ComponentDetails component=\"ic-select-with-multi\" canary />\r\n\r\n## Variants\r\n\r\n### Default value\r\n\r\nShow options as pre-selected by setting the `value` prop to an array containing the values of these options.\r\n\r\nexport const defaultValue = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi >\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.value = [\"Ame\", \"Fil\", \"Moc\"];\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.value = [\"Cap\", \"Fla\", \"Moc\"];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple\r\nvalue={[\"Ame\", \"Fil\", \"Moc\"]}\r\noptions={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\nonIcChange={(event) => console.log(event.detail.value)}\r\nonIcOptionSelect={(event) => console.log(event.detail.value)}\r\nonIcOptionDeselect={(event) => console.log(event.detail.value)}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={defaultValue}>\r\n  <IcSelectWithMulti\r\n    label=\"What are your favourite types of coffee?\"\r\n    value={[\"Ame\", \"Fil\", \"Moc\"]}\r\n    options={OPTIONS}\r\n    multiple\r\n  />\r\n</ComponentPreview>\r\n\r\n### With clear button\r\n\r\nDisplay a clear button by using the `showClearButton` prop.\r\n\r\nThis will appear when the user has selected some options and allow them to easily clear their selection.\r\n\r\nexport const clear = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi label=\"What are your favourite types of coffee?\" multiple show-clear-button id=\"select-default\" ></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple\r\nshowClearButton\r\noptions={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\nonIcChange={(event) => console.log(event.detail.value)}\r\nonIcOptionSelect={(event) => console.log(event.detail.value)}\r\nonIcOptionDeselect={(event) => console.log(event.detail.value)}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={clear}>\r\n  <IcSelectWithMulti\r\n    label=\"What are your favourite types of coffee?\"\r\n    showClearButton\r\n    options={OPTIONS}\r\n    multiple\r\n  />\r\n</ComponentPreview>\r\n\r\n### With descriptions\r\n\r\nDisplay extra information about the options by providing a description using the `description` property for each option.\r\n\r\nexport const desc = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi label=\"What are your favourite types of coffee?\" multiple  id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n  {\r\n    label: \"Cappuccino\",\r\n    value: \"Cap\",\r\n    description: \"Coffee frothed up with pressurised steam\",\r\n  },\r\n  {\r\n    label: \"Latte\",\r\n    value: \"Lat\",\r\n    description: \"A milkier coffee than a cappuccino\",\r\n  },\r\n  {\r\n    label: \"Americano\",\r\n    value: \"Ame\",\r\n    description: \"Espresso coffee diluted with hot water\",\r\n  },\r\n  {\r\n      label: \"Filter\",\r\n    value: \"Fil\",\r\n    description: \"Coffee filtered using paper or a mesh\",\r\n  },\r\n  {\r\n    label: \"Flat white\",\r\n    value: \"Fla\",\r\n    description: \"Coffee without froth made with espresso and hot steamed milk\",\r\n  },\r\n  {\r\n    label: \"Mocha\",\r\n    value: \"Moc\",\r\n    description: \"A mixture of coffee and chocolate\",\r\n  },\r\n  {\r\n    label: \"Macchiato\",\r\n    value: \"Mac\",\r\n    description: \"Espresso coffee with a dash of frothy steamed milk\",\r\n  },\r\n  ];\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple\r\noptions={[\r\n   {\r\n    label: \"Cappuccino\",\r\n    value: \"Cap\",\r\n    description: \"Coffee frothed up with pressurised steam\",\r\n  },\r\n  {\r\n    label: \"Latte\",\r\n    value: \"Lat\",\r\n    description: \"A milkier coffee than a cappuccino\",\r\n  },\r\n  {\r\n      label: \"Americano\",\r\n    value: \"Ame\",\r\n    description: \"Espresso coffee diluted with hot water\",\r\n  },\r\n  {\r\n    label: \"Filter\",\r\n    value: \"Fil\",\r\n    description: \"Coffee filtered using paper or a mesh\",\r\n  },\r\n  {\r\n      label: \"Flat white\",\r\n    value: \"Fla\",\r\n    description: \"Coffee without froth made with espresso and hot steamed milk\",\r\n  },\r\n  {\r\n    label: \"Mocha\",\r\n    value: \"Moc\",\r\n    description: \"A mixture of coffee and chocolate\",\r\n  },\r\n  {\r\n      label: \"Macchiato\",\r\n    value: \"Mac\",\r\n    description: \"Espresso coffee with a dash of frothy steamed milk\",\r\n  },\r\n]}\r\nonIcChange={(event) => console.log(event.detail.value)}\r\nonIcOptionSelect={(event) => console.log(event.detail.value)}\r\nonIcOptionDeselect={(event) => console.log(event.detail.value)}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={desc}>\r\n  <IcSelectWithMulti\r\n    label=\"What are your favourite types of coffee?\"\r\n    options={OPTIONS_WITH_DESCRIPTIONS}\r\n    multiple\r\n  />\r\n</ComponentPreview>\r\n\r\n### Helper text\r\n\r\nDisplay helper text to provide additional information by using the `helperText` prop.\r\n\r\nexport const helper = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi helper-text=\"Select some options from the list\" label=\"What are your favourite types of coffee?\" multiple id=\"select-default\" ></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple\r\nhelperText=\"Select some options from the list\"\r\noptions={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\nonIcChange={(event) => console.log(event.detail.value)}\r\nonIcOptionSelect={(event) => console.log(event.detail.value)}\r\nonIcOptionDeselect={(event) => console.log(event.detail.value)}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={helper}>\r\n  <IcSelectWithMulti\r\n    label=\"What are your favourite types of coffee?\"\r\n    options={OPTIONS}\r\n    multiple\r\n    helperText=\"Select some options from the list\"\r\n  />\r\n</ComponentPreview>\r\n\r\n### Sizes\r\n\r\nSet the size of the multi-select by using the `size` prop. This prop takes the values `small`, `default` or `large`.\r\nDepending on the chosen size, the prop will apply styling to increase or decrease the amount of spacing within the component.\r\nThe `default` variant is seen in the first [default](#default) example.\r\n\r\nexport const sizes = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi size=\"small\" label=\"What are your favourite types of coffee?\" multiple id=\"select-default-small\"></ic-select-with-multi>\r\n<ic-select-with-multi label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<ic-select-with-multi size=\"large\" label=\"What are your favourite types of coffee?\" multiple id=\"select-default-large\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `const OPTIONS = [\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]\r\n<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple options={OPTIONS} size=\"small\" />\r\n<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple options={OPTIONS} />\r\n<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple options={OPTIONS} size=\"large\" />`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={sizes}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      options={OPTIONS}\r\n      multiple\r\n      size=\"small\"\r\n    />\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      options={OPTIONS}\r\n      multiple\r\n    />\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      options={OPTIONS}\r\n      multiple\r\n      size=\"large\"\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Disabled\r\n\r\nDisable the multi-select and prevent user interaction by using the `disabled` prop.\r\n\r\nexport const disabled = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi disabled label=\"What are your favourite types of coffee?\" multiple ></ic-select-with-multi>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" disabled multiple />`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={disabled}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      multiple\r\n      disabled\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Disabled options\r\n\r\nDisable certain options by setting the `disabled` property to `true` for each option.\r\n\r\nexport const disabledOptions = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\", disabled: true },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil\", disabled: true },\r\n    { label: \"Flat white\", value: \"Fla\", disabled: true },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple options={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\", disabled: true },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\", disabled: true },\r\n  { label: \"Flat white\", value: \"Fla\", disabled: true },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\nonIcChange={(event) => console.log(event.detail.value)}\r\nonIcOptionSelect={(event) => console.log(event.detail.value)}\r\nonIcOptionDeselect={(event) => console.log(event.detail.value)}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={disabledOptions}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      options={OPTIONS_WITH_DISABLED}\r\n      multiple\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Hide label\r\n\r\nHide the visible label for the multi-select by using the `hideLabel` prop.\r\n\r\nexport const hideLabel = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi hide-label label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil\" },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti hideLabel label=\"What are your favourite types of coffee?\" multiple options={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={hideLabel}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      hideLabel\r\n      multiple\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Required\r\n\r\nInform the user that the multi-select is a required field by using the `required` prop.\r\nThis will display an asterisk next to the label and apply the `aria-required` attribute.\r\n\r\nexport const required = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi required label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil\" },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti required label=\"What are your favourite types of coffee?\" multiple options={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={required}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      multiple\r\n      required\r\n      options={OPTIONS}\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Read-only\r\n\r\nMake the multi-select read-only by using the `readonly` prop.\r\nUse the `value` prop to set which options are selected and will be displayed when it is read-only.\r\n\r\nexport const read = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi readonly label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil\" },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.value = [\"Cap\", \"Fla\", \"Moc\"];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti readonly value={[\"Cap\", \"Fla\", \"Moc\"]} label=\"What are your favourite types of coffee?\" multiple options={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={read}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      multiple\r\n      readonly\r\n      options={OPTIONS}\r\n      value={[\"Cap\", \"Fla\", \"Moc\"]}\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Groups\r\n\r\nDisplay options in groups by passing an array of child options to the `children` property of a parent option.\r\nThe parent option will be rendered as the title of the group.\r\n\r\nexport const group = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n  {\r\n    label: \"Fancy\",\r\n    children: [\r\n      { label: \"Cappuccino\", value: \"Cap\" },\r\n      { label: \"Flat white\", value: \"Flat\" },\r\n    ],\r\n  },\r\n  {\r\n    label: \"Boring\",\r\n    children: [\r\n      { label: \"Filter\", value: \"Fil\" },\r\n      { label: \"Latte\", value: \"Lat\" },\r\n    ],\r\n  },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple options={[\r\n  {\r\n    label: \"Fancy\",\r\n    children: [\r\n      { label: \"Cappuccino\", value: \"Cap\" },\r\n      { label: \"Flat white\", value: \"Flat\" },\r\n    ],\r\n  },\r\n  {\r\n    label: \"Boring\",\r\n    children: [\r\n      { label: \"Filter\", value: \"Fil\" },\r\n      { label: \"Latte\", value: \"Lat\" },\r\n    ],\r\n  },\r\n]}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={group}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      multiple\r\n      options={GROUPED_OPTIONS}\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Recommended\r\n\r\nDisplay certain options at the top of the option list by setting the `recommended` property to `true` on each option.\r\nThis will allow for quick access to these options.\r\n\r\nexport const recc = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\", recommended: true },\r\n    { label: \"Filter\", value: \"Fil\" },\r\n    { label: \"Flat white\", value: \"Fla\", recommended: true },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti label=\"What are your favourite types of coffee?\" multiple options={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\", recommended: true },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\", recommended: true },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={recc}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      multiple\r\n      options={OPTIONS_WITH_RECOMMENDED}\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Validation\r\n\r\nDisplay a validation status and message by using the `validation-status` and `validation-message` props.\r\nThe `validation-status` prop takes the values `success`, `warning` or `error`.\r\n\r\nexport const validation = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi validation-status=\"success\" validation-text=\"Coffee available\" label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil\" },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti validation-status=\"success\" validation-text=\"Coffee available\" label=\"What are your favourite types of coffee?\" multiple options={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={validation}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      multiple\r\n      options={OPTIONS}\r\n      validation-status=\"success\"\r\n      validation-text=\"Coffee available\"\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n\r\n### Loading with error\r\n\r\nDisplay the loading state by using the `loading` prop.\r\nThe multi-select will show a loading error after the amount of time specified using the `timeout` prop has elapsed.\r\n\r\nexport const loading = [\r\n  {\r\n    language: \"Web component\",\r\n    snippet: `<ic-select-with-multi loading timeout=\"1000\" label=\"What are your favourite types of coffee?\" multiple id=\"select-default\"></ic-select-with-multi>\r\n<script>\r\n  var select = document.querySelector(\"#select-default\");\r\n  select.options = [\r\n    { label: \"Cappuccino\", value: \"Cap\" },\r\n    { label: \"Latte\", value: \"Lat\" },\r\n    { label: \"Americano\", value: \"Ame\" },\r\n    { label: \"Filter\", value: \"Fil\" },\r\n    { label: \"Flat white\", value: \"Fla\" },\r\n    { label: \"Mocha\", value: \"Moc\" },\r\n    { label: \"Macchiato\", value: \"Mac\" },\r\n  ];\r\n  select.addEventListener(\"icChange\", function (event) {\r\n    console.log(event.detail.value);\r\n  });\r\n</script>`,\r\n  },\r\n  {\r\n    language: \"React\",\r\n    snippet: `<IcSelectWithMulti loading timeout=\"1000\" label=\"What are your favourite types of coffee?\" multiple options={[\r\n  { label: \"Cappuccino\", value: \"Cap\" },\r\n  { label: \"Latte\", value: \"Lat\" },\r\n  { label: \"Americano\", value: \"Ame\" },\r\n  { label: \"Filter\", value: \"Fil\" },\r\n  { label: \"Flat white\", value: \"Fla\" },\r\n  { label: \"Mocha\", value: \"Moc\" },\r\n  { label: \"Macchiato\", value: \"Mac\" },\r\n]}\r\n/>`,\r\n  },\r\n];\r\n\r\n<ComponentPreview snippets={loading}>\r\n  <div style={{ display: \"flex\", flexDirection: \"column\", gap: \"16px\" }}>\r\n    <IcSelectWithMulti\r\n      label=\"What are your favourite types of coffee?\"\r\n      multiple\r\n      loading\r\n      timeout=\"1000\"\r\n      options={OPTIONS}\r\n    />\r\n  </div>\r\n</ComponentPreview>\r\n",
       "path": "/components/multi-select/code",
-      "date": "2024-05-02",
-      "title": "Multi select",
+      "date": "2024-06-05",
+      "title": "Multi-select",
       "status": "CANARY",
       "subTitle": "Use the multi-select component to allow users to select one or more values from a list of options.",
       "tabs": [
@@ -2565,8 +2565,8 @@
       ],
       "meta": {
         "relativePath": "components\\multi-select\\code.mdx",
-        "createdAt": "2024-05-20T13:20:43.318Z",
-        "lastModified": "2024-05-20T13:20:43.318Z",
+        "createdAt": "2024-06-05T09:42:21.975Z",
+        "lastModified": "2024-06-05T09:42:21.975Z",
         "size": 27207,
         "formattedSize": "26.6 KB"
       }
@@ -2576,8 +2576,8 @@
       "contents": "\r\nimport { IcAlert, IcLink } from \"@ukic/react\";\r\nimport { IcSelectWithMulti } from \"@ukic/canary-react\";\r\n\r\nimport { OPTIONS } from \"./story-data\";\r\n\r\n<IcAlert\r\n  heading=\"Canary component\"\r\n  variant=\"info\"\r\n  message=\"This component is new and its guidance will be updated over time.\"\r\n/>\r\n\r\n## Canary components\r\n\r\nCanary components are unstable components that are released for testing purposes.\r\n\r\nWe value any feedback from users willing to try them in their applications.\r\n\r\nThese components should not be used in production apps without understanding the risk that changes may occur in order to fix bugs or improve functionality.\r\n\r\nFor more information on canary components, read our approach to [releases and versions](/get-started/releases-versions).\r\n\r\n<p>\r\n  Additional details on the props and events for this component can be found in\r\n  the ICDS{\" \"}\r\n  <IcLink\r\n    href=\"https://mi6.github.io/ic-ui-kit/branches/develop/canary-web-components/?path=/docs/web-components-multi-select--docs\"\r\n    target=\"_blank\"\r\n  >\r\n    Canary Web Components\r\n  </IcLink>{\" \"}\r\n  and{\" \"}\r\n  <IcLink\r\n    href=\"https://mi6.github.io/ic-ui-kit/branches/develop/canary-react/?path=/docs/react-components-multi-select--docs\"\r\n    target=\"_blank\"\r\n  >\r\n    Canary React\r\n  </IcLink>{\" \"}\r\n  storybooks.\r\n</p>\r\n\r\n## Single select\r\n\r\nTo view guidance and documentation relating to the single select component, check the [select page](/components/select).\r\n\r\n## Component demo\r\n\r\n<ComponentPreview>\r\n  <IcSelectWithMulti\r\n    label=\"What are your favourite types of coffee?\"\r\n    options={OPTIONS}\r\n    multiple\r\n  />\r\n</ComponentPreview>\r\n",
       "path": "/components/multi-select",
       "navPriority": 21,
-      "date": "2024-05-02",
-      "title": "Multi select",
+      "date": "2024-06-05",
+      "title": "Multi-select",
       "status": "CANARY",
       "subTitle": "Use the multi-select component to allow users to select one or more values from a list of options.",
       "tabs": [
@@ -2592,8 +2592,8 @@
       ],
       "meta": {
         "relativePath": "components\\multi-select\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.003Z",
-        "lastModified": "2024-06-04T07:48:35.003Z",
+        "createdAt": "2024-06-05T09:42:47.612Z",
+        "lastModified": "2024-06-05T09:42:47.612Z",
         "size": 2023,
         "formattedSize": "2.0 KB"
       }
@@ -2623,8 +2623,8 @@
       ],
       "meta": {
         "relativePath": "components\\page-header\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.318Z",
-        "lastModified": "2024-05-20T13:20:43.318Z",
+        "createdAt": "2024-05-30T15:54:25.605Z",
+        "lastModified": "2024-05-30T15:54:25.605Z",
         "size": 2474,
         "formattedSize": "2.4 KB"
       }
@@ -2654,8 +2654,8 @@
       ],
       "meta": {
         "relativePath": "components\\page-header\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.014Z",
-        "lastModified": "2024-04-04T12:41:44.014Z",
+        "createdAt": "2024-06-04T10:55:49.248Z",
+        "lastModified": "2024-06-04T10:55:49.248Z",
         "size": 17462,
         "formattedSize": "17.1 KB"
       }
@@ -2686,8 +2686,8 @@
       ],
       "meta": {
         "relativePath": "components\\page-header\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.004Z",
-        "lastModified": "2024-06-04T07:48:35.004Z",
+        "createdAt": "2024-06-05T09:22:54.357Z",
+        "lastModified": "2024-06-05T09:22:54.357Z",
         "size": 9274,
         "formattedSize": "9.1 KB"
       }
@@ -2717,8 +2717,8 @@
       ],
       "meta": {
         "relativePath": "components\\pagination\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.333Z",
-        "lastModified": "2024-05-20T13:20:43.333Z",
+        "createdAt": "2024-05-30T15:54:25.608Z",
+        "lastModified": "2024-05-30T15:54:25.608Z",
         "size": 3297,
         "formattedSize": "3.2 KB"
       }
@@ -2748,8 +2748,8 @@
       ],
       "meta": {
         "relativePath": "components\\pagination\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.029Z",
-        "lastModified": "2024-04-04T12:41:44.029Z",
+        "createdAt": "2024-06-04T10:55:49.248Z",
+        "lastModified": "2024-06-04T10:55:49.248Z",
         "size": 4833,
         "formattedSize": "4.7 KB"
       }
@@ -2780,8 +2780,8 @@
       ],
       "meta": {
         "relativePath": "components\\pagination\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.005Z",
-        "lastModified": "2024-06-04T07:48:35.005Z",
+        "createdAt": "2024-06-05T09:22:54.358Z",
+        "lastModified": "2024-06-05T09:22:54.358Z",
         "size": 11342,
         "formattedSize": "11.1 KB"
       }
@@ -2811,8 +2811,8 @@
       ],
       "meta": {
         "relativePath": "components\\popover-menu\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.006Z",
-        "lastModified": "2024-06-04T07:48:35.006Z",
+        "createdAt": "2024-06-05T09:22:54.359Z",
+        "lastModified": "2024-06-05T09:22:54.359Z",
         "size": 3446,
         "formattedSize": "3.4 KB"
       }
@@ -2842,8 +2842,8 @@
       ],
       "meta": {
         "relativePath": "components\\popover-menu\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.061Z",
-        "lastModified": "2024-04-04T12:41:44.061Z",
+        "createdAt": "2024-06-04T10:55:49.248Z",
+        "lastModified": "2024-06-04T10:55:49.248Z",
         "size": 14244,
         "formattedSize": "13.9 KB"
       }
@@ -2874,8 +2874,8 @@
       ],
       "meta": {
         "relativePath": "components\\popover-menu\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.007Z",
-        "lastModified": "2024-06-04T07:48:35.007Z",
+        "createdAt": "2024-06-05T09:22:54.360Z",
+        "lastModified": "2024-06-05T09:22:54.360Z",
         "size": 11543,
         "formattedSize": "11.3 KB"
       }
@@ -2905,8 +2905,8 @@
       ],
       "meta": {
         "relativePath": "components\\radio\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.008Z",
-        "lastModified": "2024-06-04T07:48:35.008Z",
+        "createdAt": "2024-06-05T09:22:54.361Z",
+        "lastModified": "2024-06-05T09:22:54.361Z",
         "size": 3634,
         "formattedSize": "3.5 KB"
       }
@@ -2936,8 +2936,8 @@
       ],
       "meta": {
         "relativePath": "components\\radio\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.092Z",
-        "lastModified": "2024-04-04T12:41:44.092Z",
+        "createdAt": "2024-06-04T10:55:49.248Z",
+        "lastModified": "2024-06-04T10:55:49.248Z",
         "size": 9641,
         "formattedSize": "9.4 KB"
       }
@@ -2968,8 +2968,8 @@
       ],
       "meta": {
         "relativePath": "components\\radio\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.009Z",
-        "lastModified": "2024-06-04T07:48:35.009Z",
+        "createdAt": "2024-06-05T09:22:54.361Z",
+        "lastModified": "2024-06-05T09:22:54.361Z",
         "size": 8448,
         "formattedSize": "8.3 KB"
       }
@@ -2999,8 +2999,8 @@
       ],
       "meta": {
         "relativePath": "components\\search-bar\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.333Z",
-        "lastModified": "2024-05-20T13:20:43.333Z",
+        "createdAt": "2024-05-30T15:54:25.620Z",
+        "lastModified": "2024-05-30T15:54:25.620Z",
         "size": 4091,
         "formattedSize": "4.0 KB"
       }
@@ -3030,8 +3030,8 @@
       ],
       "meta": {
         "relativePath": "components\\search-bar\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.108Z",
-        "lastModified": "2024-04-04T12:41:44.108Z",
+        "createdAt": "2024-06-04T10:55:49.255Z",
+        "lastModified": "2024-06-04T10:55:49.255Z",
         "size": 15192,
         "formattedSize": "14.8 KB"
       }
@@ -3062,8 +3062,8 @@
       ],
       "meta": {
         "relativePath": "components\\search-bar\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.010Z",
-        "lastModified": "2024-06-04T07:48:35.010Z",
+        "createdAt": "2024-06-05T09:22:54.362Z",
+        "lastModified": "2024-06-05T09:22:54.362Z",
         "size": 5980,
         "formattedSize": "5.8 KB"
       }
@@ -3093,8 +3093,8 @@
       ],
       "meta": {
         "relativePath": "components\\section-container\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.011Z",
-        "lastModified": "2024-06-04T07:48:35.011Z",
+        "createdAt": "2024-06-05T09:22:54.363Z",
+        "lastModified": "2024-06-05T09:22:54.363Z",
         "size": 1980,
         "formattedSize": "1.9 KB"
       }
@@ -3124,8 +3124,8 @@
       ],
       "meta": {
         "relativePath": "components\\section-container\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.108Z",
-        "lastModified": "2024-04-04T12:41:44.108Z",
+        "createdAt": "2024-06-04T10:55:49.256Z",
+        "lastModified": "2024-06-04T10:55:49.256Z",
         "size": 5824,
         "formattedSize": "5.7 KB"
       }
@@ -3156,8 +3156,8 @@
       ],
       "meta": {
         "relativePath": "components\\section-container\\guidance.mdx",
-        "createdAt": "2024-05-20T13:20:43.333Z",
-        "lastModified": "2024-05-20T13:20:43.333Z",
+        "createdAt": "2024-05-30T15:54:25.626Z",
+        "lastModified": "2024-05-30T15:54:25.626Z",
         "size": 5730,
         "formattedSize": "5.6 KB"
       }
@@ -3187,8 +3187,8 @@
       ],
       "meta": {
         "relativePath": "components\\select\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.012Z",
-        "lastModified": "2024-06-04T07:48:35.012Z",
+        "createdAt": "2024-06-05T09:22:54.364Z",
+        "lastModified": "2024-06-05T09:22:54.364Z",
         "size": 2819,
         "formattedSize": "2.8 KB"
       }
@@ -3218,8 +3218,8 @@
       ],
       "meta": {
         "relativePath": "components\\select\\code.mdx",
-        "createdAt": "2024-06-04T07:48:35.014Z",
-        "lastModified": "2024-06-04T07:48:35.014Z",
+        "createdAt": "2024-06-05T09:22:54.365Z",
+        "lastModified": "2024-06-05T09:22:54.365Z",
         "size": 36669,
         "formattedSize": "35.8 KB"
       }
@@ -3250,8 +3250,8 @@
       ],
       "meta": {
         "relativePath": "components\\select\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.015Z",
-        "lastModified": "2024-06-04T07:48:35.015Z",
+        "createdAt": "2024-06-05T09:22:54.366Z",
+        "lastModified": "2024-06-05T09:22:54.366Z",
         "size": 7650,
         "formattedSize": "7.5 KB"
       }
@@ -3281,8 +3281,8 @@
       ],
       "meta": {
         "relativePath": "components\\side-nav\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.333Z",
-        "lastModified": "2024-05-20T13:20:43.333Z",
+        "createdAt": "2024-05-30T15:54:25.632Z",
+        "lastModified": "2024-05-30T15:54:25.632Z",
         "size": 3045,
         "formattedSize": "3.0 KB"
       }
@@ -3312,8 +3312,8 @@
       ],
       "meta": {
         "relativePath": "components\\side-nav\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.135Z",
-        "lastModified": "2024-04-04T12:41:44.135Z",
+        "createdAt": "2024-06-04T10:55:49.259Z",
+        "lastModified": "2024-06-04T10:55:49.259Z",
         "size": 76725,
         "formattedSize": "74.9 KB"
       }
@@ -3344,8 +3344,8 @@
       ],
       "meta": {
         "relativePath": "components\\side-nav\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.017Z",
-        "lastModified": "2024-06-04T07:48:35.017Z",
+        "createdAt": "2024-06-05T09:22:54.367Z",
+        "lastModified": "2024-06-05T09:22:54.367Z",
         "size": 12429,
         "formattedSize": "12.1 KB"
       }
@@ -3375,8 +3375,8 @@
       ],
       "meta": {
         "relativePath": "components\\skeleton\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.333Z",
-        "lastModified": "2024-05-20T13:20:43.333Z",
+        "createdAt": "2024-05-30T15:54:25.642Z",
+        "lastModified": "2024-05-30T15:54:25.642Z",
         "size": 2876,
         "formattedSize": "2.8 KB"
       }
@@ -3406,8 +3406,8 @@
       ],
       "meta": {
         "relativePath": "components\\skeleton\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.140Z",
-        "lastModified": "2024-04-04T12:41:44.140Z",
+        "createdAt": "2024-06-04T10:55:49.260Z",
+        "lastModified": "2024-06-04T10:55:49.260Z",
         "size": 14012,
         "formattedSize": "13.7 KB"
       }
@@ -3438,8 +3438,8 @@
       ],
       "meta": {
         "relativePath": "components\\skeleton\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.017Z",
-        "lastModified": "2024-06-04T07:48:35.017Z",
+        "createdAt": "2024-06-05T09:22:54.368Z",
+        "lastModified": "2024-06-05T09:22:54.368Z",
         "size": 4797,
         "formattedSize": "4.7 KB"
       }
@@ -3469,8 +3469,8 @@
       ],
       "meta": {
         "relativePath": "components\\status-tags\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.349Z",
-        "lastModified": "2024-05-20T13:20:43.349Z",
+        "createdAt": "2024-05-30T15:54:25.645Z",
+        "lastModified": "2024-05-30T15:54:25.645Z",
         "size": 2017,
         "formattedSize": "2.0 KB"
       }
@@ -3500,8 +3500,8 @@
       ],
       "meta": {
         "relativePath": "components\\status-tags\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.155Z",
-        "lastModified": "2024-04-04T12:41:44.155Z",
+        "createdAt": "2024-06-04T10:55:49.262Z",
+        "lastModified": "2024-06-04T10:55:49.262Z",
         "size": 3835,
         "formattedSize": "3.7 KB"
       }
@@ -3532,8 +3532,8 @@
       ],
       "meta": {
         "relativePath": "components\\status-tags\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.018Z",
-        "lastModified": "2024-06-04T07:48:35.018Z",
+        "createdAt": "2024-06-05T09:22:54.369Z",
+        "lastModified": "2024-06-05T09:22:54.369Z",
         "size": 7036,
         "formattedSize": "6.9 KB"
       }
@@ -3563,8 +3563,8 @@
       ],
       "meta": {
         "relativePath": "components\\stepper\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.019Z",
-        "lastModified": "2024-06-04T07:48:35.019Z",
+        "createdAt": "2024-06-05T09:22:54.370Z",
+        "lastModified": "2024-06-05T09:22:54.370Z",
         "size": 1789,
         "formattedSize": "1.7 KB"
       }
@@ -3594,8 +3594,8 @@
       ],
       "meta": {
         "relativePath": "components\\stepper\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.155Z",
-        "lastModified": "2024-04-04T12:41:44.155Z",
+        "createdAt": "2024-06-04T10:55:49.264Z",
+        "lastModified": "2024-06-04T10:55:49.264Z",
         "size": 6929,
         "formattedSize": "6.8 KB"
       }
@@ -3626,8 +3626,8 @@
       ],
       "meta": {
         "relativePath": "components\\stepper\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.021Z",
-        "lastModified": "2024-06-04T07:48:35.021Z",
+        "createdAt": "2024-06-05T09:22:54.371Z",
+        "lastModified": "2024-06-05T09:22:54.371Z",
         "size": 7646,
         "formattedSize": "7.5 KB"
       }
@@ -3657,8 +3657,8 @@
       ],
       "meta": {
         "relativePath": "components\\switch\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.022Z",
-        "lastModified": "2024-06-04T07:48:35.022Z",
+        "createdAt": "2024-06-05T09:22:54.372Z",
+        "lastModified": "2024-06-05T09:22:54.372Z",
         "size": 3273,
         "formattedSize": "3.2 KB"
       }
@@ -3688,8 +3688,8 @@
       ],
       "meta": {
         "relativePath": "components\\switch\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.170Z",
-        "lastModified": "2024-04-04T12:41:44.170Z",
+        "createdAt": "2024-06-04T10:55:49.265Z",
+        "lastModified": "2024-06-04T10:55:49.265Z",
         "size": 4605,
         "formattedSize": "4.5 KB"
       }
@@ -3720,8 +3720,8 @@
       ],
       "meta": {
         "relativePath": "components\\switch\\guidance.mdx",
-        "createdAt": "2024-05-20T13:20:43.349Z",
-        "lastModified": "2024-05-20T13:20:43.349Z",
+        "createdAt": "2024-05-30T15:54:25.654Z",
+        "lastModified": "2024-05-30T15:54:25.654Z",
         "size": 6362,
         "formattedSize": "6.2 KB"
       }
@@ -3751,8 +3751,8 @@
       ],
       "meta": {
         "relativePath": "components\\tabs\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.349Z",
-        "lastModified": "2024-05-20T13:20:43.349Z",
+        "createdAt": "2024-05-30T15:54:25.655Z",
+        "lastModified": "2024-05-30T15:54:25.655Z",
         "size": 3437,
         "formattedSize": "3.4 KB"
       }
@@ -3782,8 +3782,8 @@
       ],
       "meta": {
         "relativePath": "components\\tabs\\code.mdx",
-        "createdAt": "2024-05-20T13:20:43.349Z",
-        "lastModified": "2024-05-20T13:20:43.349Z",
+        "createdAt": "2024-06-04T10:55:49.266Z",
+        "lastModified": "2024-06-04T10:55:49.266Z",
         "size": 15007,
         "formattedSize": "14.7 KB"
       }
@@ -3814,8 +3814,8 @@
       ],
       "meta": {
         "relativePath": "components\\tabs\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.023Z",
-        "lastModified": "2024-06-04T07:48:35.023Z",
+        "createdAt": "2024-06-05T09:22:54.373Z",
+        "lastModified": "2024-06-05T09:22:54.373Z",
         "size": 7251,
         "formattedSize": "7.1 KB"
       }
@@ -3845,8 +3845,8 @@
       ],
       "meta": {
         "relativePath": "components\\text-field\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.349Z",
-        "lastModified": "2024-05-20T13:20:43.349Z",
+        "createdAt": "2024-05-30T15:54:25.660Z",
+        "lastModified": "2024-05-30T15:54:25.660Z",
         "size": 2383,
         "formattedSize": "2.3 KB"
       }
@@ -3876,8 +3876,8 @@
       ],
       "meta": {
         "relativePath": "components\\text-field\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.202Z",
-        "lastModified": "2024-04-04T12:41:44.202Z",
+        "createdAt": "2024-06-04T10:55:49.267Z",
+        "lastModified": "2024-06-04T10:55:49.267Z",
         "size": 12108,
         "formattedSize": "11.8 KB"
       }
@@ -3908,8 +3908,8 @@
       ],
       "meta": {
         "relativePath": "components\\text-field\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.024Z",
-        "lastModified": "2024-06-04T07:48:35.024Z",
+        "createdAt": "2024-06-05T09:22:54.374Z",
+        "lastModified": "2024-06-05T09:22:54.374Z",
         "size": 6931,
         "formattedSize": "6.8 KB"
       }
@@ -3939,8 +3939,8 @@
       ],
       "meta": {
         "relativePath": "components\\toasts\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.025Z",
-        "lastModified": "2024-06-04T07:48:35.025Z",
+        "createdAt": "2024-06-05T09:22:54.375Z",
+        "lastModified": "2024-06-05T09:22:54.375Z",
         "size": 3504,
         "formattedSize": "3.4 KB"
       }
@@ -3970,8 +3970,8 @@
       ],
       "meta": {
         "relativePath": "components\\toasts\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.217Z",
-        "lastModified": "2024-04-04T12:41:44.217Z",
+        "createdAt": "2024-06-04T10:55:49.269Z",
+        "lastModified": "2024-06-04T10:55:49.269Z",
         "size": 18707,
         "formattedSize": "18.3 KB"
       }
@@ -4002,8 +4002,8 @@
       ],
       "meta": {
         "relativePath": "components\\toasts\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.026Z",
-        "lastModified": "2024-06-04T07:48:35.026Z",
+        "createdAt": "2024-06-05T09:22:54.376Z",
+        "lastModified": "2024-06-05T09:22:54.376Z",
         "size": 7413,
         "formattedSize": "7.2 KB"
       }
@@ -4033,8 +4033,8 @@
       ],
       "meta": {
         "relativePath": "components\\toggle-buttons\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.027Z",
-        "lastModified": "2024-06-04T07:48:35.027Z",
+        "createdAt": "2024-06-05T09:22:54.377Z",
+        "lastModified": "2024-06-05T09:22:54.377Z",
         "size": 3791,
         "formattedSize": "3.7 KB"
       }
@@ -4064,8 +4064,8 @@
       ],
       "meta": {
         "relativePath": "components\\toggle-buttons\\code.mdx",
-        "createdAt": "2024-05-20T13:20:43.359Z",
-        "lastModified": "2024-05-20T13:20:43.359Z",
+        "createdAt": "2024-06-04T10:55:49.270Z",
+        "lastModified": "2024-06-04T10:55:49.270Z",
         "size": 20858,
         "formattedSize": "20.4 KB"
       }
@@ -4096,8 +4096,8 @@
       ],
       "meta": {
         "relativePath": "components\\toggle-buttons\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.028Z",
-        "lastModified": "2024-06-04T07:48:35.028Z",
+        "createdAt": "2024-06-05T09:22:54.378Z",
+        "lastModified": "2024-06-05T09:22:54.378Z",
         "size": 11220,
         "formattedSize": "11.0 KB"
       }
@@ -4127,8 +4127,8 @@
       ],
       "meta": {
         "relativePath": "components\\tooltips\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.030Z",
-        "lastModified": "2024-06-04T07:48:35.030Z",
+        "createdAt": "2024-06-05T09:22:54.379Z",
+        "lastModified": "2024-06-05T09:22:54.379Z",
         "size": 2126,
         "formattedSize": "2.1 KB"
       }
@@ -4158,8 +4158,8 @@
       ],
       "meta": {
         "relativePath": "components\\tooltips\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.233Z",
-        "lastModified": "2024-04-04T12:41:44.233Z",
+        "createdAt": "2024-06-04T10:55:49.271Z",
+        "lastModified": "2024-06-04T10:55:49.271Z",
         "size": 8056,
         "formattedSize": "7.9 KB"
       }
@@ -4190,8 +4190,8 @@
       ],
       "meta": {
         "relativePath": "components\\tooltips\\guidance.mdx",
-        "createdAt": "2024-05-20T13:20:43.359Z",
-        "lastModified": "2024-05-20T13:20:43.359Z",
+        "createdAt": "2024-05-30T15:54:25.673Z",
+        "lastModified": "2024-05-30T15:54:25.673Z",
         "size": 5685,
         "formattedSize": "5.6 KB"
       }
@@ -4221,8 +4221,8 @@
       ],
       "meta": {
         "relativePath": "components\\top-nav\\accessibility.mdx",
-        "createdAt": "2024-06-04T07:48:35.030Z",
-        "lastModified": "2024-06-04T07:48:35.030Z",
+        "createdAt": "2024-06-05T09:22:54.380Z",
+        "lastModified": "2024-06-05T09:22:54.380Z",
         "size": 3089,
         "formattedSize": "3.0 KB"
       }
@@ -4252,8 +4252,8 @@
       ],
       "meta": {
         "relativePath": "components\\top-nav\\code.mdx",
-        "createdAt": "2024-06-04T07:48:35.031Z",
-        "lastModified": "2024-06-04T07:48:35.031Z",
+        "createdAt": "2024-06-05T09:22:54.380Z",
+        "lastModified": "2024-06-05T09:22:54.380Z",
         "size": 38549,
         "formattedSize": "37.6 KB"
       }
@@ -4284,8 +4284,8 @@
       ],
       "meta": {
         "relativePath": "components\\top-nav\\guidance.mdx",
-        "createdAt": "2024-06-04T07:48:35.032Z",
-        "lastModified": "2024-06-04T07:48:35.032Z",
+        "createdAt": "2024-06-05T09:22:54.380Z",
+        "lastModified": "2024-06-05T09:22:54.380Z",
         "size": 11529,
         "formattedSize": "11.3 KB"
       }
@@ -4316,8 +4316,8 @@
       ],
       "meta": {
         "relativePath": "components\\typography\\accessibility.mdx",
-        "createdAt": "2024-05-20T13:20:43.365Z",
-        "lastModified": "2024-05-20T13:20:43.365Z",
+        "createdAt": "2024-05-30T15:54:25.678Z",
+        "lastModified": "2024-05-30T15:54:25.678Z",
         "size": 1537,
         "formattedSize": "1.5 KB"
       }
@@ -4348,8 +4348,8 @@
       ],
       "meta": {
         "relativePath": "components\\typography\\code.mdx",
-        "createdAt": "2024-04-04T12:41:44.264Z",
-        "lastModified": "2024-04-04T12:41:44.264Z",
+        "createdAt": "2024-06-04T10:55:49.276Z",
+        "lastModified": "2024-06-04T10:55:49.276Z",
         "size": 8884,
         "formattedSize": "8.7 KB"
       }
@@ -4381,8 +4381,8 @@
       ],
       "meta": {
         "relativePath": "components\\typography\\guidance.mdx",
-        "createdAt": "2024-05-20T13:20:43.365Z",
-        "lastModified": "2024-05-20T13:20:43.365Z",
+        "createdAt": "2024-05-30T15:54:25.680Z",
+        "lastModified": "2024-05-30T15:54:25.680Z",
         "size": 2234,
         "formattedSize": "2.2 KB"
       }
@@ -4397,8 +4397,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/a-design-system.mdx",
       "meta": {
         "relativePath": "get-started\\a-design-system.mdx",
-        "createdAt": "2024-06-04T07:48:35.033Z",
-        "lastModified": "2024-06-04T07:48:35.033Z",
+        "createdAt": "2024-06-05T09:22:54.380Z",
+        "lastModified": "2024-06-05T09:22:54.380Z",
         "size": 2857,
         "formattedSize": "2.8 KB"
       }
@@ -4414,8 +4414,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/angular.mdx",
       "meta": {
         "relativePath": "get-started\\angular.mdx",
-        "createdAt": "2024-05-20T13:20:43.365Z",
-        "lastModified": "2024-05-20T13:20:43.365Z",
+        "createdAt": "2024-05-30T15:54:25.682Z",
+        "lastModified": "2024-05-30T15:54:25.682Z",
         "size": 3021,
         "formattedSize": "3.0 KB"
       }
@@ -4431,8 +4431,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/custom-theme.mdx",
       "meta": {
         "relativePath": "get-started\\custom-theme.mdx",
-        "createdAt": "2024-04-04T12:41:44.264Z",
-        "lastModified": "2024-04-04T12:41:44.264Z",
+        "createdAt": "2024-05-30T15:54:25.683Z",
+        "lastModified": "2024-05-30T15:54:25.683Z",
         "size": 1294,
         "formattedSize": "1.3 KB"
       }
@@ -4449,8 +4449,8 @@
       "hidden": false,
       "meta": {
         "relativePath": "get-started\\design-principles.mdx",
-        "createdAt": "2024-06-04T07:48:35.034Z",
-        "lastModified": "2024-06-04T07:48:35.034Z",
+        "createdAt": "2024-06-05T09:22:54.385Z",
+        "lastModified": "2024-06-05T09:22:54.385Z",
         "size": 1732,
         "formattedSize": "1.7 KB"
       }
@@ -4466,8 +4466,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/figma.mdx",
       "meta": {
         "relativePath": "get-started\\figma.mdx",
-        "createdAt": "2024-06-04T07:48:35.035Z",
-        "lastModified": "2024-06-04T07:48:35.035Z",
+        "createdAt": "2024-06-05T09:22:54.386Z",
+        "lastModified": "2024-06-05T09:22:54.386Z",
         "size": 3519,
         "formattedSize": "3.4 KB"
       }
@@ -4483,8 +4483,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/gatsby.mdx",
       "meta": {
         "relativePath": "get-started\\gatsby.mdx",
-        "createdAt": "2024-06-04T07:48:35.036Z",
-        "lastModified": "2024-06-04T07:48:35.036Z",
+        "createdAt": "2024-06-05T09:22:54.387Z",
+        "lastModified": "2024-06-05T09:22:54.387Z",
         "size": 2748,
         "formattedSize": "2.7 KB"
       }
@@ -4500,8 +4500,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/index.mdx",
       "meta": {
         "relativePath": "get-started\\index.mdx",
-        "createdAt": "2024-04-04T12:41:44.264Z",
-        "lastModified": "2024-04-04T12:41:44.264Z",
+        "createdAt": "2024-05-30T15:54:25.687Z",
+        "lastModified": "2024-05-30T15:54:25.687Z",
         "size": 1695,
         "formattedSize": "1.7 KB"
       }
@@ -4517,8 +4517,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/install-components.mdx",
       "meta": {
         "relativePath": "get-started\\install-components.mdx",
-        "createdAt": "2024-06-04T07:48:35.037Z",
-        "lastModified": "2024-06-04T07:48:35.037Z",
+        "createdAt": "2024-06-05T09:22:54.388Z",
+        "lastModified": "2024-06-05T09:22:54.388Z",
         "size": 2209,
         "formattedSize": "2.2 KB"
       }
@@ -4534,8 +4534,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/nextJS.mdx",
       "meta": {
         "relativePath": "get-started\\nextjs.mdx",
-        "createdAt": "2024-06-04T07:48:35.038Z",
-        "lastModified": "2024-06-04T07:48:35.038Z",
+        "createdAt": "2024-06-05T09:22:54.389Z",
+        "lastModified": "2024-06-05T09:22:54.389Z",
         "size": 1610,
         "formattedSize": "1.6 KB"
       }
@@ -4551,8 +4551,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/react.mdx",
       "meta": {
         "relativePath": "get-started\\react.mdx",
-        "createdAt": "2024-06-04T07:48:35.039Z",
-        "lastModified": "2024-06-04T07:48:35.039Z",
+        "createdAt": "2024-06-05T09:22:54.390Z",
+        "lastModified": "2024-06-05T09:22:54.390Z",
         "size": 3177,
         "formattedSize": "3.1 KB"
       }
@@ -4567,8 +4567,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/releases-versioning.mdx",
       "meta": {
         "relativePath": "get-started\\releases-versioning.mdx",
-        "createdAt": "2024-06-04T07:48:35.040Z",
-        "lastModified": "2024-06-04T07:48:35.040Z",
+        "createdAt": "2024-06-05T09:22:54.391Z",
+        "lastModified": "2024-06-05T09:22:54.391Z",
         "size": 5544,
         "formattedSize": "5.4 KB"
       }
@@ -4584,8 +4584,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/svelte.mdx",
       "meta": {
         "relativePath": "get-started\\svelte.mdx",
-        "createdAt": "2024-06-04T07:48:35.041Z",
-        "lastModified": "2024-06-04T07:48:35.041Z",
+        "createdAt": "2024-06-05T09:22:54.391Z",
+        "lastModified": "2024-06-05T09:22:54.391Z",
         "size": 2010,
         "formattedSize": "2.0 KB"
       }
@@ -4601,8 +4601,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/test-components.mdx",
       "meta": {
         "relativePath": "get-started\\test-components.mdx",
-        "createdAt": "2024-06-04T07:48:35.042Z",
-        "lastModified": "2024-06-04T07:48:35.042Z",
+        "createdAt": "2024-06-05T09:22:54.393Z",
+        "lastModified": "2024-06-05T09:22:54.393Z",
         "size": 2035,
         "formattedSize": "2.0 KB"
       }
@@ -4618,8 +4618,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/testing-with-cypress.mdx",
       "meta": {
         "relativePath": "get-started\\testing-with-cypress.mdx",
-        "createdAt": "2024-06-04T07:48:35.043Z",
-        "lastModified": "2024-06-04T07:48:35.043Z",
+        "createdAt": "2024-06-05T09:22:54.393Z",
+        "lastModified": "2024-06-05T09:22:54.393Z",
         "size": 5586,
         "formattedSize": "5.5 KB"
       }
@@ -4635,8 +4635,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/testing-with-jest.mdx",
       "meta": {
         "relativePath": "get-started\\testing-with-jest.mdx",
-        "createdAt": "2024-04-04T12:41:44.279Z",
-        "lastModified": "2024-04-04T12:41:44.279Z",
+        "createdAt": "2024-05-30T15:54:25.694Z",
+        "lastModified": "2024-05-30T15:54:25.694Z",
         "size": 5017,
         "formattedSize": "4.9 KB"
       }
@@ -4652,8 +4652,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/testing-with-react-testing-library.mdx",
       "meta": {
         "relativePath": "get-started\\testing-with-react-testing-library.mdx",
-        "createdAt": "2024-06-04T07:48:35.044Z",
-        "lastModified": "2024-06-04T07:48:35.044Z",
+        "createdAt": "2024-06-05T09:22:54.393Z",
+        "lastModified": "2024-06-05T09:22:54.393Z",
         "size": 8531,
         "formattedSize": "8.3 KB"
       }
@@ -4669,8 +4669,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/vue.mdx",
       "meta": {
         "relativePath": "get-started\\vue.mdx",
-        "createdAt": "2024-05-20T13:20:43.365Z",
-        "lastModified": "2024-05-20T13:20:43.365Z",
+        "createdAt": "2024-05-30T15:54:25.696Z",
+        "lastModified": "2024-05-30T15:54:25.696Z",
         "size": 2885,
         "formattedSize": "2.8 KB"
       }
@@ -4686,8 +4686,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/web-components.mdx",
       "meta": {
         "relativePath": "get-started\\web-components.mdx",
-        "createdAt": "2024-05-20T13:20:43.365Z",
-        "lastModified": "2024-05-20T13:20:43.365Z",
+        "createdAt": "2024-05-30T15:54:25.697Z",
+        "lastModified": "2024-05-30T15:54:25.697Z",
         "size": 3665,
         "formattedSize": "3.6 KB"
       }
@@ -4701,8 +4701,8 @@
       "subTitle": "Accessibility Statement for the Intelligence Community Design System.",
       "meta": {
         "relativePath": "icds\\accessibility-statement.mdx",
-        "createdAt": "2024-06-04T07:48:35.045Z",
-        "lastModified": "2024-06-04T07:48:35.045Z",
+        "createdAt": "2024-06-05T09:22:54.393Z",
+        "lastModified": "2024-06-05T09:22:54.393Z",
         "size": 5667,
         "formattedSize": "5.5 KB"
       }
@@ -4716,8 +4716,8 @@
       "subTitle": "Cookies Policy for the Intelligence Community Design System.",
       "meta": {
         "relativePath": "icds\\cookies-policy.mdx",
-        "createdAt": "2024-06-04T07:48:35.046Z",
-        "lastModified": "2024-06-04T07:48:35.046Z",
+        "createdAt": "2024-06-05T09:22:54.393Z",
+        "lastModified": "2024-06-05T09:22:54.393Z",
         "size": 5590,
         "formattedSize": "5.5 KB"
       }
@@ -4732,8 +4732,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/icds/index.mdx",
       "meta": {
         "relativePath": "icds\\index.mdx",
-        "createdAt": "2024-04-04T12:41:44.279Z",
-        "lastModified": "2024-04-04T12:41:44.279Z",
+        "createdAt": "2024-05-30T15:54:25.700Z",
+        "lastModified": "2024-05-30T15:54:25.700Z",
         "size": 670,
         "formattedSize": "670 Bytes"
       }
@@ -4747,8 +4747,8 @@
       "subTitle": "Privacy Policy for the Intelligence Community Design System.",
       "meta": {
         "relativePath": "icds\\privacy-policy.mdx",
-        "createdAt": "2024-06-04T07:48:35.048Z",
-        "lastModified": "2024-06-04T07:48:35.048Z",
+        "createdAt": "2024-06-05T09:22:54.397Z",
+        "lastModified": "2024-06-05T09:22:54.397Z",
         "size": 3836,
         "formattedSize": "3.7 KB"
       }
@@ -4764,8 +4764,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/patterns/deprecated-patterns/app-errors.mdx",
       "meta": {
         "relativePath": "patterns\\app-errors.mdx",
-        "createdAt": "2024-06-04T07:48:35.049Z",
-        "lastModified": "2024-06-04T07:48:35.049Z",
+        "createdAt": "2024-06-05T09:22:54.398Z",
+        "lastModified": "2024-06-05T09:22:54.398Z",
         "size": 4038,
         "formattedSize": "3.9 KB"
       }
@@ -4781,8 +4781,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/patterns/deprecated-pattern/form-layout.mdx",
       "meta": {
         "relativePath": "patterns\\form-layout.mdx",
-        "createdAt": "2024-06-04T07:48:35.050Z",
-        "lastModified": "2024-06-04T07:48:35.050Z",
+        "createdAt": "2024-06-05T09:22:54.399Z",
+        "lastModified": "2024-06-05T09:22:54.399Z",
         "size": 3278,
         "formattedSize": "3.2 KB"
       }
@@ -4798,8 +4798,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/patterns/deprecated-patterns/form-validation.mdx",
       "meta": {
         "relativePath": "patterns\\form-validation.mdx",
-        "createdAt": "2024-05-20T13:20:43.365Z",
-        "lastModified": "2024-05-20T13:20:43.365Z",
+        "createdAt": "2024-05-30T15:54:25.708Z",
+        "lastModified": "2024-05-30T15:54:25.708Z",
         "size": 2351,
         "formattedSize": "2.3 KB"
       }
@@ -4815,8 +4815,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/patterns/index.mdx",
       "meta": {
         "relativePath": "patterns\\index.mdx",
-        "createdAt": "2024-05-20T13:20:43.381Z",
-        "lastModified": "2024-05-20T13:20:43.381Z",
+        "createdAt": "2024-05-30T15:54:25.709Z",
+        "lastModified": "2024-05-30T15:54:25.709Z",
         "size": 980,
         "formattedSize": "980 Bytes"
       }
@@ -4832,8 +4832,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/patterns/navigation-patterns.mdx",
       "meta": {
         "relativePath": "patterns\\navigation-patterns.mdx",
-        "createdAt": "2024-05-20T13:20:43.381Z",
-        "lastModified": "2024-05-20T13:20:43.381Z",
+        "createdAt": "2024-05-30T15:54:25.709Z",
+        "lastModified": "2024-05-30T15:54:25.709Z",
         "size": 955,
         "formattedSize": "955 Bytes"
       }
@@ -4849,8 +4849,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/patterns/navigation-patterns/side-navigation-layout.mdx",
       "meta": {
         "relativePath": "patterns\\side-navigation-layout.mdx",
-        "createdAt": "2024-06-04T07:48:35.051Z",
-        "lastModified": "2024-06-04T07:48:35.051Z",
+        "createdAt": "2024-06-05T09:22:54.400Z",
+        "lastModified": "2024-06-05T09:22:54.400Z",
         "size": 64660,
         "formattedSize": "63.1 KB"
       }
@@ -4866,8 +4866,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/patterns/deprecated-patterns/success.mdx",
       "meta": {
         "relativePath": "patterns\\success.mdx",
-        "createdAt": "2024-06-04T07:48:35.052Z",
-        "lastModified": "2024-06-04T07:48:35.052Z",
+        "createdAt": "2024-06-05T09:22:54.401Z",
+        "lastModified": "2024-06-05T09:22:54.401Z",
         "size": 3085,
         "formattedSize": "3.0 KB"
       }
@@ -4883,8 +4883,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/patterns/navigation-patterns/top-navigation-layout.mdx",
       "meta": {
         "relativePath": "patterns\\top-navigation-layout.mdx",
-        "createdAt": "2024-06-04T07:48:35.054Z",
-        "lastModified": "2024-06-04T07:48:35.054Z",
+        "createdAt": "2024-06-05T09:22:54.403Z",
+        "lastModified": "2024-06-05T09:22:54.403Z",
         "size": 53672,
         "formattedSize": "52.4 KB"
       }
@@ -4899,8 +4899,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/colour.mdx",
       "meta": {
         "relativePath": "styles\\colour.mdx",
-        "createdAt": "2024-06-04T07:48:35.054Z",
-        "lastModified": "2024-06-04T07:48:35.054Z",
+        "createdAt": "2024-06-05T09:22:54.404Z",
+        "lastModified": "2024-06-05T09:22:54.404Z",
         "size": 4466,
         "formattedSize": "4.4 KB"
       }
@@ -4915,8 +4915,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/content-style.mdx",
       "meta": {
         "relativePath": "styles\\content-style.mdx",
-        "createdAt": "2024-06-04T07:48:35.056Z",
-        "lastModified": "2024-06-04T07:48:35.056Z",
+        "createdAt": "2024-06-05T09:22:54.405Z",
+        "lastModified": "2024-06-05T09:22:54.405Z",
         "size": 2070,
         "formattedSize": "2.0 KB"
       }
@@ -4931,8 +4931,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/elevation.mdx",
       "meta": {
         "relativePath": "styles\\elevation.mdx",
-        "createdAt": "2024-04-04T12:41:44.295Z",
-        "lastModified": "2024-04-04T12:41:44.295Z",
+        "createdAt": "2024-05-30T15:54:25.723Z",
+        "lastModified": "2024-05-30T15:54:25.723Z",
         "size": 7172,
         "formattedSize": "7.0 KB"
       }
@@ -4947,8 +4947,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/focus-indicator.mdx",
       "meta": {
         "relativePath": "styles\\focus-indicator.mdx",
-        "createdAt": "2024-06-04T07:48:35.057Z",
-        "lastModified": "2024-06-04T07:48:35.057Z",
+        "createdAt": "2024-06-05T09:22:54.406Z",
+        "lastModified": "2024-06-05T09:22:54.406Z",
         "size": 3102,
         "formattedSize": "3.0 KB"
       }
@@ -4964,8 +4964,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/grammar.mdx",
       "meta": {
         "relativePath": "styles\\grammar.mdx",
-        "createdAt": "2024-06-04T07:48:35.058Z",
-        "lastModified": "2024-06-04T07:48:35.058Z",
+        "createdAt": "2024-06-05T09:22:54.407Z",
+        "lastModified": "2024-06-05T09:22:54.407Z",
         "size": 3410,
         "formattedSize": "3.3 KB"
       }
@@ -4980,8 +4980,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/icons.mdx",
       "meta": {
         "relativePath": "styles\\icons.mdx",
-        "createdAt": "2024-04-04T12:41:44.295Z",
-        "lastModified": "2024-04-04T12:41:44.295Z",
+        "createdAt": "2024-05-30T15:54:25.726Z",
+        "lastModified": "2024-05-30T15:54:25.726Z",
         "size": 1772,
         "formattedSize": "1.7 KB"
       }
@@ -4997,8 +4997,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/inclusive-language.mdx",
       "meta": {
         "relativePath": "styles\\inclusive-language.mdx",
-        "createdAt": "2024-06-04T07:48:35.059Z",
-        "lastModified": "2024-06-04T07:48:35.059Z",
+        "createdAt": "2024-06-05T09:22:54.408Z",
+        "lastModified": "2024-06-05T09:22:54.408Z",
         "size": 5867,
         "formattedSize": "5.7 KB"
       }
@@ -5014,8 +5014,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/index.mdx",
       "meta": {
         "relativePath": "styles\\index.mdx",
-        "createdAt": "2024-06-04T07:48:35.060Z",
-        "lastModified": "2024-06-04T07:48:35.060Z",
+        "createdAt": "2024-06-05T09:22:54.408Z",
+        "lastModified": "2024-06-05T09:22:54.408Z",
         "size": 954,
         "formattedSize": "954 Bytes"
       }
@@ -5031,8 +5031,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/layout-spacing.mdx",
       "meta": {
         "relativePath": "styles\\layout-spacing.mdx",
-        "createdAt": "2024-06-04T07:48:35.061Z",
-        "lastModified": "2024-06-04T07:48:35.061Z",
+        "createdAt": "2024-06-05T09:22:54.409Z",
+        "lastModified": "2024-06-05T09:22:54.409Z",
         "size": 10187,
         "formattedSize": "9.9 KB"
       }
@@ -5048,8 +5048,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/links.mdx",
       "meta": {
         "relativePath": "styles\\links.mdx",
-        "createdAt": "2024-05-20T13:20:43.404Z",
-        "lastModified": "2024-05-20T13:20:43.404Z",
+        "createdAt": "2024-05-30T15:54:25.729Z",
+        "lastModified": "2024-05-30T15:54:25.729Z",
         "size": 1289,
         "formattedSize": "1.3 KB"
       }
@@ -5064,8 +5064,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/motion.mdx",
       "meta": {
         "relativePath": "styles\\motion.mdx",
-        "createdAt": "2024-06-04T07:48:35.062Z",
-        "lastModified": "2024-06-04T07:48:35.062Z",
+        "createdAt": "2024-06-05T09:22:54.410Z",
+        "lastModified": "2024-06-05T09:22:54.410Z",
         "size": 6094,
         "formattedSize": "6.0 KB"
       }
@@ -5081,8 +5081,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/numbers-dates-time.mdx",
       "meta": {
         "relativePath": "styles\\numbers-dates-time.mdx",
-        "createdAt": "2024-06-04T07:48:35.063Z",
-        "lastModified": "2024-06-04T07:48:35.063Z",
+        "createdAt": "2024-06-05T09:22:54.411Z",
+        "lastModified": "2024-06-05T09:22:54.411Z",
         "size": 2651,
         "formattedSize": "2.6 KB"
       }
@@ -5098,8 +5098,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/principles.mdx",
       "meta": {
         "relativePath": "styles\\principles.mdx",
-        "createdAt": "2024-05-20T13:20:43.406Z",
-        "lastModified": "2024-05-20T13:20:43.406Z",
+        "createdAt": "2024-05-30T15:54:25.732Z",
+        "lastModified": "2024-05-30T15:54:25.732Z",
         "size": 1503,
         "formattedSize": "1.5 KB"
       }
@@ -5115,8 +5115,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/templates.mdx",
       "meta": {
         "relativePath": "styles\\templates.mdx",
-        "createdAt": "2024-06-04T07:48:35.064Z",
-        "lastModified": "2024-06-04T07:48:35.064Z",
+        "createdAt": "2024-06-05T09:22:54.412Z",
+        "lastModified": "2024-06-05T09:22:54.412Z",
         "size": 4168,
         "formattedSize": "4.1 KB"
       }
@@ -5131,8 +5131,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/typography.mdx",
       "meta": {
         "relativePath": "styles\\typography.mdx",
-        "createdAt": "2024-06-04T07:48:35.065Z",
-        "lastModified": "2024-06-04T07:48:35.065Z",
+        "createdAt": "2024-06-05T09:22:54.413Z",
+        "lastModified": "2024-06-05T09:22:54.413Z",
         "size": 1923,
         "formattedSize": "1.9 KB"
       }
@@ -5148,8 +5148,8 @@
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/styles/voice-and-tone.mdx",
       "meta": {
         "relativePath": "styles\\voice-and-tone.mdx",
-        "createdAt": "2024-06-04T07:48:35.066Z",
-        "lastModified": "2024-06-04T07:48:35.066Z",
+        "createdAt": "2024-06-05T09:22:54.414Z",
+        "lastModified": "2024-06-05T09:22:54.414Z",
         "size": 3841,
         "formattedSize": "3.8 KB"
       }


### PR DESCRIPTION
## Summary of the changes

Add hyphen between Multi and select, due to consistency in naming conventions of the component.
In our Storybook build and elsewhere we have the component 'Multi-select' with a hyphen. On the guidance pages this is not reflected and should be changed.

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
