### PR TITLE
fix(root): add options array to code example

### DIFF
--- a/src/content/structured/components/multi-select/code.mdx
+++ b/src/content/structured/components/multi-select/code.mdx
@@ -105,6 +105,15 @@ return (
   },
 });
 const classes = useStyles();
+const options = [
+  { label: "Cappuccino", value: "Cap" },
+  { label: "Latte", value: "Lat" },
+  { label: "Americano", value: "Ame" },
+  { label: "Filter", value: "Fil" },
+  { label: "Flat white", value: "Fla" },
+  { label: "Mocha", value: "Moc" },
+  { label: "Macchiato", value: "Mac" },
+];
 return ( 
   <div className={classes.parentContainer}>
     {shortCode}


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes
Added the options array in the multi-select component code examples to fix the issue where the options array was not defined, causing errors when using the component.

## Related issue
 Fixes issue #1198

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
