### PR TITLE
docs(root): added css guidance for changing color-scheme in dark mode…

### DIFF
--- a/src/content/structured/patterns/dark-mode.mdx
+++ b/src/content/structured/patterns/dark-mode.mdx
@@ -21,7 +21,7 @@ export const snippetsTopNav = [
   {
     technology: "Web component",
     snippets: {
-      long: `<ic-theme theme="light">
+      long: `<ic-theme id="theme-wrapper" theme="light">
     <ic-top-navigation
       app-title="[Enter your application name]"
       status="alpha"
@@ -176,7 +176,7 @@ export const snippetsTopNav = [
   });
   const classes = useStyles(); 
   return (
-    <IcTheme theme={theme}>
+    <IcTheme id="theme-wrapper" theme={theme}>
       <IcTopNavigation
         appTitle="[Enter your application name]"
         status="alpha"
@@ -271,7 +271,7 @@ export const snippetsTopNav = [
   });
   const classes = useStyles(); 
   return (
-    <IcTheme theme={theme}>
+    <IcTheme id="theme-wrapper" theme={theme}>
       <IcTopNavigation
         appTitle="[Enter your application name]"
         status="alpha"
@@ -342,3 +342,16 @@ This pattern includes the components:
 - [Typography](/components/typography)
 
 As well as the [theme wrapper](/get-started/install-components/custom-theme).
+
+## CSS color-scheme
+
+When manually switching the theme using this pattern, things like browser scrollbars and other native elements may not switch their color-scheme. To ensure consistency, you may need to add the following CSS to the root of your project:
+
+```css
+html:has(#theme-wrapper.ic-theme-dark) {
+  color-scheme: dark;
+}
+html:has(#theme-wrapper.ic-theme-light) {
+  color-scheme: light;
+}
+```

--- a/src/pages/dark-mode-pattern.tsx
+++ b/src/pages/dark-mode-pattern.tsx
@@ -73,7 +73,7 @@ const TopNavigation: React.FC<PageProps> = () => {
   const classes = useStyles();
 
   return (
-    <IcTheme theme={theme}>
+    <IcTheme id="theme-wrapper" theme={theme}>
       <IcTopNavigation
         appTitle="[Enter your application name]"
         status="alpha"

--- a/src/styles/color-mode.css
+++ b/src/styles/color-mode.css
@@ -18,3 +18,11 @@ ic-theme {
     --table-of-contents-label: var(--ic-color-text-primary);
   }
 }
+
+/* sets the color-scheme for browser elements when in dark mode */
+html:has(#theme-wrapper.ic-theme-dark) {
+  color-scheme: dark;
+}
+html:has(#theme-wrapper.ic-theme-light) {
+  color-scheme: light;
+}

--- a/src/styles/gatsby-reset.css
+++ b/src/styles/gatsby-reset.css
@@ -3,12 +3,6 @@ html {
   -webkit-text-size-adjust: 100%;
   height: 100%;
 }
-html:has(#theme-wrapper.ic-theme-dark) {
-  color-scheme: dark;
-}
-html:has(#theme-wrapper.ic-theme-light) {
-  color-scheme: light;
-}
 body {
   margin: 0;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## Summary of the changes
- Moved the css that updates color-scheme to `color-mode.css`, which still makes it work for the site as a whole, but now covers the pattern pages.
- Added this css to a snippet on the dark mode pattern page to tell users how to implement it in their apps. Updated our pattern to match.

## Related issue
[#3212](https://github.com/mi6/ic-ui-kit/issues/3212)

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
