### PR TITLE
fix(root): added z-index to sticky subsection nav

### DIFF
--- a/src/templates/Standard/index.css
+++ b/src/templates/Standard/index.css
@@ -13,6 +13,7 @@
 .sticky {
   position: sticky;
   top: 0;
+  z-index: var(--ic-z-index-sticky-page-header);
 }
 
 .page-content {


### PR DESCRIPTION
## Summary of the changes
When the subsection nav is sticky, it affects z-indexes further down the tree, so have added an appropriate z-index to the nav to make other floating elements appear over text.

## Related issue
#1210 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
