### PR TITLE
docs(root): replace examples of the default size prop with medium

### DIFF
--- a/src/content/structured/components/badge/code.mdx
+++ b/src/content/structured/components/badge/code.mdx
@@ -121,7 +121,7 @@ export const snippetsSizes = [
   Coffee orders
 </ic-button>
 <ic-button variant="secondary">
-  <ic-badge label="8" slot="badge" variant="info"></ic-badge>
+  <ic-badge size="medium" label="8" slot="badge" variant="info"></ic-badge>
   Coffee orders
 </ic-button>
 <ic-button size="large" variant="secondary">
@@ -149,7 +149,7 @@ export const snippetsSizes = [
   Coffee orders
 </IcButton>
 <IcButton variant="secondary">
-  <IcBadge label="8" slot="badge" variant="info"/>
+  <IcBadge size="medium" label="8" slot="badge" variant="info"/>
   Coffee orders
 </IcButton>
 <IcButton size="large" variant="secondary">
@@ -202,7 +202,7 @@ return (
     Coffee orders
   </IcButton>
   <IcButton variant="secondary">
-    <IcBadge label="8" slot="badge" variant="info" size="default" />
+    <IcBadge label="8" slot="badge" variant="info" size="medium" />
     Coffee orders
   </IcButton>
   <IcButton size="large" variant="secondary">

--- a/src/content/structured/components/date-picker/code.mdx
+++ b/src/content/structured/components/date-picker/code.mdx
@@ -101,7 +101,7 @@ export const sizes = [
 ></ic-date-picker>
 <ic-date-picker
   label="When would you like to collect your coffee?"
-  size="default"
+  size="medium"
 ></ic-date-picker>
 <ic-date-picker
   label="When would you like to collect your coffee?"
@@ -203,7 +203,7 @@ export const maxWidth = [
 ></ic-date-picker>
 <ic-date-picker
   label="When would you like to collect your coffee?"
-  size="default"
+  size="medium"
 ></ic-date-picker>
 <ic-date-picker
   label="When would you like to collect your coffee?"

--- a/src/content/structured/components/status-tags/code.mdx
+++ b/src/content/structured/components/status-tags/code.mdx
@@ -209,7 +209,7 @@ export const snippetsSizes = [
 <ic-status-tag
   label="Success"
   status="success"
-  size="default"
+  size="medium"
 ></ic-status-tag>
 <ic-status-tag
   label="Warning"
@@ -233,7 +233,7 @@ export const snippetsSizes = [
     technology: "React",
     snippets: {
       short: `<IcStatusTag label="Neutral" status="neutral" size="small" />
-<IcStatusTag label="Success" status="success" size="default" />
+<IcStatusTag label="Success" status="success" size="medium" />
 <IcStatusTag label="Warning" status="warning" size="large" />`,
       long: [
         {

--- a/src/content/structured/components/toggle-buttons/code.mdx
+++ b/src/content/structured/components/toggle-buttons/code.mdx
@@ -320,7 +320,7 @@ export const snippetsSizing = [
     technology: "React",
     snippets: {
       short: `<IcToggleButton label="Switch to oat milk" size="small" />
-<IcToggleButton label="Switch to oat milk" size="default" />
+<IcToggleButton label="Switch to oat milk" size="medium" />
 <IcToggleButton label="Switch to oat milk" size="large" />`,
       long: [
         {
@@ -364,7 +364,7 @@ return (
 
 <ComponentPreview style={{ gap: "0.5rem" }} snippets={snippetsSizing}>
   <IcToggleButton label="Switch to oat milk" size="small" />
-  <IcToggleButton label="Switch to oat milk" size="default" />
+  <IcToggleButton label="Switch to oat milk" size="medium" />
   <IcToggleButton label="Switch to oat milk" size="large" />
 </ComponentPreview>
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Updated the size prop from default to medium in badge, toggle button, date picker and status tag examples.

## Related issue

#1090 

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [ ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
