### PR TITLE
docs: Fix typo on horizontal card url

### DIFF
--- a/src/content/structured/components/card-horizontal/guidance.mdx
+++ b/src/content/structured/components/card-horizontal/guidance.mdx
@@ -41,14 +41,14 @@ For more information on Canary components, read our approach to [releases and ve
   Additional details on the props and events for this component can be found in
   the{" "}
   <IcLink
-    href="https://mi6.github.io/ic-ui-kit/branches/develop/canary-web-components/?path=/docs/web-components-card-horizontal--docs"
+    href="https://mi6.github.io/ic-ui-kit/branches/develop/canary-web-components/?path=/docs/web-components-horizontal-card--docs"
     target="_blank"
   >
     Canary web components
   </IcLink>{" "}
   and{" "}
   <IcLink
-    href="https://mi6.github.io/ic-ui-kit/branches/develop/canary-react/?path=/docs/react-components-card-horizontal--docs"
+    href="https://mi6.github.io/ic-ui-kit/branches/develop/canary-react/?path=/docs/react-components-horizontal-card--docs"
     target="_blank"
   >
     Canary React


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

See https://design.sis.gov.uk/components/horizontal-card

If you click either the web component or react storybook links you get sent to a 404.
I browsed the sidepanel and found the correct URL

## Related issue

Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.

## Checklist

~- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.~
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
