### PR TITLE
fix(root): stopped back-to-top component from overlapping content on …

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -19,6 +19,8 @@ import { consentCookieApproved } from "../CookieBanner/cookies.helper";
 
 import { Heading, MdxFields, MdxFrontMatter } from "../../sharedTypes";
 
+import { IC_DEVICE_SIZES } from "../../utils/constants";
+
 const {
   STATUS,
   TITLE,
@@ -187,6 +189,41 @@ const Layout: React.FC<LayoutProps> = ({
     }
   };
 
+  const [backToTopIconVariant, setBackToTopIconVariant] = useState(false);
+
+  function calculateScreenResolution() {
+    let resolution = "XL";
+    if (screen.width > IC_DEVICE_SIZES.L) {
+      resolution = "L";
+    } else if (screen.width > IC_DEVICE_SIZES.M) {
+      resolution = "M";
+    } else if (screen.width > IC_DEVICE_SIZES.S) {
+      resolution = "S";
+    } else if (screen.width < IC_DEVICE_SIZES.S) {
+      resolution = "XS";
+    }
+    return resolution;
+  }
+
+  function calculateBackToTopVariant(screenWidth: number) {
+    let isIcon = false;
+    const screenResolution = calculateScreenResolution();
+    const iconWidthPercentageThreshold = 0.9;
+
+    if (
+      screenResolution &&
+      screenWidth <
+        IC_DEVICE_SIZES[screenResolution] * iconWidthPercentageThreshold
+    ) {
+      isIcon = true;
+    }
+    setBackToTopIconVariant(isIcon);
+  }
+
+  window.addEventListener("resize", () => {
+    calculateBackToTopVariant(window.innerWidth);
+  });
+
   return (
     <>
       <Helmet>
@@ -254,7 +291,11 @@ const Layout: React.FC<LayoutProps> = ({
               {" "}
             </a>
             {cloneElement(children, { location: location.pathname })}
-            <ic-back-to-top target="main" />
+            <ic-back-to-top
+              id="back-to-top"
+              target="main"
+              variant={backToTopIconVariant ? "icon" : "default"}
+            />
           </main>
         </div>
         <div className="footer">

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,7 @@
+export const IC_DEVICE_SIZES: { [key: string]: number } = {
+  XS: 576,
+  S: 768,
+  M: 992,
+  L: 1200,
+  XL: 99999,
+};


### PR DESCRIPTION
## Summary of the changes

Added functionality to set the percentage screen-width threshold, at which the variant of the back-to-top component changes to icon (reducing the amount of content it obscures on the pages).

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [X] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
