### PR TITLE
fix(root): change overflow-y on tree view to hide permanent scroll bar

### DIFF
--- a/src/components/SubsectionNav/index.css
+++ b/src/components/SubsectionNav/index.css
@@ -54,7 +54,7 @@
 
 .scroll {
   width: auto;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 @media screen and (max-width: 768px) {
@@ -69,10 +69,6 @@
   .small-only {
     display: block;
     visibility: visible;
-  }
-
-  .scroll {
-    height: calc(100vh - var(--ic-space-lg));
   }
 }
 

--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -215,6 +215,7 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
     }
     window.addEventListener("scroll", updateNavigationHeight);
     window.addEventListener("resize", updateNavigationHeight);
+    updateNavigationHeight();
     return () => {
       window.removeEventListener("scroll", updateNavigationHeight);
       window.removeEventListener("resize", updateNavigationHeight);

--- a/src/templates/Standard/index.css
+++ b/src/templates/Standard/index.css
@@ -13,7 +13,7 @@
 .sticky {
   position: sticky;
   top: 0;
-  z-index: var(--ic-z-index-sticky-page-header);
+  z-index: calc(var(--ic-z-index-sticky-page-header) + 1);
 }
 
 .page-content {


### PR DESCRIPTION
## Summary of the changes

(Updated PR description)

Fixed bugs mentioned in #1215 plus a couple of other small things I noticed. In summary this PR fixes the following:
- The scroll bar always being visible on the tree view on every page even when not needed (e.g. when all items were already visible on screen)
- The height of the tree view not filling the whole page when you first go to a new page
- A left box shadow visible on the page header
- The tree view being very tall on small screens

--------

So it's clear what has been fixed, here is a screenshot in which the first three of the above bugs are visible:
<img src="https://github.com/user-attachments/assets/40c8825f-3305-4a43-90b5-35dea034f620" width="600">

Video showing the tree view on a small screen issue:

https://github.com/user-attachments/assets/750f4581-10b8-4349-8d78-8cf233e67967


## Related issue

#1215 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
