### PR TITLE
fix(root): fix website crashing when selecting react on component preview

### DIFF
--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -511,12 +511,16 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
               type={type}
               code={
                 getCodeSnippet(
-                  selectedTab === "Web component" ? snippets[0] : snippets[1]
+                  selectedTab === "Web component"
+                    ? snippets[0]
+                    : snippets[1] ?? snippets[0]
                 )?.codeSnippet || ""
               }
               longCode={
                 getCodeSnippet(
-                  selectedTab === "Web component" ? snippets[0] : snippets[1]
+                  selectedTab === "Web component"
+                    ? snippets[0]
+                    : snippets[1] ?? snippets[0]
                 )?.longCode || ""
               }
               show={show}
@@ -527,16 +531,18 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
               isWebComponents={
                 (selectedTab === "Web component"
                   ? snippets[0].technology
-                  : snippets[1].technology) === "Web component"
+                  : (snippets[1] ?? snippets[0]).technology) === "Web component"
               }
               projectTitle={`${
                 projectTitle || startCase(pageMetadata.pageTitle)
               } (${
                 selectedTab === "Web component"
                   ? snippets[0].technology
-                  : snippets[1].technology
+                  : (snippets[1] ?? snippets[0]).technology
               }${getTypeOfProject(
-                selectedTab === "Web component" ? snippets[0] : snippets[1]
+                selectedTab === "Web component"
+                  ? snippets[0]
+                  : snippets[1] ?? snippets[0]
               )})`}
               projectDescription={
                 projectDescription === undefined || projectDescription === ""


### PR DESCRIPTION
fix website crashing when selecting react on a component preview that only has the react option

fix #1173

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Catch null edge case where there is only one snippet

## Related issue

#1173 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
