### PR TITLE
feat(root): added dark mode guidance

### DIFF
--- a/src/components/CodePreview/index.css
+++ b/src/components/CodePreview/index.css
@@ -50,7 +50,6 @@
   padding: var(--ic-space-xl) var(--ic-space-md);
   box-sizing: border-box;
   flex-wrap: wrap;
-  background: var(--ic-architectural-white);
 }
 
 .comp-zone.pattern {

--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -492,7 +492,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
               aria-hidden="true"
             />
           ))}
-        <ic-theme theme="light">{children}</ic-theme>
+        {children}
       </div>
       {snippets && (
         <IcTabContext

--- a/src/content/structured/components/accordion/code.mdx
+++ b/src/content/structured/components/accordion/code.mdx
@@ -399,7 +399,7 @@ export const themeDark = [
   </ic-accordion>
 </ic-accordion-group>`,
       long: `.parent-container {
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -448,7 +448,7 @@ export const themeDark = [
           language: "Typescript",
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -462,7 +462,7 @@ return (
           language: "Javascript",
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -479,7 +479,7 @@ return (
 
 <ComponentPreview
   snippets={themeDark}
-  style={{ flexDirection: "column", background: "#333333" }}
+  style={{ flexDirection: "column", background: "#17191c" }}
 >
   <IcAccordionGroup label="Coffee" theme="dark">
     <IcAccordion heading="English Breakfast">

--- a/src/content/structured/components/alerts/code.mdx
+++ b/src/content/structured/components/alerts/code.mdx
@@ -606,7 +606,7 @@ export const snippetsThemeDark = [
 ];
 
 <ComponentPreview
-  style={{ display: "block", background: "#333333" }}
+  style={{ display: "block", background: "#17191c" }}
   snippets={snippetsThemeDark}
 >
   <IcAlert

--- a/src/content/structured/components/badge/code.mdx
+++ b/src/content/structured/components/badge/code.mdx
@@ -1002,7 +1002,7 @@ export const snippetsThemeDark = [
 </ic-button>`,
       long: `.parent-container {
     padding: var(--ic-space-md);
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -1024,7 +1024,7 @@ export const snippetsThemeDark = [
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -1039,7 +1039,7 @@ return (
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -1056,7 +1056,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcButton variant="secondary" appearance="light">
     <IcBadge

--- a/src/content/structured/components/breadcrumbs/code.mdx
+++ b/src/content/structured/components/breadcrumbs/code.mdx
@@ -436,7 +436,7 @@ export const snippetsThemeDark = [
 </ic-breadcrumb-group>`,
       long: `.parent-container {
     padding: var(--ic-space-md);
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -463,7 +463,7 @@ export const snippetsThemeDark = [
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -478,7 +478,7 @@ return (
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -495,7 +495,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcBreadcrumbGroup theme="dark">
     <IcBreadcrumb

--- a/src/content/structured/components/card-horizontal/code.mdx
+++ b/src/content/structured/components/card-horizontal/code.mdx
@@ -1551,7 +1551,7 @@ export const snippetsThemeDark = [
 </ic-card-horizontal>`,
       long: `.parent-container {
     padding: var(--ic-space-md);
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -1604,7 +1604,7 @@ export const snippetsThemeDark = [
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -1619,7 +1619,7 @@ return (
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -1636,7 +1636,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcCardHorizontal
     heading="Americano order"

--- a/src/content/structured/components/card-vertical/code.mdx
+++ b/src/content/structured/components/card-vertical/code.mdx
@@ -2170,7 +2170,7 @@ export const snippetsThemeDark = [
     max-width: 20.375rem;
   }
   .parent-container {
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -2259,7 +2259,7 @@ export const snippetsThemeDark = [
     gap: "var(--ic-space-md)",
   },
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -2286,7 +2286,7 @@ return (
     gap: "var(--ic-space-md)",
   },
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -2303,7 +2303,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcCardVertical
     heading="Americano order"

--- a/src/content/structured/components/checkboxes/code.mdx
+++ b/src/content/structured/components/checkboxes/code.mdx
@@ -67,7 +67,7 @@ export const snippetsDefault = [
   },
 ];
 
-<ComponentPreview snippets={snippetsDefault} style={{ marginTop: "1.5rem" }}>
+<ComponentPreview snippets={snippetsDefault}>
   <IcCheckboxGroup
     label="Select your extras"
     name="default"
@@ -127,10 +127,7 @@ export const snippetsHiddenLabel = [
   },
 ];
 
-<ComponentPreview
-  snippets={snippetsHiddenLabel}
-  style={{ marginTop: "1.5rem" }}
->
+<ComponentPreview snippets={snippetsHiddenLabel}>
   <IcCheckboxGroup label="Select your extras" hideLabel name="1">
     <IcCheckbox value="valueName1" label="Extra shot (50p)" />
     <IcCheckbox value="valueName2" label="Soya milk" checked />
@@ -171,7 +168,7 @@ export const snippetsHelperText = [
   },
 ];
 
-<ComponentPreview snippets={snippetsHelperText} style={{ marginTop: "1.5rem" }}>
+<ComponentPreview snippets={snippetsHelperText}>
   <IcCheckboxGroup
     label="Select your extras"
     name="1"
@@ -353,10 +350,7 @@ export const snippetsConditional = [
   },
 ];
 
-<ComponentPreview
-  snippets={snippetsConditional}
-  style={{ marginTop: "1.5rem" }}
->
+<ComponentPreview snippets={snippetsConditional}>
   <IcCheckboxGroup label="Which coffee do you like best?" name="conditional">
     <IcCheckbox value="americano" label="Americano" />
     <IcCheckbox value="espresso" label="Espresso" />
@@ -421,10 +415,7 @@ export const snippetsConditionalDynamic = [
   },
 ];
 
-<ComponentPreview
-  snippets={snippetsConditionalDynamic}
-  style={{ marginRight: "1rem" }}
->
+<ComponentPreview snippets={snippetsConditionalDynamic}>
   <div style={{ width: "21.875rem" }}>
     <IcCheckboxGroup label="Which coffee do you like best?" name="dynamic">
       <IcCheckbox value="americano" label="Americano" />
@@ -473,7 +464,7 @@ export const snippetsValidation = [
   },
 ];
 
-<ComponentPreview snippets={snippetsValidation} style={{ marginTop: "1.5rem" }}>
+<ComponentPreview snippets={snippetsValidation}>
   <IcCheckboxGroup
     label="Select your extras"
     name="1"
@@ -541,10 +532,7 @@ export const snippetsIndeterminate = [
   },
 ];
 
-<ComponentPreview
-  snippets={snippetsIndeterminate}
-  style={{ marginTop: "1.5rem" }}
->
+<ComponentPreview snippets={snippetsIndeterminate}>
   <IcCheckboxGroup label="Select your preferred drinks" name="1">
     <IcCheckbox value="drinks" label="Drinks" checked indeterminate>
       <IcCheckboxGroup
@@ -585,7 +573,7 @@ export const snippetsThemeDark = [
 </ic-checkbox-group>`,
       long: `.parent-container {
     padding: var(--ic-space-md);
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -612,7 +600,7 @@ export const snippetsThemeDark = [
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -627,7 +615,7 @@ return (
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -644,7 +632,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ marginTop: "1.5rem", background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcCheckboxGroup label="Select your extras" name="default" theme="dark">
     <IcCheckbox value="extra" label="Extra shot (50p)" />

--- a/src/content/structured/components/chips/code.mdx
+++ b/src/content/structured/components/chips/code.mdx
@@ -415,7 +415,7 @@ export const snippetsThemeDark = [
 </ic-chip>`,
       long: `.parent-container {
     padding: var(--ic-space-md);
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -455,7 +455,7 @@ export const snippetsThemeDark = [
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -470,7 +470,7 @@ return (
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -491,7 +491,7 @@ return (
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
-    background: "#333333",
+    background: "#17191c",
   }}
   snippets={snippetsThemeDark}
 >

--- a/src/content/structured/components/data-list/code.mdx
+++ b/src/content/structured/components/data-list/code.mdx
@@ -774,7 +774,7 @@ export const snippetsThemeDark = [
 </ic-data-list>`,
       long: `.parent-container {
     padding: var(--ic-space-md);
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -814,7 +814,7 @@ export const snippetsThemeDark = [
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -829,7 +829,7 @@ return (
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -846,7 +846,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcDataList heading="Order details" style={{ width: "90%" }} theme="dark">
     <IcDataRow label="Drink" value="Americano">

--- a/src/content/structured/components/divider/code.mdx
+++ b/src/content/structured/components/divider/code.mdx
@@ -560,7 +560,7 @@ export const snippetsTheme = [
       label-placement="center"
     ></ic-divider>
   </div>
-  <div style="display: flex; flex-direction: column; gap: var(--ic-space-md); background: #333333; padding: var(--ic-space-md); width: 100%;">
+  <div style="display: flex; flex-direction: column; gap: var(--ic-space-md); background: #17191c; padding: var(--ic-space-md); width: 100%;">
     <ic-divider theme="dark"></ic-divider>
     <ic-divider
       theme="dark"
@@ -611,7 +611,7 @@ export const snippetsTheme = [
       display: "flex",
       flexDirection: "column",
       gap: "var(--ic-space-md)",
-      background: "#333333",
+      background: "#17191c",
       padding: "var(--ic-space-md)",
       width: "100%",
     }}
@@ -649,7 +649,7 @@ export const snippetsTheme = [
       display: "flex",
       flexDirection: "column",
       gap: "var(--ic-space-md)",
-      background: "#333333",
+      background: "#17191c",
       padding: "var(--ic-space-md)",
       width: "100%"
     }}
@@ -686,7 +686,7 @@ export const snippetsTheme = [
       display: "flex",
       flexDirection: "column",
       gap: "var(--ic-space-md)",
-      background: "#333333",
+      background: "#17191c",
       padding: "var(--ic-space-md)",
       width: "100%",
     }}
@@ -726,7 +726,7 @@ export const snippetsMonochrome = [
       label-placement="center"
     ></ic-divider>
   </div>
-  <div style="display: flex; flex-direction: column; gap: var(--ic-space-md); background: #333333; padding: var(--ic-space-md); width: 100%;">
+  <div style="display: flex; flex-direction: column; gap: var(--ic-space-md); background: #17191c; padding: var(--ic-space-md); width: 100%;">
     <ic-divider theme="dark"></ic-divider>
     <ic-divider
       theme="dark"
@@ -781,7 +781,7 @@ export const snippetsMonochrome = [
       display: "flex",
       flexDirection: "column",
       gap: "var(--ic-space-md)",
-      background: "#333333",
+      background: "#17191c",
       padding: "var(--ic-space-md)",
       width: "100%"
     }}
@@ -821,7 +821,7 @@ export const snippetsMonochrome = [
       display: "flex",
       flexDirection: "column",
       gap: "var(--ic-space-md)",
-      background: "#333333",
+      background: "#17191c",
       padding: "var(--ic-space-md)",
       width: "100%"
     }}
@@ -864,7 +864,7 @@ export const snippetsMonochrome = [
       display: "flex",
       flexDirection: "column",
       gap: "var(--ic-space-md)",
-      background: "#333333",
+      background: "#17191c",
       padding: "var(--ic-space-md)",
       width: "100%",
     }}

--- a/src/content/structured/components/empty-state/code.mdx
+++ b/src/content/structured/components/empty-state/code.mdx
@@ -637,7 +637,7 @@ export const snippetsThemeDark = [
 </ic-empty-state>`,
       long: `.parent-container {
     padding: var(--ic-space-md);
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -681,7 +681,7 @@ export const snippetsThemeDark = [
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -696,7 +696,7 @@ return (
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -713,7 +713,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcEmptyState
     heading="Hmm...there's nothing here"

--- a/src/content/structured/components/links/code.mdx
+++ b/src/content/structured/components/links/code.mdx
@@ -113,7 +113,7 @@ export const snippetsTheme = [
     padding: var(--ic-space-xs);
   }
   .dark-background {
-    background: #333333;
+    background: #17191c;
     padding: var(--ic-space-xs);
   }
 </style>
@@ -149,7 +149,7 @@ export const snippetsTheme = [
     padding: 'var(--ic-space-xs)',
   },
   darkBackground: {
-    background: '#333333',
+    background: '#17191c',
     padding: 'var(--ic-space-xs)',
   },
 });
@@ -180,7 +180,7 @@ return (
     padding: 'var(--ic-space-xs)',
   },
   darkBackground: {
-    background: '#333333',
+    background: '#17191c',
     padding: 'var(--ic-space-xs)',
   },
 });
@@ -217,7 +217,7 @@ return (
   </div>
   <div
     style={{
-      background: "#333333",
+      background: "#17191c",
       padding: "0.5rem",
     }}
   >
@@ -243,7 +243,7 @@ export const snippetsLightDark = [
     padding: var(--ic-space-xs);
   }
   .dark-background {
-    background: #333333;
+    background: #17191c;
     padding: var(--ic-space-xs);
   }
 </style>
@@ -279,7 +279,7 @@ export const snippetsLightDark = [
     padding: 'var(--ic-space-xs)',
   },
   darkBackground: {
-    background: '#333333',
+    background: '#17191c',
     padding: 'var(--ic-space-xs)',
   },
 });
@@ -310,7 +310,7 @@ return (
     padding: 'var(--ic-space-xs)',
   },
   darkBackground: {
-    background: '#333333',
+    background: '#17191c',
     padding: 'var(--ic-space-xs)',
   },
 });
@@ -347,7 +347,7 @@ return (
   </div>
   <div
     style={{
-      background: "#333333",
+      background: "#17191c",
       padding: "0.5rem",
     }}
   >

--- a/src/content/structured/components/loading-indicators/code.mdx
+++ b/src/content/structured/components/loading-indicators/code.mdx
@@ -225,7 +225,7 @@ export const snippetsThemeDark = [
       long: `.dark-background {
       flex-direction: column; 
       gap: var(--ic-space-xs); 
-      background: #333333;
+      background: #17191c;
     }
   </style>
     <body>
@@ -247,7 +247,7 @@ export const snippetsThemeDark = [
     display: "flex",
     flexDirection: "column", 
     gap: "var(--ic-space-xs)", 
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -264,7 +264,7 @@ return (
     display: "flex",
     flexDirection: "column", 
     gap: "var(--ic-space-xs)", 
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -281,7 +281,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ flexDirection: "column", gap: "0.5rem", background: "#333333" }}
+  style={{ flexDirection: "column", gap: "0.5rem", background: "#17191c" }}
 >
   <IcLoadingIndicator type="circular" label="Loading" theme="dark" />
   <IcLoadingIndicator type="linear" label="Loading" theme="dark" />

--- a/src/content/structured/components/pagination/code.mdx
+++ b/src/content/structured/components/pagination/code.mdx
@@ -55,14 +55,13 @@ export const snippets = [
   },
 ];
 
-<ComponentPreview
-  style={{ display: "block", margin: "auto" }}
-  snippets={snippets}
->
+<ComponentPreview style={{ display: "block" }} snippets={snippets}>
   <div style={{ width: "fit-content", margin: "auto" }}>
     <IcPagination pages={15} />
   </div>
-  <IcPagination pages={15} type="complex" />
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination pages={15} type="complex" />
+  </div>
 </ComponentPreview>
 
 ## Pagination details
@@ -102,11 +101,10 @@ export const hideFirstLast = [
   },
 ];
 
-<ComponentPreview
-  style={{ display: "block", margin: "auto" }}
-  snippets={hideFirstLast}
->
-  <IcPagination hideFirstAndLastPageButton pages={15} />
+<ComponentPreview style={{ display: "block" }} snippets={hideFirstLast}>
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination hideFirstAndLastPageButton pages={15} />
+  </div>
 </ComponentPreview>
 
 ### Hide current page (only in 'simple' type)
@@ -137,11 +135,10 @@ export const hideCurrent = [
   },
 ];
 
-<ComponentPreview
-  style={{ display: "block", margin: "auto" }}
-  snippets={hideCurrent}
->
-  <IcPagination hideCurrentPage pages={15} />
+<ComponentPreview style={{ display: "block" }} snippets={hideCurrent}>
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination hideCurrentPage pages={15} />
+  </div>
 </ComponentPreview>
 
 ### Theme
@@ -191,9 +188,17 @@ return (
   },
 ];
 
-<ComponentPreview style={{ display: "block", margin: "auto" }} snippets={theme}>
-  <IcPagination theme="light" pages={15} />
-  <div style={{ backgroundColor: "#000", marginBottom: "0.75rem" }}>
+<ComponentPreview style={{ display: "block" }} snippets={theme}>
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination theme="light" pages={15} />
+  </div>
+  <div
+    style={{
+      backgroundColor: "#17191c",
+      margin: "0.75rem auto",
+      width: "fit-content",
+    }}
+  >
     <IcPagination theme="dark" pages={15} />
   </div>
 </ComponentPreview>
@@ -245,12 +250,17 @@ return (
   },
 ];
 
-<ComponentPreview
-  style={{ display: "block", margin: "auto" }}
-  snippets={monochrome}
->
-  <IcPagination theme="light" monochrome pages={15} />
-  <div style={{ backgroundColor: "#000", marginBottom: "0.75rem" }}>
+<ComponentPreview style={{ display: "block" }} snippets={monochrome}>
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination theme="light" monochrome pages={15} />
+  </div>
+  <div
+    style={{
+      backgroundColor: "#17191c",
+      margin: "0.75rem auto",
+      width: "fit-content",
+    }}
+  >
     <IcPagination theme="dark" monochrome pages={15} />
   </div>
 </ComponentPreview>
@@ -293,16 +303,15 @@ export const boundaryAdjacent = [
   },
 ];
 
-<ComponentPreview
-  style={{ display: "block", margin: "auto" }}
-  snippets={boundaryAdjacent}
->
-  <IcPagination
-    type="complex"
-    adjacentPageCount={2}
-    boundaryPageCount={2}
-    pages={15}
-  />
+<ComponentPreview style={{ display: "block" }} snippets={boundaryAdjacent}>
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination
+      type="complex"
+      adjacentPageCount={2}
+      boundaryPageCount={2}
+      pages={15}
+    />
+  </div>
 </ComponentPreview>
 
 ### Disabled
@@ -333,11 +342,10 @@ export const disabled = [
   },
 ];
 
-<ComponentPreview
-  style={{ display: "block", margin: "auto" }}
-  snippets={disabled}
->
-  <IcPagination type="complex" disabled pages={12} />
+<ComponentPreview style={{ display: "block" }} snippets={disabled}>
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination type="complex" disabled pages={12} />
+  </div>
 </ComponentPreview>
 
 ### Label
@@ -369,7 +377,9 @@ export const label = [
 ];
 
 <ComponentPreview style={{ display: "block", margin: "auto" }} snippets={label}>
-  <IcPagination label="Slide" pages={12} />
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination label="Slide" pages={12} />
+  </div>
 </ComponentPreview>
 
 ### Default page
@@ -404,5 +414,7 @@ export const defaultPage = [
   style={{ display: "block", margin: "auto" }}
   snippets={defaultPage}
 >
-  <IcPagination pages={12} defaultPage={4} />
+  <div style={{ width: "fit-content", margin: "auto" }}>
+    <IcPagination pages={12} defaultPage={4} />
+  </div>
 </ComponentPreview>

--- a/src/content/structured/components/pagination/guidance.mdx
+++ b/src/content/structured/components/pagination/guidance.mdx
@@ -35,8 +35,10 @@ import paginationFig8 from "./images/fig-8-pagination-bars-with-different-elemen
 
 Pagination enables large amounts of content to be split across multiple pages so that it is more manageable and doesn’t require overly long page lengths.
 
-<ComponentPreview style={{ margin: "auto" }}>
-  <IcPagination pages={15} type="complex" />
+<ComponentPreview>
+  <div style={{ margin: "auto", width: "fit-content" }}>
+    <IcPagination pages={15} type="complex" />
+  </div>
 </ComponentPreview>
 
 ## Component variants

--- a/src/content/structured/components/popover-menu/code.mdx
+++ b/src/content/structured/components/popover-menu/code.mdx
@@ -36,7 +36,6 @@ export const snippets = [
   aria-expanded="false"
 >
   <svg
-    slot="icon"
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
@@ -88,12 +87,11 @@ export const snippets = [
   aria-expanded={popoverOpen}
 >
   <SlottedSVG
-    slot="icon"
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
     fill="currentColor"
-    class="bi bi-three-dots-vertical"
+    className="bi bi-three-dots-vertical"
     viewBox="0 0 16 16"
   >
     <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
@@ -151,12 +149,11 @@ export const DemoPopover = () => {
         aria-expanded={popoverOpen}
       >
         <svg
-          slot="icon"
           xmlns="http://www.w3.org/2000/svg"
           width="16"
           height="16"
           fill="currentColor"
-          class="bi bi-three-dots-vertical"
+          className="bi bi-three-dots-vertical"
           viewBox="0 0 16 16"
         >
           <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
@@ -219,7 +216,6 @@ export const snippetsButtons = [
   aria-expanded="false"
 >
   <svg
-    slot="icon"
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
@@ -279,17 +275,16 @@ export const snippetsButtons = [
   onClick={handlePopoverToggled}
   aria-expanded={popoverOpen}
 >
-  <SlottedSVG
-    slot="icon"
+  <svg
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
     fill="currentColor"
-    class="bi bi-three-dots-vertical"
+    className="bi bi-three-dots-vertical"
     viewBox="0 0 16 16"
   >
     <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
-  </SlottedSVG>
+  </svg>
 </IcButton>
 <IcPopoverMenu anchor="button-2" aria-label="popover" open={popoverOpen} onIcPopoverClosed={handlePopoverClosed}>
   <IcMenuItem label="Copy" disabled />
@@ -355,12 +350,11 @@ export const ButtonsPopover = () => {
         aria-expanded={popoverOpen}
       >
         <svg
-          slot="icon"
           xmlns="http://www.w3.org/2000/svg"
           width="16"
           height="16"
           fill="currentColor"
-          class="bi bi-three-dots-vertical"
+          className="bi bi-three-dots-vertical"
           viewBox="0 0 16 16"
         >
           <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
@@ -422,7 +416,6 @@ export const snippetsGroups = [
   aria-expanded="false"
 >
   <svg
-    slot="icon"
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
@@ -470,17 +463,16 @@ export const snippetsGroups = [
   onClick={handlePopoverToggled}
   aria-expanded={popoverOpen}
 >
-  <SlottedSVG
-    slot="icon"
+  <svg
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
     fill="currentColor"
-    class="bi bi-three-dots-vertical"
+    className="bi bi-three-dots-vertical"
     viewBox="0 0 16 16"
   >
     <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
-  </SlottedSVG>
+  </svg>
 </IcButton>
 <IcPopoverMenu anchor="button-3" aria-label="popover" open={popoverOpen} onIcPopoverClosed={handlePopoverClosed}>
   <IcMenuGroup label="Edit options">
@@ -534,12 +526,11 @@ export const GroupsPopover = () => {
         aria-expanded={popoverOpen}
       >
         <svg
-          slot="icon"
           xmlns="http://www.w3.org/2000/svg"
           width="16"
           height="16"
           fill="currentColor"
-          class="bi bi-three-dots-vertical"
+          className="bi bi-three-dots-vertical"
           viewBox="0 0 16 16"
         >
           <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
@@ -581,13 +572,13 @@ export const snippetsThemeDark = [
     technology: "Web component",
     snippets: {
       short: `<ic-button 
-  id="button-1" 
+  id="button-4" 
   variant="icon"
   title="More information" 
   onclick="handleClick()"
+  theme="dark"
 >
   <svg
-    slot="icon"
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
@@ -599,7 +590,7 @@ export const snippetsThemeDark = [
   </svg>
 </ic-button>
 <div>
-  <ic-popover-menu theme="dark" anchor="button-1" aria-label="popover" id="popover-menu">
+  <ic-popover-menu theme="dark" anchor="button-4" aria-label="popover" id="popover-menu">
     <ic-menu-item label="Copy code"></ic-menu-item>
     <ic-menu-item label="Paste code"></ic-menu-item>
     <ic-menu-item
@@ -628,24 +619,24 @@ export const snippetsThemeDark = [
       short: `<IcButton
   variant="icon"
   title="More information"
-  id="button-1"
+  id="button-4"
   onClick={handlePopoverToggled}
+  theme="dark"
 >
-  <SlottedSVG
-    slot="icon"
+  <svg
     xmlns="http://www.w3.org/2000/svg"
     width="16"
     height="16"
     fill="currentColor"
-    class="bi bi-three-dots-vertical"
+    className="bi bi-three-dots-vertical"
     viewBox="0 0 16 16"
   >
     <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
-  </SlottedSVG>
+  </svg>
 </IcButton>
 <IcPopoverMenu 
   theme="dark" 
-  anchor="button-1" 
+  anchor="button-4" 
   aria-label="popover" 
   open={popoverOpen} 
   onIcPopoverClosed={handlePopoverClosed}
@@ -696,23 +687,23 @@ export const ThemeDarkPopover = () => {
       <IcButton
         variant="icon"
         title="More information"
-        id="button-1"
+        id="button-4"
         onClick={handlePopoverToggled}
+        theme="dark"
       >
         <svg
-          slot="icon"
           xmlns="http://www.w3.org/2000/svg"
           width="16"
           height="16"
           fill="currentColor"
-          class="bi bi-three-dots-vertical"
+          className="bi bi-three-dots-vertical"
           viewBox="0 0 16 16"
         >
           <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
         </svg>
       </IcButton>
       <IcPopoverMenu
-        anchor="button-1"
+        anchor="button-4"
         aria-label="popover"
         open={popoverOpen}
         onIcPopoverClosed={handlePopoverClosed}
@@ -735,6 +726,7 @@ export const ThemeDarkPopover = () => {
   style={{
     display: "flex",
     justifyContent: "center",
+    background: "#17191c",
   }}
   snippets={snippetsThemeDark}
 >

--- a/src/content/structured/components/popover-menu/guidance.mdx
+++ b/src/content/structured/components/popover-menu/guidance.mdx
@@ -52,12 +52,11 @@ export const IntroPopover = () => {
         aria-expanded={popoverOpen}
       >
         <svg
-          slot="icon"
           xmlns="http://www.w3.org/2000/svg"
           width="16"
           height="16"
           fill="currentColor"
-          class="bi bi-three-dots-vertical"
+          className="bi bi-three-dots-vertical"
           viewBox="0 0 16 16"
         >
           <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />

--- a/src/content/structured/components/radio/code.mdx
+++ b/src/content/structured/components/radio/code.mdx
@@ -78,7 +78,7 @@ export const snippets = [
   },
 ];
 
-<ComponentPreview style={{ marginTop: "1.5rem" }} snippets={snippets}>
+<ComponentPreview snippets={snippets}>
   <IcRadioGroup
     name="radio-group-1"
     label="Add a free purchase with any hot drink"
@@ -164,7 +164,7 @@ name="radio-group-2"
   },
 ];
 
-<ComponentPreview style={{ marginTop: "1.5rem" }} snippets={conditional}>
+<ComponentPreview snippets={conditional}>
   <IcRadioGroup name="radio-group-2" label="Do you have any special requests?">
     <IcRadioOption value="request" label="Yes, I want to modify my order">
       <IcTextField
@@ -311,7 +311,7 @@ export const withHelperText = [
   },
 ];
 
-<ComponentPreview style={{ marginTop: "1.5rem" }} snippets={withHelperText}>
+<ComponentPreview snippets={withHelperText}>
   <IcRadioGroup
     label="Do you have any special requests?"
     helperText="Let us know if you'd like an alternative to dairy milk."
@@ -370,7 +370,7 @@ export const smallSnippet = [
   },
 ];
 
-<ComponentPreview style={{ marginTop: "1.5rem" }} snippets={smallSnippet}>
+<ComponentPreview snippets={smallSnippet}>
   <IcRadioGroup
     label="Do you have any special requests?"
     name="radio-group-5"
@@ -433,7 +433,7 @@ export const withValidation = [
   },
 ];
 
-<ComponentPreview style={{ marginTop: "1.5rem" }} snippets={withValidation}>
+<ComponentPreview snippets={withValidation}>
   <IcRadioGroup
     label="Do you have any special requests?"
     validationStatus="error"
@@ -471,7 +471,7 @@ export const snippetsThemeDark = [
   ></ic-radio-option>
 </ic-radio-group>`,
       long: `.parent-container {
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -502,7 +502,7 @@ export const snippetsThemeDark = [
           language: "Typescript",
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -516,7 +516,7 @@ return (
           language: "Javascript",
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -532,7 +532,7 @@ return (
 ];
 
 <ComponentPreview
-  style={{ marginTop: "1.5rem", background: "#333333" }}
+  style={{ background: "#17191c" }}
   snippets={snippetsThemeDark}
 >
   <IcRadioGroup

--- a/src/content/structured/components/radio/guidance.mdx
+++ b/src/content/structured/components/radio/guidance.mdx
@@ -37,7 +37,7 @@ import radioFig10 from "./images/fig-10-only-display-the-error-on-the-field-caus
 
 An example of the radio button component.
 
-<ComponentPreview style={{ marginTop: "1.5rem" }}>
+<ComponentPreview>
   <IcRadioGroup label="Add a free purchase with any hot drink" name="snacks">
     <IcRadioOption value="crisps" label="Crisps" />
     <IcRadioOption

--- a/src/content/structured/components/search-bar/code.mdx
+++ b/src/content/structured/components/search-bar/code.mdx
@@ -875,7 +875,7 @@ export const snippetsThemeDark = [
 ></ic-search-bar>`,
       long: `.parent-container {
     padding: var(--ic-space-md);
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -918,7 +918,7 @@ export const snippetsThemeDark = [
 const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -941,7 +941,7 @@ return (
 const useStyles = createUseStyles({
   parentContainer: {
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -958,7 +958,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcSearchBar
     label="What is your favourite coffee?"

--- a/src/content/structured/components/status-tags/code.mdx
+++ b/src/content/structured/components/status-tags/code.mdx
@@ -389,7 +389,7 @@ export const snippetsThemeDark = [
       gap: var(--ic-space-xs);
       flex-wrap: wrap;
       padding: var(--ic-space-md);
-      background: #333333;
+      background: #17191c;
     }
   </style>
   <body>
@@ -414,7 +414,7 @@ export const snippetsThemeDark = [
     flexWrap: "wrap",
     gap: "var(--ic-space-xs)",
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -432,7 +432,7 @@ return (
     flexWrap: "wrap",
     gap: "var(--ic-space-xs)",
     padding: "var(--ic-space-md)",
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -448,7 +448,7 @@ return (
 ];
 
 <ComponentPreview
-  style={{ gap: "0.5rem", background: "#333333" }}
+  style={{ gap: "0.5rem", background: "#17191c" }}
   snippets={snippetsThemeDark}
 >
   <IcStatusTag label="Neutral" status="neutral" theme="dark" />

--- a/src/content/structured/components/stepper/code.mdx
+++ b/src/content/structured/components/stepper/code.mdx
@@ -336,7 +336,7 @@ export const snippetsThemeDark = [
   <ic-step heading="Collect" type="disabled"></ic-step>
 </ic-stepper>`,
       long: `.parent-container {
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -358,7 +358,7 @@ export const snippetsThemeDark = [
           language: "Typescript",
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -372,7 +372,7 @@ return (
           language: "Javascript",
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();

--- a/src/content/structured/components/switch/code.mdx
+++ b/src/content/structured/components/switch/code.mdx
@@ -276,7 +276,7 @@ export const snippetsThemeDark = [
     snippets: {
       short: `<ic-switch label="Coffee preferences" theme="dark"></ic-switch>`,
       long: `parent-container {
-    background: #333333;
+    background: #17191c;
   }
 </style>
 <body>
@@ -297,7 +297,7 @@ export const snippetsThemeDark = [
           language: "Typescript",
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -311,7 +311,7 @@ return (
           language: "Javascript",
           snippet: `const useStyles = createUseStyles({
   parentContainer: {
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -328,7 +328,7 @@ return (
 
 <ComponentPreview
   snippets={snippetsThemeDark}
-  style={{ background: "#333333" }}
+  style={{ background: "#17191c" }}
 >
   <IcSwitch label="Coffee preferences" theme="dark" />
 </ComponentPreview>

--- a/src/content/structured/components/tree-view/code.mdx
+++ b/src/content/structured/components/tree-view/code.mdx
@@ -568,7 +568,7 @@ export const snippetsTheme = [
       long: `.dark-background {
       flex-direction: column; 
       gap: var(--ic-space-xs); 
-      background: #333333;
+      background: #17191c;
     }
   </style>
     <body>
@@ -624,7 +624,7 @@ export const snippetsTheme = [
     display: "flex",
     flexDirection: "column", 
     gap: "var(--ic-space-xs)", 
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -641,7 +641,7 @@ return (
     display: "flex",
     flexDirection: "column", 
     gap: "var(--ic-space-xs)", 
-    background: "#333333",
+    background: "#17191c",
   },
 });
 const classes = useStyles();
@@ -656,7 +656,7 @@ return (
   },
 ];
 
-<ComponentPreview snippets={snippetsTheme} style={{ background: "#333333" }}>
+<ComponentPreview snippets={snippetsTheme} style={{ background: "#17191c" }}>
   <div style={{ width: "250px" }}>
     <IcTreeView heading="Menu" theme="dark">
       <SlottedSVG

--- a/src/content/structured/get-started/custom-theme.mdx
+++ b/src/content/structured/get-started/custom-theme.mdx
@@ -3,24 +3,31 @@ path: "/get-started/install-components/custom-theme"
 
 navPriority: 9
 
-date: "2024-02-05"
+date: "2024-12-02"
 
-title: "Custom theme"
+title: "Custom theme and branding"
 
-subTitle: "How to change the theme colour of some components."
+subTitle: "How to change the theme and brand colours of some components."
 
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/custom-theme.mdx"
 ---
 
+import { useState } from "react";
+import { IcAlert, IcButton, IcTheme } from "@ukic/react";
+
 ## Customising component colours
 
-Some components can have their theme colour changed by using either of the methods below. When the theme colour is changed, components will automatically update.
+Some components can have their 'brand' colour changed by using either of the methods below. When the 'brand' colour is changed, components will automatically update.
 
 Other styles on affected components will also adapt accordingly, such as the colour of text or icons.
 
+Components that follow the 'brand' colour will not update in the same way as other components when adapting to dark mode. Instead their appearance will only adjust to match the contrast of the 'brand' colour.
+
+Branding is not the same as theming. With theming, component colours can be modified using a more fine-grained approach, allowing total control over their appearance. Branding focuses on the core structural components of an application, and creates an appearance that is recognisable to a user.
+
 ## CSS variables
 
-You can set the theme colour by using the three CSS variables (one for each of the RGB values for the colour) shown below:
+You can set the 'brand' colour by using the three CSS variables (one for each of the RGB values for the colour) shown below:
 
 ```css
 :root {
@@ -39,9 +46,150 @@ Alternatively, you can include the `ic-theme` component and set the `color` prop
 <ic-theme color="#5c0949"></ic-theme>
 ```
 
-### Components that use the theme colour
+The components that use the 'brand' colour are:
 
 - [Footer](/components/footer)
 - [Hero](/components/hero)
 - [Side navigation](/components/side-navigation)
 - [Top navigation](/components/top-navigation)
+
+### Theme details
+
+<ComponentDetails component="ic-theme" />
+
+## Dark mode as a theme
+
+Most component's variants can be displayed using dark mode colours. This creates better colour contrast with backgrounds, borders and text for when components need to be used on dark backgrounds.
+
+These component has been given a `theme` prop, taking values of `inherit` (default), `light` and `dark`. By setting the value to either `light` or `dark` at the component level, those components will display dark mode colours, independent of any higher level themes or system settings.
+
+By leaving the theme prop as the default value (`inherit`), it will decide the colours based on either a high-level `ic-theme` component, or if one does not exist, the browser/system settings.
+
+### Example
+
+When implementing dark mode into an app without an `ic-theme` wrapper, the components will default to the browser/system settings unless overridden manually. If using a fixed background colour, this will need to be considered as user's system settings may cause dark components to render on a light background, for example.
+
+See the [Dark mode pattern](/patterns/dark-mode) for an example of how to implement dark mode into an application.
+
+export const snippetsDefault = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-button onclick="handleClick()">Update ic-theme</ic-button>
+<ic-theme class="theme-container" theme="light">
+  <ic-alert heading="Set at component level" variant="info" theme="light"></ic-alert>
+  <ic-alert heading="Inherits from ic-theme" variant="info"></ic-alert>
+</ic-theme>
+<ic-alert heading="Inherits from system/browser settings" variant="info"></ic-alert>`,
+      long: `.theme-container {
+    border: "1px solid var(--ic-architectural-white)",
+    padding: "var(--ic-space-sm)"
+  }
+</style>
+<body>
+  <div>
+    {shortCode}
+  </div>
+  <script>
+    function handleClick() {
+      theme = document.querySelector("ic-theme");
+      theme.theme = theme.theme === "light" ? "dark" : "light";
+    }
+  </script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcButton onClick={handleClick}>Update ic-theme</IcButton>
+<IcTheme theme={theme} className={classes.themeContainer}>
+  <IcAlert heading="Set at component level" variant="info" theme="light" />
+  <IcAlert heading="Inherits from ic-theme" variant="info" />
+</IcTheme>
+<IcAlert heading="Inherits from system/browser settings" variant="info" />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const [theme, setTheme] = useState<"light" | "dark">("light");
+const handleClick = () => {
+  setTheme(theme === "light" ? "dark" : "light");
+};
+const useStyles = createUseStyles({
+  themeContainer: {
+    border: "1px solid var(--ic-architectural-white)",
+    padding: "var(--ic-space-sm)"
+  },
+});
+const classes = useStyles();
+<>
+  {shortCode}
+</>`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const [theme, setTheme] = useState("light");
+const handleClick = () => {
+  setTheme(theme === "light" ? "dark" : "light");
+};
+const useStyles = createUseStyles({
+  themeContainer: {
+    border: "1px solid var(--ic-architectural-white)",
+    padding: "var(--ic-space-sm)"
+  },
+});
+const classes = useStyles();
+<>
+  {shortCode}
+</>`,
+        },
+      ],
+    },
+  },
+];
+
+export const DarkModeExample = () => {
+  const [theme, setTheme] = useState("light");
+  const handleClick = () => {
+    setTheme(theme === "light" ? "dark" : "light");
+  };
+  return (
+    <>
+      <IcButton onClick={handleClick}>Update ic-theme</IcButton>
+      <IcTheme
+        theme={theme}
+        style={{
+          border: "1px solid var(--ic-architectural-white)",
+          padding: "var(--ic-space-sm)",
+        }}
+      >
+        <IcAlert
+          heading="Set at component level"
+          variant="info"
+          theme="light"
+        />
+        <IcAlert heading="Inherits from ic-theme" variant="info" />
+      </IcTheme>
+      <IcAlert heading="Inherits from system/browser settings" variant="info" />
+    </>
+  );
+};
+
+<ComponentPreview
+  style={{
+    flexDirection: "column",
+    gap: "var(--ic-space-sm)",
+    background: "#17191c",
+  }}
+  snippets={snippetsDefault}
+>
+  <DarkModeExample />
+</ComponentPreview>
+
+## Monochrome
+
+The `monochrome` prop can be set to `true` to remove the colour from components to help them display on certain backgrounds. It will display as either black or white, switching between the two based on the dark mode preference mentioned above.
+
+<ComponentPreview style={{ gap: "var(--ic-space-sm)" }}>
+  <IcButton>Regular</IcButton>
+  <IcButton monochrome>Monochrome</IcButton>
+</ComponentPreview>

--- a/src/content/structured/get-started/install-components.mdx
+++ b/src/content/structured/get-started/install-components.mdx
@@ -12,6 +12,8 @@ subTitle: "Install and use the UI Kit component library. Use React or web compon
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/install-components.mdx"
 ---
 
+import { IcAlert } from "@ukic/react";
+
 ## Installing the components
 
 <p>
@@ -35,6 +37,21 @@ npm install @ukic/react @ukic/fonts
 ```
 
 ## Using the components
+
+<IcAlert
+  heading="Components automatically switch colours based on the user's system settings"
+  variant="warning"
+>
+  <span slot="message">
+    When the ic-theme component is not implemented, components will default to
+    the user's system colour scheme. Please keep this in mind when styling your
+    application. See the{" "}
+    <ic-link href="/get-started/install-components/custom-theme/#dark-mode-as-a-theme">
+      theming guidance
+    </ic-link>{" "}
+    for more information.
+  </span>
+</IcAlert>
 
 To use the components in a particular framework, follow the framework instructions.
 

--- a/src/content/structured/patterns/dark-mode.mdx
+++ b/src/content/structured/patterns/dark-mode.mdx
@@ -1,0 +1,344 @@
+---
+path: "/patterns/dark-mode"
+
+navPriority: 6
+
+date: "2024-12-02"
+
+title: "Dark mode"
+
+subTitle: "Use the dark mode pattern to quickly implement theming into an application."
+---
+
+import { IcLink } from "@ukic/react";
+import { createReactAppTsx } from "./components/StackblitzButton/stackblitz-helpers";
+
+## Introduction
+
+This pattern details how to implement dark mode theme switching into an application using a top navigation. A similar approach has been used in the ICDS guidance site.
+
+export const snippetsTopNav = [
+  {
+    technology: "Web component",
+    snippets: {
+      long: `<ic-theme theme="light">
+    <ic-top-navigation
+      app-title="[Enter your application name]"
+      status="alpha"
+      version="v0.0.7"
+      content-aligned="center"
+    >
+      <svg
+        slot="app-icon"
+        xmlns="http://www.w3.org/2000/svg" 
+        viewBox="0 0 24 24" 
+        fill="#000000"
+        width="24"
+        height="24"
+      >
+        <path d="M0 0h24v24H0V0z" fill="none" />
+        <path
+          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z"
+        />
+      </svg>
+      <ic-navigation-button id="theme-toggle" label="Turn on light mode" slot="buttons" onclick="toggleTheme()">
+        <svg
+          slot="icon"
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g id="Icon">
+            <path
+              id="Vector"
+              d="M14.5 2C16.32 2 18.03 2.5 19.5 3.35C16.51 5.08 14.5 8.3 14.5 12C14.5 15.7 16.51 18.92 19.5 20.65C18.03 21.5 16.32 22 14.5 22C8.98 22 4.5 17.52 4.5 12C4.5 6.48 8.98 2 14.5 2Z"
+              fill="currentColor"
+            />
+          </g>
+        </svg>
+      </ic-navigation-button>
+    </ic-top-navigation>
+    <main>
+      <ic-section-container class="main-section-container" aligned="center">
+        <div class="main-content-div">
+          <ic-alert heading="See how the content changes" variant="info"></ic-alert>
+          <ic-typography variant="h2">
+            <h2>Example heading</h2>
+          </ic-typography>
+          <ic-typography variant="subtitle-large">
+            <p>Example sub-heading</p>
+          </ic-typography>
+        </div>
+      </ic-section-container>
+    </main>
+  </ic-theme>
+  <script>
+    const LIGHT_ICON = '<svg
+      slot="icon"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g id="Icon">
+        <path
+          id="Vector"
+          d="M14.5 2C16.32 2 18.03 2.5 19.5 3.35C16.51 5.08 14.5 8.3 14.5 12C14.5 15.7 16.51 18.92 19.5 20.65C18.03 21.5 16.32 22 14.5 22C8.98 22 4.5 17.52 4.5 12C4.5 6.48 8.98 2 14.5 2Z"
+          fill="currentColor"
+        />
+      </g>
+    </svg>';
+    const DARK_ICON = '<svg
+      slot="icon"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g id="Icon">
+        <path
+          id="Vector"
+          d="M12 7C9.24 7 7 9.24 7 12C7 14.76 9.24 17 12 17C14.76 17 17 14.76 17 12C17 9.24 14.76 7 12 7ZM2 13H4C4.55 13 5 12.55 5 12C5 11.45 4.55 11 4 11H2C1.45 11 1 11.45 1 12C1 12.55 1.45 13 2 13ZM20 13H22C22.55 13 23 12.55 23 12C23 11.45 22.55 11 22 11H20C19.45 11 19 11.45 19 12C19 12.55 19.45 13 20 13ZM11 2V4C11 4.55 11.45 5 12 5C12.55 5 13 4.55 13 4V2C13 1.45 12.55 1 12 1C11.45 1 11 1.45 11 2ZM11 20V22C11 22.55 11.45 23 12 23C12.55 23 13 22.55 13 22V20C13 19.45 12.55 19 12 19C11.45 19 11 19.45 11 20ZM5.99 4.58C5.6 4.19 4.96 4.19 4.58 4.58C4.19 4.97 4.19 5.61 4.58 5.99L5.64 7.05C6.03 7.44 6.67 7.44 7.05 7.05C7.43 6.66 7.44 6.02 7.05 5.64L5.99 4.58ZM18.36 16.95C17.97 16.56 17.33 16.56 16.95 16.95C16.56 17.34 16.56 17.98 16.95 18.36L18.01 19.42C18.4 19.81 19.04 19.81 19.42 19.42C19.81 19.03 19.81 18.39 19.42 18.01L18.36 16.95ZM19.42 5.99C19.81 5.6 19.81 4.96 19.42 4.58C19.03 4.19 18.39 4.19 18.01 4.58L16.95 5.64C16.56 6.03 16.56 6.67 16.95 7.05C17.34 7.43 17.98 7.44 18.36 7.05L19.42 5.99ZM7.05 18.36C7.44 17.97 7.44 17.33 7.05 16.95C6.66 16.56 6.02 16.56 5.64 16.95L4.58 18.01C4.19 18.4 4.19 19.04 4.58 19.42C4.97 19.8 5.61 19.81 5.99 19.42L7.05 18.36Z"
+          fill="currentColor"
+        />
+      </g>
+    </svg>';
+    function toggleTheme() {
+      theme = document.querySelector("ic-theme");
+      navButton = document.querySelector("#theme-toggle");
+      const currentTheme = theme.theme;
+      theme.theme = currentTheme === "light" ? "dark" : "light";
+      navButton.innerHTML = currentTheme === "light" ? DARK_ICON : LIGHT_ICON;
+      navButton.label = \`Turn on \${theme === "light" ? "dark" : "light"} mode\`;
+    }
+  </script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      long: [
+        {
+          language: "Typescript",
+          snippet: createReactAppTsx(
+            `  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const handleToggle = () => {
+    setTheme(theme === "light" ? "dark" : "light");
+  };
+  const DarkIcon = () => (
+    <SlottedSVG
+      slot="icon"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g id="Icon">
+        <path
+          id="Vector"
+          d="M14.5 2C16.32 2 18.03 2.5 19.5 3.35C16.51 5.08 14.5 8.3 14.5 12C14.5 15.7 16.51 18.92 19.5 20.65C18.03 21.5 16.32 22 14.5 22C8.98 22 4.5 17.52 4.5 12C4.5 6.48 8.98 2 14.5 2Z"
+          fill="currentColor"
+        />
+      </g>
+    </SlottedSVG>
+  );
+  const LightIcon = () => (
+    <SlottedSVG
+      slot="icon"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g id="Icon">
+        <path
+          id="Vector"
+          d="M12 7C9.24 7 7 9.24 7 12C7 14.76 9.24 17 12 17C14.76 17 17 14.76 17 12C17 9.24 14.76 7 12 7ZM2 13H4C4.55 13 5 12.55 5 12C5 11.45 4.55 11 4 11H2C1.45 11 1 11.45 1 12C1 12.55 1.45 13 2 13ZM20 13H22C22.55 13 23 12.55 23 12C23 11.45 22.55 11 22 11H20C19.45 11 19 11.45 19 12C19 12.55 19.45 13 20 13ZM11 2V4C11 4.55 11.45 5 12 5C12.55 5 13 4.55 13 4V2C13 1.45 12.55 1 12 1C11.45 1 11 1.45 11 2ZM11 20V22C11 22.55 11.45 23 12 23C12.55 23 13 22.55 13 22V20C13 19.45 12.55 19 12 19C11.45 19 11 19.45 11 20ZM5.99 4.58C5.6 4.19 4.96 4.19 4.58 4.58C4.19 4.97 4.19 5.61 4.58 5.99L5.64 7.05C6.03 7.44 6.67 7.44 7.05 7.05C7.43 6.66 7.44 6.02 7.05 5.64L5.99 4.58ZM18.36 16.95C17.97 16.56 17.33 16.56 16.95 16.95C16.56 17.34 16.56 17.98 16.95 18.36L18.01 19.42C18.4 19.81 19.04 19.81 19.42 19.42C19.81 19.03 19.81 18.39 19.42 18.01L18.36 16.95ZM19.42 5.99C19.81 5.6 19.81 4.96 19.42 4.58C19.03 4.19 18.39 4.19 18.01 4.58L16.95 5.64C16.56 6.03 16.56 6.67 16.95 7.05C17.34 7.43 17.98 7.44 18.36 7.05L19.42 5.99ZM7.05 18.36C7.44 17.97 7.44 17.33 7.05 16.95C6.66 16.56 6.02 16.56 5.64 16.95L4.58 18.01C4.19 18.4 4.19 19.04 4.58 19.42C4.97 19.8 5.61 19.81 5.99 19.42L7.05 18.36Z"
+          fill="currentColor"
+        />
+      </g>
+    </SlottedSVG>
+  );
+  const useStyles = createUseStyles({
+    main: { minHeight: "100vh", display: "flex", background: "var(--ic-color-background-primary)" },
+    mainContentDiv: {
+      border: "var(--ic-border-width) dashed var(--ic-architectural-400)",
+      padding: "var(--ic-space-md)",
+      flex: 1,
+    },
+    mainSectionContainer: { display: "flex", flex: 1 },
+  });
+  const classes = useStyles(); 
+  return (
+    <IcTheme theme={theme}>
+      <IcTopNavigation
+        appTitle="[Enter your application name]"
+        status="alpha"
+        version="v0.0.7"
+      >
+        <SlottedSVG
+          slot="app-icon"
+          xmlns="http://www.w3.org/2000/svg" 
+          viewBox="0 0 24 24" 
+          fill="#000000"
+          width="24"
+          height="24" 
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+        </SlottedSVG>
+        <IcNavigationButton onClick={handleToggle} label={\`Turn on \${theme === "light" ? "dark" : "light"} mode\`} slot="buttons">
+          {theme === "light" ? <DarkIcon /> : <LightIcon />}
+        </IcNavigationButton>
+      </IcTopNavigation>
+      <main className={classes.main}>
+        <IcSectionContainer className={classes.mainSectionContainer}>
+          <div className={classes.mainContentDiv}>
+            <IcAlert heading="See how the content changes" variant="info" />
+            <IcTypography variant="h2">
+              <h2>Example heading</h2>
+            </IcTypography>
+            <IcTypography variant="subtitle-large">
+              <p>Example sub-heading</p>
+            </IcTypography>
+          </div>
+        </IcSectionContainer>
+      </main>
+    </IcTheme>
+  )`,
+            "TopNavigation",
+            "tsx",
+            true
+          ),
+        },
+        {
+          language: "Javascript",
+          snippet: createReactAppTsx(
+            ` const [theme, setTheme] = useState("light");
+  const handleToggle = () => {
+    setTheme(theme === "light" ? "dark" : "light");
+  };
+  const DarkIcon = () => (
+    <SlottedSVG
+      slot="icon"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g id="Icon">
+        <path
+          id="Vector"
+          d="M14.5 2C16.32 2 18.03 2.5 19.5 3.35C16.51 5.08 14.5 8.3 14.5 12C14.5 15.7 16.51 18.92 19.5 20.65C18.03 21.5 16.32 22 14.5 22C8.98 22 4.5 17.52 4.5 12C4.5 6.48 8.98 2 14.5 2Z"
+          fill="currentColor"
+        />
+      </g>
+    </SlottedSVG>
+  );
+  const LightIcon = () => (
+    <SlottedSVG
+      slot="icon"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <g id="Icon">
+        <path
+          id="Vector"
+          d="M12 7C9.24 7 7 9.24 7 12C7 14.76 9.24 17 12 17C14.76 17 17 14.76 17 12C17 9.24 14.76 7 12 7ZM2 13H4C4.55 13 5 12.55 5 12C5 11.45 4.55 11 4 11H2C1.45 11 1 11.45 1 12C1 12.55 1.45 13 2 13ZM20 13H22C22.55 13 23 12.55 23 12C23 11.45 22.55 11 22 11H20C19.45 11 19 11.45 19 12C19 12.55 19.45 13 20 13ZM11 2V4C11 4.55 11.45 5 12 5C12.55 5 13 4.55 13 4V2C13 1.45 12.55 1 12 1C11.45 1 11 1.45 11 2ZM11 20V22C11 22.55 11.45 23 12 23C12.55 23 13 22.55 13 22V20C13 19.45 12.55 19 12 19C11.45 19 11 19.45 11 20ZM5.99 4.58C5.6 4.19 4.96 4.19 4.58 4.58C4.19 4.97 4.19 5.61 4.58 5.99L5.64 7.05C6.03 7.44 6.67 7.44 7.05 7.05C7.43 6.66 7.44 6.02 7.05 5.64L5.99 4.58ZM18.36 16.95C17.97 16.56 17.33 16.56 16.95 16.95C16.56 17.34 16.56 17.98 16.95 18.36L18.01 19.42C18.4 19.81 19.04 19.81 19.42 19.42C19.81 19.03 19.81 18.39 19.42 18.01L18.36 16.95ZM19.42 5.99C19.81 5.6 19.81 4.96 19.42 4.58C19.03 4.19 18.39 4.19 18.01 4.58L16.95 5.64C16.56 6.03 16.56 6.67 16.95 7.05C17.34 7.43 17.98 7.44 18.36 7.05L19.42 5.99ZM7.05 18.36C7.44 17.97 7.44 17.33 7.05 16.95C6.66 16.56 6.02 16.56 5.64 16.95L4.58 18.01C4.19 18.4 4.19 19.04 4.58 19.42C4.97 19.8 5.61 19.81 5.99 19.42L7.05 18.36Z"
+          fill="currentColor"
+        />
+      </g>
+    </SlottedSVG>
+  );
+  const useStyles = createUseStyles({
+    main: { minHeight: "100vh", display: "flex", background: "var(--ic-color-background-primary)" },
+    mainContentDiv: {
+      border: "var(--ic-border-width) dashed var(--ic-architectural-400)",
+      padding: "var(--ic-space-md)",
+      flex: 1,
+    },
+    mainSectionContainer: { display: "flex", flex: 1 },
+  });
+  const classes = useStyles(); 
+  return (
+    <IcTheme theme={theme}>
+      <IcTopNavigation
+        appTitle="[Enter your application name]"
+        status="alpha"
+        version="v0.0.7"
+      >
+        <SlottedSVG
+          slot="app-icon"
+          xmlns="http://www.w3.org/2000/svg" 
+          viewBox="0 0 24 24" 
+          fill="#000000"
+          width="24"
+          height="24" 
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+        </SlottedSVG>
+        <IcNavigationButton onClick={handleToggle} label={'Turn on [LIGHT/DARK] mode'} slot="buttons">
+          {theme === "light" ? <DarkIcon /> : <LightIcon />}
+        </IcNavigationButton>
+      </IcTopNavigation>
+      <main className={classes.main}>
+        <IcSectionContainer className={classes.mainSectionContainer}>
+          <div className={classes.mainContentDiv}>
+            <IcAlert heading="See how the content changes" variant="info" />
+            <IcTypography variant="h2">
+              <h2>Example heading</h2>
+            </IcTypography>
+            <IcTypography variant="subtitle-large">
+              <p>Example sub-heading</p>
+            </IcTypography>
+          </div>
+        </IcSectionContainer>
+      </main>
+    </IcTheme>
+  )`,
+            "TopNavigation",
+            "jsx",
+            true
+          ),
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview
+  snippets={snippetsTopNav}
+  type="pattern"
+  noPadding
+  style={{
+    display: "flex",
+    height: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: "1rem",
+  }}
+>
+  <IcLink href="/dark-mode-pattern" target="_blank">
+    View example in new window
+  </IcLink>
+</ComponentPreview>
+
+This pattern includes the components:
+
+- [Top navigation](/components/top-navigation)
+- [Section container](/components/section-container)
+- [Alert](/components/alert)
+- [Typography](/components/typography)
+
+As well as the [theme wrapper](/get-started/install-components/custom-theme).

--- a/src/icds-pages-data.json
+++ b/src/icds-pages-data.json
@@ -4649,9 +4649,9 @@
       "contents": "\n## Customising component colours\n\nSome components can have their theme colour changed by using either of the methods below. When the theme colour is changed, components will automatically update.\n\nOther styles on affected components will also adapt accordingly, such as the colour of text or icons.\n\n## CSS variables\n\nYou can set the theme colour by using the three CSS variables (one for each of the RGB values for the colour) shown below:\n\n```css\n:root {\n  --ic-theme-primary-r: 92;\n  --ic-theme-primary-g: 9;\n  --ic-theme-primary-b: 72;\n}\n```\n\n## Theme component\n\nAlternatively, you can include the `ic-theme` component and set the `color` property:\n\n```jsx\n<ic-theme color=\"rgb(92, 9, 72)\"></ic-theme>\n<ic-theme color=\"#5c0949\"></ic-theme>\n```\n\n### Components that use the theme colour\n\n- [Footer](/components/footer)\n- [Hero](/components/hero)\n- [Side navigation](/components/side-navigation)\n- [Top navigation](/components/top-navigation)\n",
       "path": "/get-started/install-components/custom-theme",
       "navPriority": 9,
-      "date": "2024-02-05",
+      "date": "2024-12-02",
       "title": "Custom theme",
-      "subTitle": "How to change the theme colour of some components.",
+      "subTitle": "How to change the colours of some components.",
       "contribute": "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/custom-theme.mdx",
       "meta": {
         "relativePath": "get-started\\custom-theme.mdx",

--- a/src/pages/dark-mode-pattern.tsx
+++ b/src/pages/dark-mode-pattern.tsx
@@ -1,0 +1,117 @@
+import React, { useState } from "react";
+import {
+  IcAlert,
+  IcNavigationButton,
+  IcSectionContainer,
+  IcTheme,
+  IcTopNavigation,
+  IcTypography,
+  SlottedSVG,
+} from "@ukic/react";
+
+import { createUseStyles } from "react-jss";
+import { PageProps } from "gatsby";
+
+const DarkIcon = () => (
+  <SlottedSVG
+    slot="icon"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g id="Icon">
+      <path
+        id="Vector"
+        d="M14.5 2C16.32 2 18.03 2.5 19.5 3.35C16.51 5.08 14.5 8.3 14.5 12C14.5 15.7 16.51 18.92 19.5 20.65C18.03 21.5 16.32 22 14.5 22C8.98 22 4.5 17.52 4.5 12C4.5 6.48 8.98 2 14.5 2Z"
+        fill="currentColor"
+      />
+    </g>
+  </SlottedSVG>
+);
+
+const LightIcon = () => (
+  <SlottedSVG
+    slot="icon"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g id="Icon">
+      <path
+        id="Vector"
+        d="M12 7C9.24 7 7 9.24 7 12C7 14.76 9.24 17 12 17C14.76 17 17 14.76 17 12C17 9.24 14.76 7 12 7ZM2 13H4C4.55 13 5 12.55 5 12C5 11.45 4.55 11 4 11H2C1.45 11 1 11.45 1 12C1 12.55 1.45 13 2 13ZM20 13H22C22.55 13 23 12.55 23 12C23 11.45 22.55 11 22 11H20C19.45 11 19 11.45 19 12C19 12.55 19.45 13 20 13ZM11 2V4C11 4.55 11.45 5 12 5C12.55 5 13 4.55 13 4V2C13 1.45 12.55 1 12 1C11.45 1 11 1.45 11 2ZM11 20V22C11 22.55 11.45 23 12 23C12.55 23 13 22.55 13 22V20C13 19.45 12.55 19 12 19C11.45 19 11 19.45 11 20ZM5.99 4.58C5.6 4.19 4.96 4.19 4.58 4.58C4.19 4.97 4.19 5.61 4.58 5.99L5.64 7.05C6.03 7.44 6.67 7.44 7.05 7.05C7.43 6.66 7.44 6.02 7.05 5.64L5.99 4.58ZM18.36 16.95C17.97 16.56 17.33 16.56 16.95 16.95C16.56 17.34 16.56 17.98 16.95 18.36L18.01 19.42C18.4 19.81 19.04 19.81 19.42 19.42C19.81 19.03 19.81 18.39 19.42 18.01L18.36 16.95ZM19.42 5.99C19.81 5.6 19.81 4.96 19.42 4.58C19.03 4.19 18.39 4.19 18.01 4.58L16.95 5.64C16.56 6.03 16.56 6.67 16.95 7.05C17.34 7.43 17.98 7.44 18.36 7.05L19.42 5.99ZM7.05 18.36C7.44 17.97 7.44 17.33 7.05 16.95C6.66 16.56 6.02 16.56 5.64 16.95L4.58 18.01C4.19 18.4 4.19 19.04 4.58 19.42C4.97 19.8 5.61 19.81 5.99 19.42L7.05 18.36Z"
+        fill="currentColor"
+      />
+    </g>
+  </SlottedSVG>
+);
+
+const TopNavigation: React.FC<PageProps> = () => {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  const toggleTheme = () => {
+    setTheme(theme === "light" ? "dark" : "light");
+  };
+
+  const useStyles = createUseStyles({
+    main: {
+      minHeight: "100vh",
+      display: "flex",
+      background: "var(--ic-color-background-primary)",
+    },
+    mainContentDiv: {
+      border: "var(--ic-border-width) dashed var(--ic-architectural-400)",
+      padding: "var(--ic-space-md)",
+      flex: 1,
+    },
+    mainSectionContainer: { display: "flex", flex: 1 },
+  });
+  const classes = useStyles();
+
+  return (
+    <IcTheme theme={theme}>
+      <IcTopNavigation
+        appTitle="[Enter your application name]"
+        status="alpha"
+        version="v0.0.7"
+      >
+        <SlottedSVG
+          slot="app-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="#000000"
+          width="24"
+          height="24"
+        >
+          <path d="M0 0h24v24H0V0z" fill="none" />
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-5.5-2.5l7.51-3.49L17.5 6.5 9.99 9.99 6.5 17.5zm5.5-6.6c.61 0 1.1.49 1.1 1.1s-.49 1.1-1.1 1.1-1.1-.49-1.1-1.1.49-1.1 1.1-1.1z" />
+        </SlottedSVG>
+        <IcNavigationButton
+          label={`Turn on ${theme === "light" ? "dark" : "light"} mode`}
+          slot="buttons"
+          onClick={toggleTheme}
+        >
+          {theme === "light" ? <DarkIcon /> : <LightIcon />}
+        </IcNavigationButton>
+      </IcTopNavigation>
+      <main className={classes.main}>
+        <IcSectionContainer className={classes.mainSectionContainer}>
+          <div className={classes.mainContentDiv}>
+            <IcAlert heading="See how the content changes!" variant="info" />
+            <IcTypography variant="h2">
+              <h2>
+                Click the button in the top-navigation to change between light
+                and dark mode...
+              </h2>
+            </IcTypography>
+          </div>
+        </IcSectionContainer>
+      </main>
+    </IcTheme>
+  );
+};
+export default TopNavigation;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -8,6 +8,7 @@ const paths = [
   "/top-navigation-page-header-pattern/",
   "/top-navigation-back-to-top-pattern/",
   "/top-navigation-mega-menu-pattern/",
+  "/dark-mode-pattern/",
 ];
 
 export default paths;


### PR DESCRIPTION
## Summary of the changes
Added explanation of dark mode terminology, and gave examples of how to apply dark mode through the theme prop and across a larger app through a pattern page.

Figma guidance to be added at a later date.

Also added a fix to code previews from a bug introduced in #1222 

## Related issue
#1223 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
