### PR TITLE
docs(root): addressed typos in switch and colour contrast

### DIFF
--- a/src/content/structured/accessibility/needs/visual.mdx
+++ b/src/content/structured/accessibility/needs/visual.mdx
@@ -46,7 +46,7 @@ In addressing some of the design issues below, we make it easier for everyone to
 Use the [typographic scale](/styles/typography) with the font ‘Open Sans’ to create readable content.
 
 <p>
-  Use a colour contrast of at least 4:5:1. Use a{" "}
+  Use a colour contrast of at least 4.5:1. Use a{" "}
   <ic-link
     target="_blank"
     href="http://contrast-checker.glitch.me/"

--- a/src/content/structured/components/switch/guidance.mdx
+++ b/src/content/structured/components/switch/guidance.mdx
@@ -91,7 +91,7 @@ Avoid automatically altering a switch's state based on another trigger. A change
   variant="label"
   style={{ marginTop: "-1rem", marginBottom: "1.5rem" }}
 >
-  Avoid changing a switches state without the user’s specific instruction.
+  Avoid changing a switch's state without the user’s specific instruction.
 </IcTypography>
 
 ## Sizing


### PR DESCRIPTION
## Summary of the changes

- Fixed typo on switch page
- Fixed contrast compliance typo from 4:5:1 to 4.5:1

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
