### PR TITLE
docs: update Next.js documentation to reflect new versions, fix broken link to code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Welcome and thank you for contributing to the [Intelligence Community Design Sys
 
 ## Code of conduct
 
-The Intelligence Community Design System (ICDS) has adopted the [Contributor Covenant](https://www.contributor-covenant.org/). Please familiarise yourself with our full [conduct principles](/CODE_OF_CONDUCT).
+The Intelligence Community Design System (ICDS) has adopted the [Contributor Covenant](https://www.contributor-covenant.org/). Please familiarise yourself with our full [conduct principles](/CODE_OF_CONDUCT.md).
 
 ## How to contribute
 

--- a/src/content/structured/get-started/nextjs.mdx
+++ b/src/content/structured/get-started/nextjs.mdx
@@ -16,7 +16,7 @@ contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/struc
 
 The `@ukic/react` package will need to be transpiled for use with Next.js. The steps required will depend on the version of Next.js you are using.
 
-### Next.js 13
+### Next.js 13 and later
 
 Set the following in the `next.config.js` file.
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

The current documentation reads in a way that doesn't account for nextJS versions later than 13. 
Fixed broken link to code of conduct

## Related issue

n/a

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
