### PR TITLE
fix(root): update expanded prop behaviour on tree view

### DIFF
--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -156,18 +156,19 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
         key={item.data.id}
         label={item.data.frontmatter.title}
         selected={!hasChildren && isCurrentPage(item.data.fields.slug, false)}
-        expanded={hasChildren && isChildSelected(item)}
         onMouseOver={handleMouseOver}
         onIcTreeItemSelected={() =>
           sessionStorage.setItem("navlinkclick", "true")
         }
-        {...(!hasChildren && {
-          onClick: (e) => {
-            e.preventDefault();
-            handleNavigation(item.data.fields.slug);
-          },
-          onKeyUp: handleKeyUp,
-        })}
+        {...(hasChildren
+          ? isChildSelected(item) && { expanded: true }
+          : {
+              onClick: (e) => {
+                e.preventDefault();
+                handleNavigation(item.data.fields.slug);
+              },
+              onKeyUp: handleKeyUp,
+            })}
       >
         {hasChildren && (
           <IcTreeItem


### PR DESCRIPTION
## Summary of the changes

Changed how the expanded prop was being applied on tree view items to fix collapsing on scroll issue. Also updated package-lock file to remove vulnerabilities.

The expanded prop now gets conditionally applied - if the current page is a child page, the prop is applied, and if not, it doesn't get applied at all (instead of just being set to false like it was previously). (The collapsing on scroll was because of updating the `navHeight` state in the `useEffect` and the [expanded prop then changing to `false`](https://github.com/mi6/ic-design-system/blob/1446feb5c495361a6be231fdb5242f7f32fe3dc0/src/components/SubsectionNav/index.tsx#L159)).

## Related issue

#1256 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
