### PR TITLE
docs(root): updated typography page with latest font details

### DIFF
--- a/src/content/structured/styles/components/TypographicScale/index.css
+++ b/src/content/structured/styles/components/TypographicScale/index.css
@@ -9,8 +9,7 @@ ic-button[data-class="additional-padding"] {
   margin-bottom: var(--ic-space-xs);
 }
 
-.caption {
-  opacity: 1;
+.ic-typography-caption {
   margin-bottom: 0.375rem;
 }
 

--- a/src/content/structured/styles/components/TypographicScale/index.tsx
+++ b/src/content/structured/styles/components/TypographicScale/index.tsx
@@ -1,132 +1,51 @@
 import React from "react";
 
 import "./index.css";
+import { TypographyConfig, TypographyVariant } from "./typography.config";
 
-interface TypographicScaleProps {
-  variants: string;
-}
+const ExampleElement: React.FC<{
+  variant: TypographyVariant;
+  title: string;
+}> = ({ variant, title }) => {
+  if (variant === "link")
+    return (
+      <ic-typography variant="body" data-class="additional-padding">
+        <ic-link href="/styles/typography">{title}</ic-link>
+      </ic-typography>
+    );
+  if (variant.includes("label"))
+    return (
+      <ic-button
+        variant={variant === "label-uppercase" ? "destructive" : "secondary"}
+        data-class="additional-padding"
+      >
+        {title}
+      </ic-button>
+    );
+  return <ic-typography variant={variant}>{title}</ic-typography>;
+};
 
-const TypographicScale: React.FC<TypographicScaleProps> = ({ variants }) => (
+const TypographicScale: React.FC<{
+  config: TypographyConfig[];
+}> = ({ config }) => (
   <div className="typography-container">
-    {variants.indexOf("h1") >= 0 && (
-      <>
-        <ic-typography variant="h1">Heading extra large</ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Nunito Sans • ExtraBold • 42pt • Line-height: 56pt • Letter-spacing:
-          normal
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("h2") >= 0 && (
-      <>
-        <ic-typography variant="h2">Heading large</ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Nunito Sans • Bold • 34pt • Line-height: 45pt • Letter-spacing:
-          0.0025rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("h3") >= 0 && (
-      <>
-        <ic-typography variant="h3">Heading medium</ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • Regular • 24pt • Line-height: 32pt • Letter-spacing:
-          normal
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("h4") >= 0 && (
-      <>
-        <ic-typography variant="h4">Heading small</ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • SemiBold • 20pt • Line-height: 24pt • Letter-spacing:
-          0.0015rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("subtitle-large") >= 0 && (
-      <>
-        <ic-typography variant="subtitle-large">Subtitle large</ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • Bold • 16pt • Line-height: 24pt • Letter-spacing:
-          0.0015rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("subtitle-small") >= 0 && (
-      <>
-        <ic-typography variant="subtitle-small">
-          Subtitle small and table headings
-        </ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • SemiBold • 14pt • Line-height: 16pt • Letter-spacing:
-          0.0015rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("body") >= 0 && (
-      <>
-        <ic-typography variant="body">Body</ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • Regular • 16pt • Line-height: 24pt • Letter-spacing:
-          0.005rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("caption") >= 0 && (
-      <>
-        <ic-typography variant="caption">
-          Helper text on input fields and other captions
-        </ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • SemiBold • 12pt • Line-height: 20pt • Letter-spacing:
-          0.0025rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("caption-uppercase") >= 0 && (
-      <>
-        <ic-typography variant="caption-uppercase">
-          Helper text on input fields and other captions
-        </ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • SemiBold • 12pt • Line-height: 20pt • Letter-spacing:
-          0.0025rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("label") >= 0 && (
-      <>
-        <ic-button variant="secondary" data-class="additional-padding">
-          Secondary button
-        </ic-button>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • SemiBold • 14pt • Line-height: 24pt • Letter-spacing:
-          0.0025rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("label-uppercase") >= 0 && (
-      <>
-        <ic-button variant="destructive" data-class="additional-padding">
-          DESTRUCTIVE BUTTON
-        </ic-button>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • SemiBold • 14pt • Line-height: 24pt • Letter-spacing:
-          0.0025rem
-        </ic-typography>
-      </>
-    )}
-    {variants.indexOf("link") >= 0 && (
-      <>
-        <ic-typography variant="body" data-class="additional-padding">
-          <ic-link href="/styles/typography">Link style</ic-link>
-        </ic-typography>
-        <ic-typography variant="caption" data-class="internal-caption">
-          Open Sans • Bold underline • 16pt • Line-height: 24pt •
-          Letter-spacing: 0.0025rem
-        </ic-typography>
-      </>
+    {config.map(
+      ({
+        variant,
+        title,
+        fontFamily,
+        fontSize,
+        fontWeight,
+        letterSpacing,
+        lineHeight,
+      }) => (
+        <>
+          <ExampleElement variant={variant} title={title} />
+          <ic-typography variant="caption" data-class="internal-caption">
+            {`${fontFamily} • ${fontWeight} • ${fontSize}rem • Line-height: ${lineHeight}rem • Letter-spacing: ${letterSpacing}`}
+          </ic-typography>
+        </>
+      )
     )}
   </div>
 );

--- a/src/content/structured/styles/components/TypographicScale/typography.config.ts
+++ b/src/content/structured/styles/components/TypographicScale/typography.config.ts
@@ -1,0 +1,167 @@
+import { IcTypographyVariants } from "@ukic/web-components";
+
+export type TypographyVariant = IcTypographyVariants | "link";
+
+export interface TypographyConfig {
+  variant: TypographyVariant;
+  title: string;
+  fontFamily: "Nunito sans" | "Open sans" | "Source Code Pro";
+  fontWeight: "ExtraBold" | "Bold" | "Regular" | "SemiBold";
+
+  /** Value expected in `rem` units */
+  fontSize: number;
+
+  /** Value expected in `rem` units */
+  lineHeight: number;
+  letterSpacing: string;
+}
+
+export const TypographyHeadings: TypographyConfig[] = [
+  {
+    variant: "h1",
+    title: "Heading extra large",
+    fontFamily: "Nunito sans",
+    fontWeight: "ExtraBold",
+    fontSize: 2.625,
+    lineHeight: 3.5,
+    letterSpacing: "normal",
+  },
+  {
+    variant: "h2",
+    title: "Heading large",
+    fontFamily: "Nunito sans",
+    fontWeight: "Bold",
+    fontSize: 2.125,
+    lineHeight: 3.5,
+    letterSpacing: "0.0025rem",
+  },
+  {
+    variant: "h3",
+    title: "Heading medium",
+    fontFamily: "Open sans",
+    fontWeight: "Regular",
+    fontSize: 1.5,
+    lineHeight: 2.5,
+    letterSpacing: "normal",
+  },
+  {
+    variant: "h4",
+    title: "Heading small",
+    fontFamily: "Open sans",
+    fontWeight: "SemiBold",
+    fontSize: 1.25,
+    lineHeight: 2,
+    letterSpacing: "0.0015rem",
+  },
+];
+
+export const TypographySubtitles: TypographyConfig[] = [
+  {
+    variant: "subtitle-large",
+    title: "Subtitle large",
+    fontFamily: "Open sans",
+    fontWeight: "Bold",
+    fontSize: 1,
+    lineHeight: 1.5,
+    letterSpacing: "0.0015rem",
+  },
+  {
+    variant: "subtitle-small",
+    title: "Subtitle small and table headings",
+    fontFamily: "Open sans",
+    fontWeight: "SemiBold",
+    fontSize: 0.875,
+    lineHeight: 1.5,
+    letterSpacing: "0.0015rem",
+  },
+];
+
+export const TypographyText: TypographyConfig[] = [
+  {
+    variant: "body",
+    title: "Body",
+    fontFamily: "Open sans",
+    fontWeight: "Regular",
+    fontSize: 1,
+    lineHeight: 1.5,
+    letterSpacing: "0.005rem",
+  },
+  {
+    variant: "caption",
+    title: "Helper text on input fields and other captions",
+    fontFamily: "Open sans",
+    fontWeight: "SemiBold",
+    fontSize: 0.75,
+    lineHeight: 1.25,
+    letterSpacing: "0.0025rem",
+  },
+  {
+    variant: "caption-uppercase",
+    title: "Helper text on input fields and other captions",
+    fontFamily: "Open sans",
+    fontWeight: "SemiBold",
+    fontSize: 0.75,
+    lineHeight: 1.25,
+    letterSpacing: "0.0025rem",
+  },
+  {
+    variant: "code-large",
+    title: "Code large",
+    fontFamily: "Source Code Pro",
+    fontWeight: "Regular",
+    fontSize: 1,
+    lineHeight: 1.5,
+    letterSpacing: "0.025rem",
+  },
+  {
+    variant: "code-small",
+    title: "Code small",
+    fontFamily: "Source Code Pro",
+    fontWeight: "SemiBold",
+    fontSize: 0.875,
+    lineHeight: 1.5,
+    letterSpacing: "0.005rem",
+  },
+  {
+    variant: "code-extra-small",
+    title: "Code extra-small",
+    fontFamily: "Source Code Pro",
+    fontWeight: "Regular",
+    fontSize: 0.75,
+    lineHeight: 1.5,
+    letterSpacing: "0.025rem",
+  },
+];
+
+export const TypographyLabels: TypographyConfig[] = [
+  {
+    variant: "label",
+    title: "Secondary button",
+    fontFamily: "Open sans",
+    fontWeight: "SemiBold",
+    fontSize: 0.875,
+    lineHeight: 1.5,
+    letterSpacing: "0.025rem",
+  },
+  {
+    variant: "label-uppercase",
+    title: "Destructive button",
+    fontFamily: "Open sans",
+    fontWeight: "SemiBold",
+    fontSize: 0.875,
+    lineHeight: 1.5,
+    letterSpacing: "0.025rem",
+  },
+];
+
+export const TypographyLinks: TypographyConfig[] = [
+  {
+    variant: "link",
+    title: "Link style",
+    fontFamily: "Open sans",
+    fontWeight: "Regular",
+    fontSize: 1,
+    lineHeight: 1.5,
+    letterSpacing: "0.005rem",
+  },
+];

--- a/src/content/structured/styles/typography.mdx
+++ b/src/content/structured/styles/typography.mdx
@@ -3,7 +3,7 @@ path: "/styles/typography"
 
 navPriority: 6
 
-date: "2022-11-15"
+date: "2025-03-11"
 
 title: "Typography"
 
@@ -11,6 +11,13 @@ contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/struc
 ---
 
 import TypographicScale from "./components/TypographicScale";
+import {
+  TypographyHeadings,
+  TypographyLabels,
+  TypographyLinks,
+  TypographySubtitles,
+  TypographyText,
+} from "./components/TypographicScale/typography.config";
 
 ## Using consistent typography
 
@@ -43,7 +50,7 @@ Write all headings in sentence case.
 
 Use the logical order of `h#` tags in code. For example, a `h3` heading needs to come after a `h2` heading but can be styled as any variant. It's important that [heading tags are used properly](/accessibility/coding/headings).
 
-<TypographicScale variants="h1, h2, h3, h4" />
+<TypographicScale config={TypographyHeadings} />
 
 ## Subtitles
 
@@ -51,22 +58,34 @@ Write all subtitles in sentence case.
 
 Use subtitles for sub-section headings and table headings.
 
-<TypographicScale variants="subtitle-large, subtitle-small" />
+<TypographicScale config={TypographySubtitles} />
 
 ## Text
 
 Write all body text in sentence case.
 
-Use a minimum of 16pt for body text. 18pt should be used for apps with a lot of text (like intranets or reports).
+Use a minimum of `1rem` for body text. `1.125rem` should be used for apps with a lot of text (like intranets or reports).
 
-<TypographicScale variants="body, caption, caption-uppercase" />
+<p>
+  Code snippets use the{" "}
+  <ic-link
+    target="_blank"
+    href="https://fonts.google.com/specimen/Source+Code+Pro"
+    rel="noreferrer noopener nofollow"
+  >
+    Source Code Pro
+  </ic-link>{" "}
+  font.
+</p>
+
+<TypographicScale config={TypographyText} />
 
 ## Labels
 
-<TypographicScale variants="label, label-uppercase" />
+<TypographicScale config={TypographyLabels} />
 
 ## Links
 
 If your link is at the end of a sentence or paragraph, make sure that the linked text does not include the full stop.
 
-<TypographicScale variants="link" />
+<TypographicScale config={TypographyLinks} />


### PR DESCRIPTION
## Summary of the changes
- Refactored the TypographyScale component to pull values from a config file (similar to the colours pages) rather than using hard-coded values.
- Updated the values in the new config to be the latest typography values, displayed in correct units (rem).

## Related issue
#1291 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
