### PR TITLE
docs(root): add aria-expanded to popover-menu examples

### DIFF
--- a/src/content/structured/components/popover-menu/code.mdx
+++ b/src/content/structured/components/popover-menu/code.mdx
@@ -33,6 +33,7 @@ export const snippets = [
   variant="icon"
   title="More information" 
   onclick="handleClick()"
+  aria-expanded="false"
 >
   <svg
     slot="icon"
@@ -64,8 +65,14 @@ export const snippets = [
       long: `{shortCode}
 <script>
   var icPopover = document.querySelector("#popover-menu");
+  var anchorButton = document.querySelector("#button-1");
   function handleClick() {
     icPopover.open = !icPopover.open;
+    anchorButton.setAttribute('aria-expanded', icPopover.open);
+  }
+  icPopover.addEventListener('icPopoverClosed', handleClose);
+  function handleClose() {
+    anchorButton.setAttribute('aria-expanded', 'false');
   }
 </script>`,
     },
@@ -78,6 +85,7 @@ export const snippets = [
   title="More information"
   id="button-1"
   onClick={handlePopoverToggled}
+  aria-expanded={popoverOpen}
 >
   <SlottedSVG
     slot="icon"
@@ -140,6 +148,7 @@ export const DemoPopover = () => {
         title="More information"
         id="button-1"
         onClick={handlePopoverToggled}
+        aria-expanded={popoverOpen}
       >
         <svg
           slot="icon"
@@ -207,6 +216,7 @@ export const snippetsButtons = [
   variant="icon"
   title="More information" 
   onclick="handleClick()"
+  aria-expanded="false"
 >
   <svg
     slot="icon"
@@ -247,8 +257,14 @@ export const snippetsButtons = [
       long: `{shortCode}
 <script>
   var icPopover = document.querySelector("#popover-menu-2");
+  var anchorButton = document.querySelector("#button-2");
   function handleClick() {
     icPopover.open = !icPopover.open;
+    anchorButton.setAttribute('aria-expanded', icPopover.open);
+  }
+  icPopover.addEventListener('icPopoverClosed', handleClose);
+  function handleClose() {
+    anchorButton.setAttribute('aria-expanded', 'false');
   }
 </script>`,
     },
@@ -261,6 +277,7 @@ export const snippetsButtons = [
   title="More information"
   id="button-2"
   onClick={handlePopoverToggled}
+  aria-expanded={popoverOpen}
 >
   <SlottedSVG
     slot="icon"
@@ -335,6 +352,7 @@ export const ButtonsPopover = () => {
         title="More information"
         id="button-2"
         onClick={handlePopoverToggled}
+        aria-expanded={popoverOpen}
       >
         <svg
           slot="icon"
@@ -401,6 +419,7 @@ export const snippetsGroups = [
   variant="icon"
   title="More information" 
   onclick="handleClick()"
+  aria-expanded="false"
 >
   <svg
     slot="icon"
@@ -423,14 +442,20 @@ export const snippetsGroups = [
     <ic-menu-group>
       <ic-menu-item label="Format"></ic-menu-item>
       <ic-menu-item label="Help"></ic-menu-item>
-    <ic-menu-group>
+    </ic-menu-group>
   </ic-popover-menu>
 </div>`,
       long: `{shortCode}
 <script>
   var icPopover = document.querySelector("#popover-menu-3");
+  var anchorButton = document.querySelector("#button-3");
   function handleClick() {
     icPopover.open = !icPopover.open;
+    anchorButton.setAttribute('aria-expanded', icPopover.open);
+  }
+  icPopover.addEventListener('icPopoverClosed', handleClose);
+  function handleClose() {
+    anchorButton.setAttribute('aria-expanded', 'false');
   }
 </script>`,
     },
@@ -443,6 +468,7 @@ export const snippetsGroups = [
   title="More information"
   id="button-3"
   onClick={handlePopoverToggled}
+  aria-expanded={popoverOpen}
 >
   <SlottedSVG
     slot="icon"
@@ -505,6 +531,7 @@ export const GroupsPopover = () => {
         title="More information"
         id="button-3"
         onClick={handlePopoverToggled}
+        aria-expanded={popoverOpen}
       >
         <svg
           slot="icon"

--- a/src/content/structured/components/popover-menu/guidance.mdx
+++ b/src/content/structured/components/popover-menu/guidance.mdx
@@ -22,7 +22,7 @@ tabs:
 ---
 
 import { IcPopoverMenu, IcMenuItem, IcButton } from "@ukic/react";
-import { useRef } from "react";
+import { useState } from "react";
 import popoverFig1 from "./images/fig-1-use-popover-menu-to-house-secondary-actions.png";
 import popoverFig2 from "./images/fig-2-dont-use-popover-menu-for-few-actions.png";
 import popoverFig3 from "./images/fig-3-set-maxheight-to-force-scroll.png";
@@ -39,17 +39,17 @@ import popoverVid3 from "./images/anim-3-avoid-nested-sub-menus.mp4";
 Click on the 'More Information' button below to view an example of the popover menu component.
 
 export const IntroPopover = () => {
-  const popoverEl = useRef(null);
-  const handleClick = () => {
-    popoverEl.current.open = !popoverEl.current.open;
-  };
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const handlePopoverToggled = () => setPopoverOpen((value) => !value);
+  const handlePopoverClosed = () => setPopoverOpen(false);
   return (
     <>
       <IcButton
         variant="icon"
         title="More information"
         id="button-1"
-        onClick={handleClick}
+        onClick={handlePopoverToggled}
+        aria-expanded={popoverOpen}
       >
         <svg
           slot="icon"
@@ -63,7 +63,7 @@ export const IntroPopover = () => {
           <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
         </svg>
       </IcButton>
-      <IcPopoverMenu anchor="button-1" aria-label="popover" ref={popoverEl}>
+      <IcPopoverMenu anchor="button-1" aria-label="popover" open={popoverOpen} onIcPopoverClosed={handlePopoverClosed}>
         <IcMenuItem label="Copy code" />
         <IcMenuItem label="Paste code" />
         <IcMenuItem label="Actions" submenuTriggerFor="actions" />


### PR DESCRIPTION
## Summary of the changes

Added aria-expanded to popover-menu examples.

## Related issue

#1064 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
