### PR TITLE
docs(root): add guidance for neutral alert and show default icon prop

### DIFF
--- a/src/content/structured/components/alerts/code.mdx
+++ b/src/content/structured/components/alerts/code.mdx
@@ -377,11 +377,132 @@ export const snippetsCustomMessage = [
         letterSpacing: "var(--ic-font-letter-spacing-0pt005)",
       }}
     >
-      Got to our{" "}
+      Go to our{" "}
       <IcLink href="#" onClick={(e) => e.preventDefault()}>
         coffee page
       </IcLink>{" "}
       to learn more.
     </span>
   </IcAlert>
+</ComponentPreview>
+
+### With custom icon
+
+export const snippetsCustomIcon = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-alert 
+  variant="neutral" 
+  heading="Increased wait times" 
+  message="Due to unprecedented coffee demand, wait times may be longer than usual."
+>
+  <svg
+    slot="neutral-icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+    >
+    <path d="M12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22C6.47,22 2,17.5 2,12A10,10 0 0,1 12,2M12.5,7V12.25L17,14.92L16.25,16.15L11,13V7H12.5Z"/>
+  </svg>
+</ic-alert>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcAlert 
+  variant="neutral" 
+  heading="Increased wait times" 
+  message="Due to unprecedented coffee demand, wait times may be longer than usual."
+>
+  <SlottedSVG
+    slot="neutral-icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+    >
+    <path d="M12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22C6.47,22 2,17.5 2,12A10,10 0 0,1 12,2M12.5,7V12.25L17,14.92L16.25,16.15L11,13V7H12.5Z"/>
+  </SlottedSVG>
+</IcAlert>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsCustomIcon}>
+  <IcAlert
+    variant="neutral"
+    heading="Increased wait times"
+    message="Due to unprecedented coffee demand, wait times may be longer than usual."
+  >
+    <svg
+      slot="neutral-icon"
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      fill="#000000"
+    >
+      <path d="M12,20A8,8 0 0,0 20,12A8,8 0 0,0 12,4A8,8 0 0,0 4,12A8,8 0 0,0 12,20M12,2A10,10 0 0,1 22,12A10,10 0 0,1 12,22C6.47,22 2,17.5 2,12A10,10 0 0,1 12,2M12.5,7V12.25L17,14.92L16.25,16.15L11,13V7H12.5Z" />
+    </svg>
+  </IcAlert>
+</ComponentPreview>
+
+### With no icon
+
+export const snippetsNoIcon = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-alert 
+  heading="Order queued" 
+  show-default-icon="false"
+  message="Your coffee order is in the queue. We'll notify you when it's ready to be picked up."
+></ic-alert>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcAlert 
+  heading="Order queued" 
+  showDefaultIcon="false"
+  message="Your coffee order is in the queue. We'll notify you when it's ready to be picked up."
+></IcAlert>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsNoIcon}>
+  <IcAlert
+    heading="Order queued"
+    showDefaultIcon="false"
+    message="Your coffee order is in the queue. We'll notify you when it's ready to be picked up."
+  />
 </ComponentPreview>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add guidance for neutral alert and show default icon prop.

## Related issue

Issue #1126 

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
