### PR TITLE
docs(root): add examples of custom and full width code snippets in ic-text-field

### DIFF
--- a/src/content/structured/components/text-field/code.mdx
+++ b/src/content/structured/components/text-field/code.mdx
@@ -730,3 +730,168 @@ return (
     helperText="Such as Arabica, Robusta or Liberica"
   />
 </ComponentPreview>
+
+### Full width text field
+
+export const snippetsFullWidth = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-text-field  
+  label="What is your favourite coffee?" 
+  required="true" 
+  placeholder="Please enter…" 
+  helper-text="Such as Arabica, Robusta or Liberica" 
+  full-width="true"
+>
+</ic-text-field>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTextField
+  label="What is your favourite coffee?" 
+  required 
+  placeholder="Please enter…" 
+  helperText="Such as Arabica, Robusta or Liberica"
+  fullWidth="true"
+>
+</IcTextField>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsFullWidth}>
+  <IcTextField
+    label="What is your favourite coffee?"
+    required
+    placeholder="Please enter…"
+    helperText="Such as Arabica, Robusta or Liberica"
+    fullWidth="true"
+  />
+</ComponentPreview>
+
+### Custom width text field
+
+export const snippetsCustomWidth = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-text-field  
+  label="What is your favourite coffee?" 
+  required="true" 
+  placeholder="Please enter…" 
+  helper-text="Such as Arabica, Robusta or Liberica" 
+>
+</ic-text-field>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+  ic-text-field {
+    --input-width: 25.25rem;
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTextField
+  label="What is your favourite coffee?" 
+  required 
+  placeholder="Please enter…" 
+  helperText="Such as Arabica, Robusta or Liberica"
+>
+</IcTextField>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+  textField: {
+    "--input-width": "25.25rem",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+  textField: {
+    "--input-width": "25.25rem",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsCustomWidth}>
+  <IcTextField
+    style={{ "--input-width": "25.25rem" }}
+    label="What is your favourite coffee?"
+    required
+    placeholder="Please enter…"
+    helperText="Such as Arabica, Robusta or Liberica"
+  />
+</ComponentPreview>


### PR DESCRIPTION
…-text-field

add examples of custom and full width code snippets in ic-text-field

1084

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Added two code examples to the Ic-Text-Field code tab. One shows a full width text box and the other shows a text box fo custom width

## Related issue

1084

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [ ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
