### PR TITLE
fix(root): added color-scheme: dark when using dark ic-theme

### DIFF
--- a/src/styles/gatsby-reset.css
+++ b/src/styles/gatsby-reset.css
@@ -3,6 +3,9 @@ html {
   -webkit-text-size-adjust: 100%;
   height: 100%;
 }
+html:has(ic-theme.ic-theme-dark) {
+  color-scheme: dark;
+}
 body {
   margin: 0;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary of the changes
When ic-theme is set to dark applies a color-scheme prop to the root html, to set the root scroll bar to dark mode

This is part 2 of the fix. Part 1 is in the [ic-ui-kit](https://github.com/mi6/ic-ui-kit/pull/3106)

## Related issue
[#2869](https://github.com/mi6/ic-ui-kit/issues/2869)

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
