### PR TITLE
fix(root): fix syntax highlighting in code preview

### DIFF
--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -140,11 +140,11 @@ const ToggleShowButton: React.FC<ToggleShowProps> = ({
   </div>
 );
 
-const CodeWindow: React.FC<CodeWindowProps> = ({ code, show }) => (
+const CodeWindow: React.FC<CodeWindowProps> = ({ code, show, language }) => (
   <div className="code-window">
     {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
     {show && (
-      <Highlight {...defaultProps} code={code} language="jsx" theme={undefined}>
+      <Highlight {...defaultProps} code={code} language={language === "Javascript" ? 'jsx' : 'tsx'} theme={undefined}>
         {({ className, style, tokens, getLineProps, getTokenProps }) => (
           <pre
             className={clsx(className, "snippet")}
@@ -555,6 +555,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
               <CodeWindow
                 code={getCodeSnippet(snippet)?.codeSnippet || ""}
                 show={show}
+                language={selectedLanguage}
               />
             </IcTabPanel>
           ))}

--- a/src/components/CodePreview/types.ts
+++ b/src/components/CodePreview/types.ts
@@ -52,6 +52,7 @@ export interface ToggleShowProps {
 export interface CodeWindowProps {
   code: string;
   show: boolean;
+  language: string;
 }
 
 export interface FrameworkTabProps {


### PR DESCRIPTION
**Title:**
fix(root): fix syntax highlighting in code preview

**Description:**
- Added conditional language for the `<Highlight>` component.

**Files Changed:**
1. [src/components/CodePreview/index.tsx](https://github.com/mi6/ic-design-system/blob/b0fc079b9f11fc12314a2b8f31440f14fab720c6/src/components/CodePreview/index.tsx)
   - Adjusted the `CodeWindow` component to accept a `language` prop and conditionally set the language for the syntax highlighting.
   - Added the `language` prop to the `ComponentPreview` component.
2. [src/components/CodePreview/types.ts](https://github.com/mi6/ic-design-system/blob/b0fc079b9f11fc12314a2b8f31440f14fab720c6/src/components/CodePreview/types.ts)
   - Added `language` to `CodeWindowProps` interface.

### Summary
This pull request aims to fix the syntax highlighting in the code preview by introducing a conditional language parameter to the `<Highlight>` component. It updates the `CodeWindow` component to accept the `language` prop and adjusts the `ComponentPreview` to pass the selected language. Additionally, it modifies the relevant TypeScript types to include the new `language` property.

## Related issue

#1146 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
