### PR TITLE
2704 tree view side nav items not truncating 

### DIFF
--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -257,6 +257,7 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
             navHeight > 0 && { height: `${navHeight}px` }) ||
           {}
         }
+        truncateTreeItems
         focusInset
       >
         {isRoot && (


### PR DESCRIPTION
## Summary of the changes

Added `truncateTreeItems` to `ic-tree-view`

## Related issue

#2704

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [ ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
