### PR TITLE
docs(root): removed --ic-hyperlink-hover from colour palette

### DIFF
--- a/src/content/structured/styles/colour.mdx
+++ b/src/content/structured/styles/colour.mdx
@@ -3,7 +3,7 @@ path: "/styles/colour"
 
 navPriority: 1
 
-date: "2024-05-10"
+date: "2024-09-30"
 
 title: "Colour"
 
@@ -62,8 +62,6 @@ Interactive elements sometimes require transparent backgrounds for their hover a
 ## Links
 
 Use these colours for all links. These specific colours help to identify links from non-interactive text.
-
-Use the contrast colour variants to achieve good contrast for links that appear on dark backgrounds.
 
 <ColorTable config={ColoursLinks} />
 

--- a/src/content/structured/styles/components/ColourTable/colours.config.ts
+++ b/src/content/structured/styles/components/ColourTable/colours.config.ts
@@ -136,7 +136,6 @@ export const ColoursLinks = [
     colors: [
       { name: "Link", token: "--ic-hyperlink", hex: "#1759BC" },
       { name: "Link visited", token: "--ic-hyperlink-visited", hex: "#330072" },
-      { name: "Link hover", token: "--ic-hyperlink-hover", hex: "#7C2855" },
     ],
   },
 ];


### PR DESCRIPTION
Removed --ic-hyperlink-hover from colour palette

## Summary of the changes

On the colour palette page, the --ic-hyperlink-hover has been removed. Also removed an unnecessary sentence in the Links section regarding contrast.

## Related issue

#1019 

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
