### PR TITLE
1407 parent tree items should close when child tree item selected 

### DIFF
--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -163,8 +163,13 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
       return isOverviewSelected || isAnyChildSelected;
     };
 
+    const [isExpanded, setIsExpanded] = useState(
+      hasChildren && isChildSelected(item)
+    );
+
     const handleParentClick = () => {
       setTreeChange(true);
+      setIsExpanded(!isExpanded);
     };
 
     return (
@@ -179,7 +184,7 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
             : handleNavigation(item.data.fields.slug);
         }}
         onKeyUp={hasChildren ? handleKeyUpParent : handleKeyUp}
-        {...(hasChildren && isChildSelected(item) && { expanded: true })}
+        expanded={isExpanded}
       >
         {hasChildren && (
           <IcTreeItem


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update parent tree items to be collapsible when a child tree item is selected

## Related issue

#1407

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
