### PR TITLE
1365 links in markdown pages do not work on deployed site

### DIFF
--- a/src/components/WrappedLink/index.tsx
+++ b/src/components/WrappedLink/index.tsx
@@ -10,16 +10,27 @@ interface WrappedLinkProps {
 
 // Destructuring props results in those values being undefined?
 /* eslint-disable react/destructuring-assignment */
-const WrappedLink: React.FC<WrappedLinkProps> = (props) =>
-  props.href ? (
+const WrappedLink: React.FC<WrappedLinkProps> = (props) => {
+  let correctedHref = props.href;
+
+  if (
+    props.href &&
+    process.env.GATSBY_ICDS_PREFIX &&
+    props.href.startsWith(process.env.GATSBY_ICDS_PREFIX)
+  ) {
+    correctedHref = props.href.replace(process.env.GATSBY_ICDS_PREFIX, "");
+  }
+
+  return correctedHref ? (
     <ic-link>
-      <GatsbyLink to={props.href} {...props}>
+      <GatsbyLink to={correctedHref} {...props}>
         {props.children}
       </GatsbyLink>
     </ic-link>
   ) : (
     <ic-link {...props} />
   );
+};
 /* eslint-enable react/destructuring-assignment */
 
 export default WrappedLink;


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update WrappedLink to remove the duplicated GATSBY_ICDS_PREFIX for github pages deployment

## Related issue

#1365

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
