### PR TITLE
1268 dm text highlighting

### DIFF
--- a/src/components/ComponentTesting/index.tsx
+++ b/src/components/ComponentTesting/index.tsx
@@ -28,7 +28,7 @@ const ActionButtons: React.FC<ActionProps> = ({
   stackblitzButtonTestAppProps,
   isLargeViewport,
 }) => {
-  const { oppositeTheme } = useTheme();
+  const { theme } = useTheme();
   return (
     <div className="button-container">
       {showStackblitzBtn && stackblitzButtonTestAppProps && (
@@ -42,7 +42,7 @@ const ActionButtons: React.FC<ActionProps> = ({
         aria-label={isLargeViewport ? "" : "Copy code"}
         variant={isLargeViewport ? "tertiary" : "icon"}
         size={isLargeViewport ? "small" : "medium"}
-        theme={oppositeTheme}
+        theme={theme}
         monochrome
         onClick={() => {
           navigator.clipboard.writeText(longCode);
@@ -70,14 +70,14 @@ const ToggleShowButton: React.FC<ToggleShowProps> = ({
   showMore,
   setShowMore,
 }) => {
-  const { oppositeTheme } = useTheme();
+  const { theme } = useTheme();
   return (
     <div className="button-container">
       <IcButton
         variant="tertiary"
         size="small"
         onClick={() => setShowMore(!showMore)}
-        theme={oppositeTheme}
+        theme={theme}
         monochrome
         disabled={disableMoreButton}
       >

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -260,11 +260,7 @@ const Layout: React.FC<LayoutProps> = ({
           content={process.env.GATSBY_GOOGLE_SEARCH_TOKEN}
         />
       </Helmet>
-      <ThemeProvider
-        theme={theme}
-        toggleTheme={toggleTheme}
-        oppositeTheme={theme === "light" ? "dark" : "light"}
-      >
+      <ThemeProvider theme={theme} toggleTheme={toggleTheme}>
         <ic-theme theme={theme}>
           {!GATSBY_GA_TRACKING_ID && (
             <ic-classification-banner
@@ -307,11 +303,11 @@ const Layout: React.FC<LayoutProps> = ({
                     (footerLink: FooterLinks) => footerLink.key !== undefined
                   )
                   .map((footerLink: FooterLinks) => (
-                    <ic-footer-link
-                      slot="link"
-                      key={footerLink.key}
-                    >
-                      <GatsbyLink to={footerLink.link} style={{color: "white"}}>
+                    <ic-footer-link slot="link" key={footerLink.key}>
+                      <GatsbyLink
+                        to={footerLink.link}
+                        style={{ color: "white" }}
+                      >
                         {footerLink.text}
                       </GatsbyLink>
                     </ic-footer-link>

--- a/src/components/TopNavWrapper/index.tsx
+++ b/src/components/TopNavWrapper/index.tsx
@@ -54,11 +54,11 @@ interface TopNavWrapperProps {
 }
 
 const ThemeToggleButton: React.FC = () => {
-  const { theme, toggleTheme, oppositeTheme } = useTheme();
+  const { theme, toggleTheme } = useTheme();
 
   return (
     <ic-navigation-button
-      label={`Turn on ${oppositeTheme} mode`}
+      label={`Turn on ${theme === "light" ? "dark" : "light"} mode`}
       slot="buttons"
       onClick={toggleTheme}
     >

--- a/src/content/structured/accessibility/coding/css.mdx
+++ b/src/content/structured/accessibility/coding/css.mdx
@@ -21,8 +21,8 @@ Don't use inline styles; keep CSS separate to the HTML. This can be a separate C
 Decoupling the styling will create more flexibility as the visual styling can be updated without touching the HTML.
 
 <p>
-  Don't use <code style={{ backgroundColor: "#EEEFF0" }}>!important</code> on a
-  style declaration as this overrides any other declarations. You can read more
+  Don't use <code className="language-text">!important</code> on a style
+  declaration as this overrides any other declarations. You can read more
   information from Mozilla on{" "}
   <ic-link
     target="_blank"

--- a/src/content/structured/accessibility/coding/doctype.mdx
+++ b/src/content/structured/accessibility/coding/doctype.mdx
@@ -38,8 +38,7 @@ This tells the browser how to render the HTML, as in this example:
 ## When it goes wrong
 
 <p>
-  If no valid{" "}
-  <code style={{ backgroundColor: "#EEEFF0" }}>&lt;!DOCTYPE&gt;</code> is
+  If no valid <code className="language-text">&lt;!DOCTYPE&gt;</code> is
   declared, the browser switches to{" "}
   <ic-link
     target="_blank"

--- a/src/content/structured/accessibility/coding/document-structure.mdx
+++ b/src/content/structured/accessibility/coding/document-structure.mdx
@@ -42,10 +42,10 @@ The following example shows the semantic elements for document structure:
 Not using the document structure elements accordingly may mean the page is not correctly rendered in every browser.
 
 <p>
-  Omitting the <code style={{ backgroundColor: "#EEEFF0" }}>&lt;html&gt;</code>,{" "}
-  <code style={{ backgroundColor: "#EEEFF0" }}>&lt;head&gt;</code> and{" "}
-  <code style={{ backgroundColor: "#EEEFF0" }}>&lt;body&gt;</code> is allowed
-  under certain conditions in the{" "}
+  Omitting the <code className="language-text">&lt;html&gt;</code>,{" "}
+  <code className="language-text">&lt;head&gt;</code> and{" "}
+  <code className="language-text">&lt;body&gt;</code> is allowed under certain
+  conditions in the{" "}
   <ic-link
     target="_blank"
     href="https://www.w3.org/TR/2011/WD-html5-20110525/syntax.html#optional-tags"

--- a/src/content/structured/accessibility/coding/semantic-html.mdx
+++ b/src/content/structured/accessibility/coding/semantic-html.mdx
@@ -29,24 +29,11 @@ Using correct semantic HTML elements makes web content more accessible.
   >
     HTML elements
   </ic-link>
-  , particularly <code style={{ backgroundColor: "#EEEFF0" }}>&lt;nav&gt;</code>,{" "}
-  <code style={{ backgroundColor: "#EEEFF0" }}>&lt;section&gt;</code> and <code
-    style={{ backgroundColor: "#EEEFF0" }}
-  >
-    &lt;role&gt;
-  </code>. They're mentioned in <ic-link
-    target=""
-    href="/accessibility/coding/document-structure"
-    rel="noreferer noopener nofollow"
-  >
-    Document structure
-  </ic-link> and <ic-link
-    target=""
-    href="/accessibility/coding/semantic-layout"
-    rel="noreferer noopener nofollow"
-  >
-    Semantic layout
-  </ic-link>.
+  , particularly <code className="language-text">&lt;nav&gt;</code>, <code className="language-text">
+    &lt;section&gt;
+  </code> and <code className="language-text">&lt;role&gt;</code>. They're mentioned
+  in <a href="/accessibility/coding/document-structure">Document structure</a> and{" "}
+  <a href="/accessibility/coding/semantic-layout">Semantic layout</a>.
 </p>
 
 ## When it goes wrong

--- a/src/content/structured/accessibility/documenting/accessibility-statements.mdx
+++ b/src/content/structured/accessibility/documenting/accessibility-statements.mdx
@@ -32,13 +32,9 @@ To make the statement useful for everyone, follow the template and don't change 
 
 <ul>
   <li>
-    <ic-link
-      target=""
-      href="/accessibility/documenting/accessibility-statements-guidance"
-      rel="noreferer noopener nofollow"
-    >
+    <a href="/accessibility/documenting/accessibility-statements-guidance">
       Guidance for completing accessibility statements
-    </ic-link>
+    </a>
   </li>
   <li>
     <ic-link

--- a/src/content/structured/accessibility/testing/automated-testing-limitation.mdx
+++ b/src/content/structured/accessibility/testing/automated-testing-limitation.mdx
@@ -32,14 +32,7 @@ Checks in automated accessibility testing tools have a yes or no outcome. The bi
     Accessibility Developers' Guide
   </ic-link>{" "}
   shows what type of testing is needed to meet{" "}
-  <ic-link
-    target=""
-    href="/accessibility/requirement/wcag"
-    rel="noreferer noopener nofollow"
-  >
-    WCAG 2.2 Level AA
-  </ic-link>
-  .
+  <a href="/accessibility/requirement/wcag">WCAG 2.2 Level AA</a>.
 </p>
 
 Of the 66 success criteria needed to meet WCAG AA, there are none that can be met fully with automated testing alone.

--- a/src/content/structured/accessibility/testing/automated-testing.mdx
+++ b/src/content/structured/accessibility/testing/automated-testing.mdx
@@ -94,11 +94,7 @@ Tools called 'linters' analyse source code for a range of potential bugs. Some l
 Linters detect issues very early and can prevent certain accessibility problems from ever being implemented.
 
 <p>
-  The{" "}
-  <ic-link target="" href="/components" rel="noreferer noopener nofollow">
-    UI Kit
-  </ic-link>{" "}
-  uses the ESLint accessibility plugin{" "}
+  The <a href="/components">UI Kit</a> uses the ESLint accessibility plugin{" "}
   <ic-link
     target="_blank"
     href="https://github.com/jsx-eslint/eslint-plugin-jsx-a11y"

--- a/src/content/structured/accessibility/testing/manual-testing.mdx
+++ b/src/content/structured/accessibility/testing/manual-testing.mdx
@@ -28,14 +28,7 @@ Manual accessibility testing is needed to address the [limitations of automated 
     Accessibility Developers' Guide
   </ic-link>{" "}
   shows what type of testing is needed to meet{" "}
-  <ic-link
-    target=""
-    href="/accessibility/requirement/wcag"
-    rel="noreferer noopener nofollow"
-  >
-    WCAG 2.2 Level AA
-  </ic-link>
-  .
+  <a href="/accessibility/requirement/wcag">WCAG 2.2 Level AA</a>.
 </p>
 
 ## Keyboard-only testing
@@ -119,14 +112,7 @@ Full manual testing is required on all the main pages of your app. Many apps use
   </ic-link>{" "}
   browser plugin in Assessment mode. It runs the automated tests but also guides
   you through manual testing to meet{" "}
-  <ic-link
-    target=""
-    href="/accessibility/requirement/wcag#level-aa"
-    rel="noreferer noopener nofollow"
-  >
-    WCAG AA
-  </ic-link>
-  .
+  <a href="/accessibility/requirement/wcag#level-aa">WCAG AA</a>.
 </p>
 
 <IcAlert

--- a/src/content/structured/get-started/development.mdx
+++ b/src/content/structured/get-started/development.mdx
@@ -53,7 +53,13 @@ With a focus on accessibility and ease of use, these components empower develope
           y2="89.6359"
           stroke="white"
         />
-        <line x1="124.635" y1="89.658" x2="139.635" y2="73.658" stroke="white" />
+        <line
+          x1="124.635"
+          y1="89.658"
+          x2="139.635"
+          y2="73.658"
+          stroke="white"
+        />
       </svg>
     </IcCardVertical>
   </GatsbyLink>
@@ -84,7 +90,11 @@ With a focus on accessibility and ease of use, these components empower develope
           stroke="white"
           stroke-width="0.864706"
         />
-        <path d="M104.156 55.05H121.882" stroke="white" stroke-width="0.864706" />
+        <path
+          d="M104.156 55.05H121.882"
+          stroke="white"
+          stroke-width="0.864706"
+        />
         <path
           d="M104.156 74.9382H121.882"
           stroke="white"

--- a/src/content/structured/get-started/figma.mdx
+++ b/src/content/structured/get-started/figma.mdx
@@ -102,7 +102,7 @@ The UI Kit is turned on by default for all projects within our community. Check 
   >
     raise it on GitHub issues
   </ic-link>
-  . For more information please read <ic-link href="/community/contribute#contribute-to-the-figma-ui-kit">
+  . For more information please read <a href="/community/contribute#contribute-to-the-figma-ui-kit">
     how to contribute to the Figma UI Kit
-  </ic-link>.
+  </a>.
 </p>

--- a/src/content/structured/get-started/install-components.mdx
+++ b/src/content/structured/get-started/install-components.mdx
@@ -14,8 +14,6 @@ contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/struc
 
 import { IcAlert } from "@ukic/react";
 
-import { Link as GatsbyLink } from "gatsby";
-
 ## Installing the components
 
 <p>
@@ -44,19 +42,15 @@ npm install @ukic/react @ukic/fonts
   heading="Components automatically switch colours based on the user's system settings"
   variant="warning"
 >
-  <span slot="message">
-    <ic-typography>
-      When the ic-theme component is not implemented, components will default to
-      the user's system colour scheme. Please keep this in mind when styling your
-      application. See the{" "}
-      <ic-link>
-        <GatsbyLink slot="router-item" to="/get-started/development/custom-theme#dark-mode-as-a-theme">
-          theming guidance
-        </GatsbyLink>
-      </ic-link>{" "}
-      for more information.
-    </ic-typography>
-  </span>
+  <ic-typography slot="message">
+    When the ic-theme component is not implemented, components will default to
+    the user's system colour scheme. Please keep this in mind when styling your
+    application. See the{" "}
+    <a href="/get-started/development/custom-theme#dark-mode-as-a-theme">
+      theming guidance
+    </a>{" "}
+    for more information.
+  </ic-typography>
 </IcAlert>
 
 To use the components in a particular framework, follow the framework instructions.

--- a/src/content/structured/get-started/react.mdx
+++ b/src/content/structured/get-started/react.mdx
@@ -83,8 +83,7 @@ To slot an SVG into one of our React components, import the `SlottedSVG` compone
     href="https://css-tricks.com/scale-svg/#aa-the-viewbox-attribute"
     rel="noreferer noopener nofollow"
   >
-    <code style={{ backgroundColor: "#EEEFF0", color: "black" }}>viewBox</code>{" "}
-    attribute
+    <code className="language-text">viewBox</code> attribute
   </ic-link>
   .
 </p>

--- a/src/content/structured/get-started/testing-with-jest-and-rtl.mdx
+++ b/src/content/structured/get-started/testing-with-jest-and-rtl.mdx
@@ -125,16 +125,15 @@ Add a `transformIgnorePatterns` field with the value `["/node_modules/(?!@ukic/r
   test React components based on how the users view the components rather than
   the implementation of the component. For example, a user wouldview a button by
   the label 'Add', so the library provides a method called{" "}
-  <code style={{ backgroundColor: "#EEEFF0" }}>getByText()</code> to facilitate
-  that.
+  <code className="language-text">getByText()</code> to facilitate that.
 </p>
 
 ## Shadow DOM Testing Library
 
 <p>
   It is not possible to exclusively use RTL to test{" "}
-  <code style={{ backgroundColor: "#EEEFF0" }}>@ukic/react</code> components as
-  they are React-wrapped web components, which use the{" "}
+  <code className="language-text">@ukic/react</code> components as they are
+  React-wrapped web components, which use the{" "}
   <ic-link
     target="_blank"
     href="https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM"
@@ -142,9 +141,9 @@ Add a `transformIgnorePatterns` field with the value `["/node_modules/(?!@ukic/r
   >
     shadow DOM
   </ic-link>{" "}
-  (<code style={{ backgroundColor: "#EEEFF0" }}>&lt;ShadowRoot&gt;</code>). RTL
-  does not provide utility functions that traverse beyond the shadow DOM. With
-  the addition of{" "}
+  (<code className="language-text">&lt;ShadowRoot&gt;</code>). RTL does not
+  provide utility functions that traverse beyond the shadow DOM. With the
+  addition of{" "}
   <ic-link
     target="_blank"
     href="https://github.com/KonnorRogers/shadow-dom-testing-library"
@@ -154,9 +153,7 @@ Add a `transformIgnorePatterns` field with the value `["/node_modules/(?!@ukic/r
   </ic-link>
   , elements within the shadow DOM can be selected and then interacted with by using
   methods provided by RTL. Shadow DOM Testing Library provides functions with 'Shadow'
-  prefixed to the query type (for example, <code
-    style={{ backgroundColor: "#EEEFF0" }}
-  >
+  prefixed to the query type (for example, <code className="language-text">
     getByShadowText()
   </code>).
 </p>

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -5,25 +5,19 @@ export type Theme = "dark" | "light";
 interface ThemeContextType {
   theme: Theme;
   toggleTheme: () => void;
-  oppositeTheme: Theme;
 }
 
 const ThemeContext = createContext<ThemeContextType>({
   theme: "light",
   toggleTheme: () => {},
-  oppositeTheme: "dark",
 });
 
 export const ThemeProvider: React.FC<{
   children: React.ReactNode;
   theme: Theme;
   toggleTheme: () => void;
-  oppositeTheme: Theme;
-}> = ({ children, theme, toggleTheme, oppositeTheme }) => {
-  const value = useMemo(
-    () => ({ theme, toggleTheme, oppositeTheme }),
-    [theme, toggleTheme, oppositeTheme]
-  );
+}> = ({ children, theme, toggleTheme }) => {
+  const value = useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
 
   return (
     <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>

--- a/src/templates/Homepage/index.tsx
+++ b/src/templates/Homepage/index.tsx
@@ -186,9 +186,7 @@ const Homepage: React.FC = () => {
                   text: string;
                   variant: IcButtonVariants;
                 }) => (
-                  <ic-button
-                    variant={button.variant}
-                  >
+                  <ic-button variant={button.variant}>
                     <GatsbyLink slot="router-item" to={button.href}>
                       {button.text}
                     </GatsbyLink>
@@ -228,9 +226,7 @@ const Homepage: React.FC = () => {
                   text: string;
                   variant: IcButtonVariants;
                 }) => (
-                  <ic-button
-                    variant={button.variant}
-                  >
+                  <ic-button variant={button.variant}>
                     <GatsbyLink slot="router-item" to={button.href}>
                       {button.text}
                     </GatsbyLink>
@@ -265,11 +261,11 @@ const Homepage: React.FC = () => {
                 {text}
               </ic-typography>
             ))}
-              <ic-button>
-                <GatsbyLink slot="router-item" to={homepage.contribute.link}>
-                  {homepage.contribute.buttonText}
-                </GatsbyLink>
-              </ic-button>
+            <ic-button>
+              <GatsbyLink slot="router-item" to={homepage.contribute.link}>
+                {homepage.contribute.buttonText}
+              </GatsbyLink>
+            </ic-button>
           </div>
         </div>
       </ic-section-container>


### PR DESCRIPTION
## Summary of the changes

- Removed inline styling of certain `<code>` tags, swapping it for the `language-text` class which would apply dark mode styling in line with other code snippets. #1268 
- Updated certain links in markdown that weren't using GatsbyLink, swapping them to `<a>` tags so that they utilised GatsbyLink through the WrappedLink component. https://github.com/mi6/ic-ui-kit/issues/2893
- Swapped the theme on component testing buttons to match the other component preview buttons. #1257 
- Removed `oppositeTheme` from the ThemeContext as it was no longer being used after swapping the theme.

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
