### PR TITLE
feat(root): persist user's chosen language and framework for code demos

### DIFF
--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -277,7 +277,56 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
 
   const tabSelectCallback = (ev: CustomEvent) => {
     setSelectedTab(ev.detail.tabLabel);
+    localStorage.setItem("selectedTab", ev.detail.tabLabel); 
+  
+    const event = new CustomEvent("tabSelectionChanged", {
+      detail: { selectedTab: ev.detail.tabLabel },
+    });
+    window.dispatchEvent(event);
   };
+
+  useEffect(() => {
+    const storedTab = localStorage.getItem("selectedTab");
+    if (storedTab) {
+      setSelectedTab(storedTab as "Web component" | "React");
+    }
+
+    const handleTabSelectionChange = (event: CustomEvent) => {
+      setSelectedTab(event.detail.selectedTab);
+    };
+
+    window.addEventListener("tabSelectionChanged", handleTabSelectionChange); 
+
+    return () => {
+      window.removeEventListener(
+        "tabSelectionChanged",
+        handleTabSelectionChange
+      );
+    };
+  }, []);
+
+  useEffect(() => {
+    const storedLanguage = localStorage.getItem("selectedLanguage");
+    if (storedLanguage) {
+      setSelectedLanguage(storedLanguage as "Typescript" | "Javascript");
+    }
+
+    const handleLanguageSelectionChange = (event: CustomEvent) => {
+      setSelectedLanguage(event.detail.selectedLanguage);
+    };
+
+    window.addEventListener(
+      "languageSelectionChanged",
+      handleLanguageSelectionChange
+    );
+
+    return () => {
+      window.removeEventListener(
+        "languageSelectionChanged",
+        handleLanguageSelectionChange
+      );
+    };
+  }, []);
 
   const pageMetadata = React.useContext(PageMetadataContext);
 
@@ -461,6 +510,12 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
         currentToggleBtnRef.current.checked = true;
       }
     }
+
+    localStorage.setItem("selectedLanguage", intendedLanguage);
+    const event = new CustomEvent("languageSelectionChanged", {
+      detail: { selectedLanguage: intendedLanguage },
+    });
+    window.dispatchEvent(event);
   };
 
   return (


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

feat(root): persist user's chosen language and framework for code demos

added local storage to store the stage of language and framework, to preent users from repeating the selection of their language and framework


## Related issue
#817 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [v3 develop branch](https://github.com/mi6/ic-design-system/tree/develop)
