### PR TITLE
docs(root): add code example for icon in select

### DIFF
--- a/src/content/structured/components/select/code.mdx
+++ b/src/content/structured/components/select/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/select/code"
 
-date: "2024-05-31"
+date: "2024-07-02"
 
 title: "Select"
 
@@ -395,6 +395,133 @@ export const SelectExampleOptionsDisabled = () => (
 
 <ComponentPreview snippets={snippetsOptionDisabled}>
   <SelectExampleOptionsDisabled />
+</ComponentPreview>
+
+### With icon
+
+export const snippetsWithIcon = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-select 
+  label="What is your favourite coffee?" 
+>
+  <svg
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21H20V19H2M20,8H18V5H20M20,3H4V13A4,4 0 0,0 8,17H14A4,4 0 0,0 18,13V10H20A2,2 0 0,0 22,8V5C22,3.89 21.1,3 20,3Z" />
+  </svg>
+</ic-select>`,
+      long: `{shortCode}
+<script>
+  const select = document.querySelector("ic-select");
+  let option = "Cappuccino";
+  select.options = [
+    { label: "Cappuccino", value: "cappuccino", description: "Coffee frothed up with pressurised steam" },
+    { label: "Americano", value: "americano", description: "Espresso coffee diluted with hot water" },
+    { label: "Mocha", value: "mocha", description: "Coffee with chocolate" },
+  ];
+  select.addEventListener("icChange", function (event) {
+    console.log(event.detail.value);
+  });
+</script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcSelect 
+  label="What is your favourite coffee?"
+  options={options}
+  onIcChange={(event) => console.log(event.detail.value)}
+>
+  <SlottedSVG
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21H20V19H2M20,8H18V5H20M20,3H4V13A4,4 0 0,0 8,17H14A4,4 0 0,0 18,13V10H20A2,2 0 0,0 22,8V5C22,3.89 21.1,3 20,3Z" />
+  </SlottedSVG>
+</IcSelect>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const options = [
+   { label: "Espresso", value: "espresso" },
+   { label: "Double Espresso", value: "doubleespresso" },
+   { label: "Flat White", value: "flatwhite" },
+   { label: "Cappuccino", value: "cappuccino" },
+   { label: "Americano", value: "americano" },
+   { label: "Mocha", value: "mocha" },
+ ];
+ return (
+   {shortCode}
+ )`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const options = [
+   { label: "Espresso", value: "espresso" },
+   { label: "Double Espresso", value: "doubleespresso" },
+   { label: "Flat White", value: "flatwhite" },
+   { label: "Cappuccino", value: "cappuccino" },
+   { label: "Americano", value: "americano" },
+   { label: "Mocha", value: "mocha" },
+ ];
+ return (
+   {shortCode}
+ )`,
+        },
+      ],
+    },
+  },
+];
+
+export const SelectExampleWithIcon = () => (
+  <IcSelect
+    label="What is your favourite coffee?"
+    options={[
+      {
+        label: "Cappuccino",
+        value: "cappuccino",
+        description: "Coffee frothed up with pressurised steam",
+      },
+      {
+        label: "Americano",
+        value: "americano",
+        description: "Espresso coffee diluted with hot water",
+      },
+      {
+        label: "Mocha",
+        value: "mocha",
+        description: "Coffee with chocolate",
+      },
+    ]}
+    onIcChange={(event) => console.log(event.detail.value)}
+  >
+    <svg
+      slot="icon"
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      fill="#000000"
+    >
+      <path d="M2,21H20V19H2M20,8H18V5H20M20,3H4V13A4,4 0 0,0 8,17H14A4,4 0 0,0 18,13V10H20A2,2 0 0,0 22,8V5C22,3.89 21.1,3 20,3Z" />
+    </svg>
+  </IcSelect>
+);
+
+<ComponentPreview snippets={snippetsWithIcon}>
+  <SelectExampleWithIcon />
 </ComponentPreview>
 
 ### Size small


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add code example for icon in select input. Won't show up until https://github.com/mi6/ic-ui-kit/pull/2071 has been merged, will need to test locally by building components off that branch until then.

## Related issue

https://github.com/mi6/ic-ui-kit/issues/2045

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
