### PR TITLE
docs(root): add guidance about using slotted links in breadcrumbs

### DIFF
--- a/src/content/structured/components/breadcrumbs/accessibility.mdx
+++ b/src/content/structured/components/breadcrumbs/accessibility.mdx
@@ -27,6 +27,8 @@ Breadcrumbs are formed out of a set of links. Each of these links is individuall
 
 The separators between links are added programmatically so that they aren't read out by screen readers. The separators are purely decorative so don't need to be announced to the user.
 
+Avoid adding a slotted link to the breadcrumb for the current page. Doing so may cause screen readers to announce the breadcrumb as a link which could be confusing to users because current page breadcrumbs are not focusable.
+
 ## Based on
 
 The breadcrumbs component has been based on the following resources:

--- a/src/content/structured/components/breadcrumbs/code.mdx
+++ b/src/content/structured/components/breadcrumbs/code.mdx
@@ -535,11 +535,7 @@ export const withReactRouter = [
         <NavLink slot="router-item" to="/">Beverages</NavLink>
       </IcLink>
     </IcBreadcrumb>
-    <IcBreadcrumb pageTitle="Coffee" current>
-      <IcLink>
-        <NavLink to="/" slot="router-item">Coffee</NavLink>
-      </IcLink>
-    </IcBreadcrumb>
+    <IcBreadcrumb pageTitle="Coffee" href="/" current />
   </IcBreadcrumbGroup>
 </MemoryRouter>`,
       long: [
@@ -573,13 +569,7 @@ export const withReactRouter = [
           </NavLink>
         </IcLink>
       </IcBreadcrumb>
-      <IcBreadcrumb pageTitle="Coffee" current>
-        <IcLink>
-          <NavLink to="/" slot="router-item">
-            Coffee
-          </NavLink>
-        </IcLink>
-      </IcBreadcrumb>
+      <IcBreadcrumb pageTitle="Coffee" href="/" current />
     </IcBreadcrumbGroup>
   </MemoryRouter>
 </ComponentPreview>


### PR DESCRIPTION
## Summary of the changes
Add note about not using slotted links in current page breadcrumbs. Relates to findings from PR [#3050](https://github.com/mi6/ic-ui-kit/pull/3050).

## Related issue
mi6/ic-ui-kit#2194

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
