### PR TITLE
fix(root): reducing margin-bottom of dodontcaution

### DIFF
--- a/src/components/DoDontCaution/index.css
+++ b/src/components/DoDontCaution/index.css
@@ -14,14 +14,14 @@
 .dont {
   border-top: var(--ic-space-xs) solid var(--ic-status-error-default);
   position: relative;
-  margin-bottom: var(--ic-space-xxl);
+  margin-bottom: var(--ic-space-lg);
   display: inline-block;
 }
 
 .do {
   border-top: var(--ic-space-xs) solid var(--ic-status-success-default);
   position: relative;
-  margin-bottom: var(--ic-space-xxl);
+  margin-bottom: var(--ic-space-lg);
   display: inline-block;
 }
 


### PR DESCRIPTION
## Summary of the changes

Reducing margin-bottom of dodontcaution so that gap between dodontcaution and heading is not too large.

## Related issue

#1159 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
