### PR TITLE
fix(root): added override to mdxjs replacing typography examples

### DIFF
--- a/src/components/WrappedH1/index.tsx
+++ b/src/components/WrappedH1/index.tsx
@@ -2,15 +2,22 @@ import React from "react";
 
 import "./index.css";
 
-const WrappedH1: React.FC = (props: any) => (
-  <ic-typography
-    variant="h1"
-    apply-vertical-margins
-    data-class="heading-extra-large"
-  >
-    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-    <h2 {...props} />
-  </ic-typography>
-);
+interface WrappedH1Props {
+  children: string;
+  preview?: boolean;
+}
+
+const WrappedH1: React.FC = ({ children, preview }: WrappedH1Props) =>
+  preview ? (
+    <h1>{children}</h1>
+  ) : (
+    <ic-typography
+      variant="h1"
+      apply-vertical-margins
+      data-class="heading-extra-large"
+    >
+      <h2>{children}</h2>
+    </ic-typography>
+  );
 
 export default WrappedH1;

--- a/src/components/WrappedH2/index.tsx
+++ b/src/components/WrappedH2/index.tsx
@@ -8,16 +8,19 @@ const { slug } = require("github-slugger");
 
 interface WrappedH2Props {
   children: string;
+  preview?: boolean;
 }
 
-const WrappedH2: React.FC<WrappedH2Props> = ({ children }) => (
-  <ic-typography variant="h2" apply-vertical-margins data-class="h2">
-    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-    <h3 id={slug(children)}>
-      {children}
-      <Permalink title={children} sluggedTitle={slug(children)} />
-    </h3>
-  </ic-typography>
-);
+const WrappedH2: React.FC<WrappedH2Props> = ({ children, preview }) =>
+  preview ? (
+    <h2>{children}</h2>
+  ) : (
+    <ic-typography variant="h2" apply-vertical-margins data-class="h2">
+      <h3 id={slug(children)}>
+        {children}
+        <Permalink title={children} sluggedTitle={slug(children)} />
+      </h3>
+    </ic-typography>
+  );
 
 export default WrappedH2;

--- a/src/components/WrappedH3/index.tsx
+++ b/src/components/WrappedH3/index.tsx
@@ -8,16 +8,19 @@ const { slug } = require("github-slugger");
 
 interface WrappedH3Props {
   children: string;
+  preview?: boolean;
 }
 
-const WrappedH3: React.FC<WrappedH3Props> = ({ children }) => (
-  <ic-typography variant="h3" apply-vertical-margins data-class="h3">
-    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-    <h4 id={slug(children)}>
-      {children}
-      <Permalink title={children?.toString()} sluggedTitle={slug(children)} />
-    </h4>
-  </ic-typography>
-);
+const WrappedH3: React.FC<WrappedH3Props> = ({ children, preview }) =>
+  preview ? (
+    <h3>{children}</h3>
+  ) : (
+    <ic-typography variant="h3" apply-vertical-margins data-class="h3">
+      <h4 id={slug(children)}>
+        {children}
+        <Permalink title={children?.toString()} sluggedTitle={slug(children)} />
+      </h4>
+    </ic-typography>
+  );
 
 export default WrappedH3;

--- a/src/components/WrappedH4/index.tsx
+++ b/src/components/WrappedH4/index.tsx
@@ -2,11 +2,18 @@ import React from "react";
 
 import "./index.css";
 
-const WrappedH4: React.FC = (props: any) => (
-  <ic-typography variant="h4" apply-vertical-margins data-class="h4">
-    {/* eslint-disable-next-line jsx-a11y/heading-has-content */}
-    <h5 {...props} />
-  </ic-typography>
-);
+interface WrappedH4Props {
+  children: string;
+  preview?: boolean;
+}
+
+const WrappedH4: React.FC = ({ children, preview }: WrappedH4Props) =>
+  preview ? (
+    <h4>{children}</h4>
+  ) : (
+    <ic-typography variant="h4" apply-vertical-margins data-class="h4">
+      <h5>{children}</h5>
+    </ic-typography>
+  );
 
 export default WrappedH4;

