### PR TITLE
fix(root): add missing prop to code examples

### DIFF
--- a/src/content/structured/components/radio/code.mdx
+++ b/src/content/structured/components/radio/code.mdx
@@ -185,7 +185,11 @@ export const conditionalDynamic = [
   name="radio-group-3"
   label="Do you have any special requests?"
 >
-  <ic-radio-option value="request" label="Yes, I want to modify my order">
+  <ic-radio-option 
+    value="request" 
+    label="Yes, I want to modify my order"
+    additional-field-display="dynamic"
+  >
     <ic-text-field
       slot="additional-field"
       label="Please provide some additional information"
@@ -208,7 +212,11 @@ export const conditionalDynamic = [
   name="radio-group-3"
   label="Do you have any special requests?"
 >
-  <IcRadioOption value="request" label="Yes, I want to modify my order">
+  <IcRadioOption 
+    value="request" 
+    label="Yes, I want to modify my order" 
+    additionalFieldDisplay="dynamic"
+  >
     <IcTextField
       slot="additional-field"
       label="Please provide some additional information"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Added the code snippet that was missing the relevent prop shown in the example.

## Related issue

Issue #1050 

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
