### PR TITLE
feat(root): add colour tokens for table of contents light and dark mode

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -3,6 +3,7 @@ import "@ukic/web-components/dist/core/core.css";
 import "@ukic/web-components/dist/core/normalize.css";
 import "./src/styles/gatsby-override.css";
 import "./src/styles/gatsby-reset.css";
+import "./src/styles/color-mode.css";
 
 import React from "react";
 import Layout from "./src/components/Layout";

--- a/src/components/AnchorNav/index.css
+++ b/src/components/AnchorNav/index.css
@@ -9,23 +9,23 @@
 }
 
 .contents-header {
-  color: var(--ic-color-secondary-text);
+  color: var(--table-of-contents-label);
 }
 
 .nav-link {
   padding: var(--ic-space-xs) var(--ic-space-md);
   margin: 0;
-  color: var(--ic-color-primary-text) !important;
+  color: var(--table-of-contents-text) !important;
   transition: var(--ic-easing-transition-fast);
   text-decoration: none !important;
 }
 
-.nav-link:hover:not(:focus) {
-  background-color: var(--ic-architectural-60);
+.nav-link:hover {
+  background-color: var(--table-of-contents-hover);
 }
 
-.nav-link:active:not(:focus) {
-  background-color: var(--ic-architectural-100);
+.nav-link:active {
+  background-color: var(--table-of-contents-pressed);
 }
 
 .nav-link:focus {
@@ -35,8 +35,7 @@
 }
 
 .active-nav-link {
-  padding: var(--ic-space-xs) var(--ic-space-md) var(--ic-space-xs)
-    var(--ic-space-xs);
+  padding: var(--ic-space-xs) var(--ic-space-md) var(--ic-space-xs) var(--ic-space-xs);
   margin: 0 0 0 var(--ic-space-xs);
 }
 
@@ -65,7 +64,7 @@
   content: " ";
   display: block;
   width: var(--ic-space-xs);
-  background: var(--ic-action-default);
+  background: var(--table-of-contents-banner);
 }
 
 @media screen and (max-width: 576px) {

--- a/src/styles/color-mode.css
+++ b/src/styles/color-mode.css
@@ -1,0 +1,20 @@
+/* colors for system light mode/light theme */
+:root,
+ic-theme {
+  --table-of-contents-text: var(--ic-color-text-primary);
+  --table-of-contents-banner: var(--ic-action-default);
+  --table-of-contents-hover: var(--ic-action-default-bg-hover);
+  --table-of-contents-pressed: var(--ic-action-default-bg-active);
+  --table-of-contents-label: var(--ic-color-text-primary);
+}
+
+/* colors for system dark mode */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --table-of-contents-text: var(--ic-color-text-primary);
+    --table-of-contents-banner: var(--ic-action-default);
+    --table-of-contents-hover: var(--ic-action-default-bg-hover);
+    --table-of-contents-pressed: var(--ic-action-default-bg-active);
+    --table-of-contents-label: var(--ic-color-text-primary);
+  }
+}


### PR DESCRIPTION
## Summary of the changes

Added a color-mode.css file to the website. Added colour tokens for light and dark mode of the table of contents / anchor nav component.

I have only added theme changes / code for the table of contents - I believe the rest (e.g. wrapping the whole website in an ic-theme component? Etc.) will be done in #1133.

-----

To view the changes in this PR, add the following to the styles in Chrome DevTools:
```
:root {
  color-scheme: light dark;
}
```
and then click on the paintbrush icon to change between modes.

<img src="https://github.com/user-attachments/assets/641b0eba-0275-4de7-9775-61e5111b3288" width="300">


## Related issue

Part of mi6/ic-ui-kit#1214

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