--- a/src/content/structured/components/typography/code.mdx
+++ b/src/content/structured/components/typography/code.mdx
@@ -29,10 +29,18 @@ export const snippets = [
   {
     technology: "Web component",
     snippets: {
-      short: `<ic-typography variant="h1"><h1>H1</h1></ic-typography>
-<ic-typography variant="h2"><h2>H2</h2></ic-typography>
-<ic-typography variant="h3"><h3>H3</h3></ic-typography>
-<ic-typography variant="h4"><h4>H4</h4></ic-typography>
+      short: `<ic-typography variant="h1">
+  <h1>H1</h1>
+</ic-typography>
+<ic-typography variant="h2">
+  <h2>H2</h2>
+</ic-typography>
+<ic-typography variant="h3">
+  <h3>H3</h3>
+</ic-typography>
+<ic-typography variant="h4">
+  <h4>H4</h4>
+</ic-typography>
 <ic-typography>Body</ic-typography>
 <ic-typography variant="subtitle-large">Subtitle large</ic-typography>
 <ic-typography variant="subtitle-small">Subtitle small</ic-typography>
@@ -49,10 +57,18 @@ export const snippets = [
   {
     technology: "React",
     snippets: {
-      short: `<IcTypography variant="h1">H1</IcTypography>
-<IcTypography variant="h2"><h2>H2</h2></IcTypography>
-<IcTypography variant="h3"><h3>H3</h3></IcTypography>
-<IcTypography variant="h4"><h4>H4</h4></IcTypography>
+      short: `<IcTypography variant="h1">
+  <h1>H1</h1>
+</IcTypography>
+<IcTypography variant="h2">
+  <h2>H2</h2>
+</IcTypography>
+<IcTypography variant="h3">
+  <h3>H3</h3>
+</IcTypography>
+<IcTypography variant="h4">
+  <h4>H4</h4>
+</IcTypography>
 <IcTypography>Body</IcTypography>
 <IcTypography variant="subtitle-large">Subtitle large</IcTypography>
 <IcTypography variant="subtitle-small">Subtitle small</IcTypography>
@@ -84,16 +100,16 @@ export const snippets = [
 <ComponentPreview snippets={snippets}>
   <div>
     <IcTypography variant="h1">
-      <h1>H1</h1>
+      <h1 preview>H1</h1>
     </IcTypography>
     <IcTypography variant="h2">
-      <h2>H2</h2>
+      <h2 preview>H2</h2>
     </IcTypography>
     <IcTypography variant="h3">
-      <h3>H3</h3>
+      <h3 preview>H3</h3>
     </IcTypography>
     <IcTypography variant="h4">
-      <h4>H4</h4>
+      <h4 preview>H4</h4>
     </IcTypography>
     <IcTypography>Body</IcTypography>
     <IcTypography variant="subtitle-large">Subtitle large</IcTypography>
@@ -160,7 +176,7 @@ export const spacingSnippets = [
   {
     technology: "Web component",
     snippets: {
-      short: `<ic-typography apply-vertical-margins="true">
+      short: `<ic-typography apply-vertical-margins>
   <h5>H5 with margins applied</h5>
 </ic-typography>`,
       long: `{shortCode}`,
@@ -198,7 +214,7 @@ export const spacingRestyledSnippets = [
   {
     technology: "Web component",
     snippets: {
-      short: `<ic-typography variant="h2" apply-vertical-margins="true">
+      short: `<ic-typography variant="h2" apply-vertical-margins>
   <h5>H5 with H2 styling and margins applied</h5>
 </ic-typography>`,
       long: `{shortCode}`,
@@ -305,20 +321,36 @@ export const additionalStylingSnippets = [
   {
     technology: "Web component",
     snippets: {
-      short: `<ic-typography variant="h4" bold="true">Bold</ic-typography>
-<ic-typography variant="h4" italic="true">Italic</ic-typography>
-<ic-typography variant="h4" underline="true">Underline</ic-typography>
-<ic-typography variant="h4" strikethrough="true">Strikethrough</ic-typography>`,
+      short: `<ic-typography variant="h4" bold>
+  <h4>Bold</h4>
+</ic-typography>
+<ic-typography variant="h4" italic>
+  <h4>Italic</h4>
+</ic-typography>
+<ic-typography variant="h4" underline>
+  <h4>Underline</h4>
+</ic-typography>
+<ic-typography variant="h4" strikethrough>
+  <h4>Strikethrough</h4>
+</ic-typography>`,
       long: `{shortCode}`,
     },
   },
   {
     technology: "React",
     snippets: {
-      short: `<IcTypography variant="h4" bold>Bold</IcTypography>
-<IcTypography variant="h4" italic>Italic</IcTypography>
-<IcTypography variant="h4" underline>Underline</IcTypography>
-<IcTypography variant="h4" strikethrough>Strikethrough</IcTypography>`,
+      short: `<IcTypography variant="h4" bold>
+  <h4>Bold</h4>
+</IcTypography>
+<IcTypography variant="h4" italic>
+  <h4>Italic</h4>
+</IcTypography>
+<IcTypography variant="h4" underline>
+  <h4>Underline</h4>
+</IcTypography>
+<IcTypography variant="h4" strikethrough>
+  <h4>Strikethrough</h4>
+</IcTypography>`,
       long: [
         {
           language: "Typescript",
@@ -340,16 +372,16 @@ export const additionalStylingSnippets = [
 <ComponentPreview snippets={additionalStylingSnippets}>
   <div>
     <IcTypography variant="h4" bold>
-      <h4>Bold</h4>
+      <h4 preview>Bold</h4>
     </IcTypography>
     <IcTypography variant="h4" italic>
-      <h4>Italic</h4>
+      <h4 preview>Italic</h4>
     </IcTypography>
     <IcTypography variant="h4" underline>
-      <h4>Underline</h4>
+      <h4 preview>Underline</h4>
     </IcTypography>
     <IcTypography variant="h4" strikethrough>
-      <h4>Strikethrough</h4>
+      <h4 preview>Strikethrough</h4>
     </IcTypography>
   </div>
 </ComponentPreview>


### PR DESCRIPTION
## Summary of the changes
- Added a boolean prop called `preview` to the header tags included within the typography code previews. When mdxjs detects it and tries to replace it as per our custom component overrides, the prop is detected and a regular header tag is rendered instead. I figured that we'd still want to show the code examples as they are, since it follows our guidance to use correct header semantics, so I implemented this rather than just removing the header tags from the examples.
- Updated code snippets to read better

## Related issue
#1391 

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
