### PR TITLE
fix(root): fixes web-comps stackblitz examples

### DIFF
--- a/src/content/structured/patterns/components/StackblitzButton/stackblitz-helpers.ts
+++ b/src/content/structured/patterns/components/StackblitzButton/stackblitz-helpers.ts
@@ -242,6 +242,15 @@ export const createWebComponentsIndexHTML = (
 
   const formattedCodeSnippet = formatLines();
 
+  const fontsPackage =
+    `${designSystemPackageJson.dependencies["@ukic/fonts"]}`.slice(1);
+  const webCompsPackage =
+    `${designSystemPackageJson.dependencies["@ukic/web-components"]}`.slice(1);
+  const canaryWebCompsPackage =
+    `${designSystemPackageJson.dependencies["@ukic/canary-web-components"]}`.slice(
+      1
+    );
+
   return `<html lang="en">
   <head>
     <title>Home</title>
@@ -250,30 +259,30 @@ export const createWebComponentsIndexHTML = (
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://unpkg.com/@ukic/fonts/dist/fonts.css"
+      href="https://unpkg.com/@ukic/fonts@${fontsPackage}/dist/fonts.css"
       crossorigin="anonymous"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://unpkg.com/@ukic/web-components/dist/core/core.css"
+      href="https://unpkg.com/@ukic/web-components@${webCompsPackage}/dist/core/core.css"
       crossorigin="anonymous"
     />
     <link
       rel="stylesheet"
       type="text/css"
-      href="https://unpkg.com/@ukic/web-components/dist/core/normalize.css"
+      href="https://unpkg.com/@ukic/web-components@${webCompsPackage}/dist/core/normalize.css"
       crossorigin="anonymous"
     />
   </head>
   ${styling}
     ${formattedCodeSnippet}
     <script defer>
-      import('https://unpkg.com/@ukic/web-components/loader').then((module) => {
+      import('https://unpkg.com/@ukic/web-components@${webCompsPackage}/loader').then((module) => {
         module.defineCustomElements();
       });${
         getCanaryWebComponentsImports()
-          ? `\n\t  import('https://unpkg.com/@ukic/canary-web-components/loader').then((module) => {
+          ? `\n\t  import('https://unpkg.com/@ukic/canary-web-components@${canaryWebCompsPackage}/loader').then((module) => {
         module.defineCustomElements();
       });`
           : ""


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Fixes web-components examples not working in stackblitz on v3 due to loading v2 packages

## Related issue

#1424 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
