### PR TITLE
docs(root): removed showState examples for IcSwitch

### DIFF
--- a/src/components/AnchorNav/index.tsx
+++ b/src/components/AnchorNav/index.tsx
@@ -13,7 +13,11 @@ interface AnchorNavProps {
   id?: string;
 }
 
-const AnchorNav: React.FC<AnchorNavProps> = ({ allHeadings, currentPage, id }) => {
+const AnchorNav: React.FC<AnchorNavProps> = ({
+  allHeadings,
+  currentPage,
+  id,
+}) => {
   const headings = allHeadings.filter(({ depth }) => depth === 2);
 
   const headingIds = headings.map(({ value }) => slug(value));

--- a/src/content/static/components/InlineCookiesManager.tsx
+++ b/src/content/static/components/InlineCookiesManager.tsx
@@ -49,7 +49,6 @@ const InlineCookiesManager: React.FC = () => {
           checked={cookiesApproved}
           label="Optional analytics cookies"
           onIcChange={() => handleCookiesChange()}
-          showState
           disabled={!process.env.GATSBY_GA_TRACKING_ID}
         />
       </div>
@@ -60,7 +59,6 @@ const InlineCookiesManager: React.FC = () => {
           checked={localStorageApproved}
           label="Optional local storage"
           onIcChange={() => handleLocalStorageChange()}
-          showState
         />
       </div>
     </>

--- a/src/content/structured/components/switch/code.mdx
+++ b/src/content/structured/components/switch/code.mdx
@@ -82,38 +82,6 @@ export const snippetsDefault = [
 
 ## Variants
 
-### State
-
-export const snippetsState = [
-  {
-    technology: "Web component",
-    snippets: {
-      short: `<ic-switch label="Coffee preferences" show-state="true"></ic-switch>`,
-      long: `{shortCode}`,
-    },
-  },
-  {
-    technology: "React",
-    snippets: {
-      short: `<IcSwitch label="Coffee preferences" showState />`,
-      long: [
-        {
-          language: "Typescript",
-          snippet: `{shortCode}`,
-        },
-        {
-          language: "Javascript",
-          snippet: `{shortCode}`,
-        },
-      ],
-    },
-  },
-];
-
-<ComponentPreview snippets={snippetsState}>
-  <IcSwitch label="Coffee preferences" showState />
-</ComponentPreview>
-
 ### Small
 
 export const snippetsSmall = [
@@ -122,7 +90,6 @@ export const snippetsSmall = [
     snippets: {
       short: `<ic-switch
   label="Coffee preferences"
-  show-state="true"
   size="small"
 ></ic-switch>`,
       long: `{shortCode}`,
@@ -131,7 +98,7 @@ export const snippetsSmall = [
   {
     technology: "React",
     snippets: {
-      short: `<IcSwitch label="Coffee preferences" showState size="small"/>`,
+      short: `<IcSwitch label="Coffee preferences" size="small"/>`,
       long: [
         {
           language: "Typescript",
@@ -147,7 +114,7 @@ export const snippetsSmall = [
 ];
 
 <ComponentPreview snippets={snippetsSmall}>
-  <IcSwitch label="Coffee preferences" showState size="small" />
+  <IcSwitch label="Coffee preferences" size="small" />
 </ComponentPreview>
 
 ### Disabled
@@ -158,12 +125,10 @@ export const snippetsDisabled = [
     snippets: {
       short: `<ic-switch
   label="Coffee preferences"
-  show-state="true"
   disabled="true"
 ></ic-switch>
 <ic-switch
   label="Coffee preferences"
-  show-state="true"
   disabled="true"
   checked="true"
 ></ic-switch>`,
@@ -173,8 +138,8 @@ export const snippetsDisabled = [
   {
     technology: "React",
     snippets: {
-      short: `<IcSwitch label="Coffee preferences" showState disabled />
-      <IcSwitch label="Coffee preferences" showState disabled checked />`,
+      short: `<IcSwitch label="Coffee preferences" disabled />
+      <IcSwitch label="Coffee preferences" disabled checked />`,
       long: [
         {
           language: "Typescript",
@@ -195,8 +160,8 @@ export const snippetsDisabled = [
 
 <ComponentPreview snippets={snippetsDisabled}>
   <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
-    <IcSwitch label="Coffee preferences" showState disabled />
-    <IcSwitch label="Coffee preferences" showState disabled checked />
+    <IcSwitch label="Coffee preferences" disabled />
+    <IcSwitch label="Coffee preferences" disabled checked />
   </div>
 </ComponentPreview>
 

--- a/src/templates/CoreTemplate/index.tsx
+++ b/src/templates/CoreTemplate/index.tsx
@@ -64,7 +64,9 @@ const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({
 
   useEffect(() => {
     const checkFontSize = () => {
-      const bodyFontSize = parseFloat(window.getComputedStyle(document.body).fontSize);
+      const bodyFontSize = parseFloat(
+        window.getComputedStyle(document.body).fontSize
+      );
       if (bodyFontSize > 16) {
         setIsLargeFont(true);
       } else {
@@ -85,8 +87,19 @@ const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({
           tabs={mdx.frontmatter.tabs}
           location={location}
         />
-        <ic-section-container aligned="center" id={isLargeFont ? "page-section-container-large-font" : "page-section-container"}>
-          <AnchorNav currentPage={mdx.fields.slug} allHeadings={mdx.headings} id={isLargeFont ? 'anchor-nav-large-font' : ''} />
+        <ic-section-container
+          aligned="center"
+          id={
+            isLargeFont
+              ? "page-section-container-large-font"
+              : "page-section-container"
+          }
+        >
+          <AnchorNav
+            currentPage={mdx.fields.slug}
+            allHeadings={mdx.headings}
+            id={isLargeFont ? "anchor-nav-large-font" : ""}
+          />
           <div className="content-container">
             <PageMetadataContext.Provider value={pageTitleValue}>
               <MDXRenderer>{children}</MDXRenderer>


### PR DESCRIPTION
## Summary of the changes
- Removed any references to showState, in docs and in our own code
- Prettier fixes

## Related issue
[#2733](https://github.com/mi6/ic-ui-kit/issues/2733)

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
