### PR TITLE
fix(root): add color to visited links in safari

### DIFF
--- a/src/styles/gatsby-override.css
+++ b/src/styles/gatsby-override.css
@@ -9,3 +9,5 @@ ic-typography label {
   font: inherit;
   letter-spacing: inherit;
 }
+
+ic-link > a:visited { color: var(--ic-hyperlink-visited) !important; }


### PR DESCRIPTION
## Summary of the changes

Adds a color to visited anchor tag elements in mdx.

## Related issue

https://github.com/mi6/ic-ui-kit/issues/2197


## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
