### PR TITLE
docs(root): added button guidance around tooltips

### DIFF
--- a/src/content/structured/components/buttons/code.mdx
+++ b/src/content/structured/components/buttons/code.mdx
@@ -147,6 +147,8 @@ export const snippetsWithIcon = [
 
 ### Icon Button
 
+When using an icon button, refer to the guidance of using [tooltips](/components/tooltip/#when-to-use). When disabling tooltips, provide a suitable `aria-label` or `title` to provide context to screen readers.
+
 export const snippetsIcon = [
   {
     language: "Web component",
@@ -160,6 +162,24 @@ export const snippetsIcon = [
     >
     <path d="M0 0h24v24H0V0z" fill="none"></path>
     <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>
+  </svg>
+</ic-button>
+<ic-button
+  variant="icon"
+  aria-label="you can disable tooltips on icon buttons"
+  disable-tooltip="true"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 0 24 24"
+    width="24px"
+    fill="#000000"
+  >
+    <path d="M0 0h24v24H0V0z" fill="none" />
+    <path
+      d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+    />
   </svg>
 </ic-button>`,
   },
@@ -175,6 +195,24 @@ export const snippetsIcon = [
     >
     <path d="M0 0h24v24H0V0z" fill="none"></path>
     <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>
+  </svg>
+</IcButton>
+<IcButton
+  variant="icon"
+  aria-label="you can disable tooltips on icon buttons"
+  disableTooltip
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24px"
+    viewBox="0 0 24 24"
+    width="24px"
+    fill="#000000"
+  >
+    <path d="M0 0h24v24H0V0z" fill="none" />
+    <path
+      d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"
+    />
   </svg>
 </IcButton>`,
   },
@@ -192,6 +230,64 @@ export const snippetsIcon = [
       <path d="M0 0h24v24H0V0z" fill="none" />
       <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
     </svg>
+  </IcButton>
+  <IcButton
+    variant="icon"
+    aria-label="you can disable tooltips on icon buttons"
+    disableTooltip
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24px"
+      viewBox="0 0 24 24"
+      width="24px"
+      fill="#000000"
+    >
+      <path d="M0 0h24v24H0V0z" fill="none" />
+      <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
+    </svg>
+  </IcButton>
+</ComponentPreview>
+
+### Tooltip
+
+export const snippetsTooltip = [
+  {
+    language: "Web component",
+    snippet: `<ic-button variant="primary" title="We can add tooltips to text buttons">Button With Title</ic-button>
+<ic-button
+  variant="primary"
+  title="the tooltipPlacement prop allows us to change the location of the tooltip"
+  tooltip-placement="right"
+>
+  Different positions
+</ic-button>`,
+  },
+  {
+    language: "React",
+    snippet: `<IcButton variant="primary" title="We can add tooltips to text buttons">
+  Button With Title
+</IcButton>
+<IcButton
+  variant="primary"
+  title="the tooltipPlacement prop allows us to change the location of the tooltip"
+  tooltipPlacement="right"
+>
+  Different positions
+</IcButton>`,
+  },
+];
+
+<ComponentPreview style={{ gap: "8px" }} snippets={snippetsTooltip}>
+  <IcButton variant="primary" title="We can add tooltips to text buttons">
+    Button With Title
+  </IcButton>
+  <IcButton
+    variant="primary"
+    title="the tooltipPlacement prop allows us to change the location of the tooltip"
+    tooltipPlacement="right"
+  >
+    Different positions
   </IcButton>
 </ComponentPreview>
 

--- a/src/content/structured/get-started/testing-with-react-testing-library.mdx
+++ b/src/content/structured/get-started/testing-with-react-testing-library.mdx
@@ -60,8 +60,7 @@ contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/struc
     style={{ backgroundColor: "#EEEFF0" }}
   >
     getByShadowText()
-  </code>
-  ).
+  </code>).
 </p>
 
 ```tsx


### PR DESCRIPTION
## Summary of the changes
Added code examples to button page around using tooltips correctly

## Related issue
#667 

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
