### PR TITLE
docs(root): update codemod instructions to include "next" tag

### DIFF
--- a/src/content/structured/get-started/migrating-to-v3.mdx
+++ b/src/content/structured/get-started/migrating-to-v3.mdx
@@ -60,7 +60,7 @@ Given a directory, it will scan over files and find any relevant ICDS components
 ```console
 - npm i @ukic/react@next
 - npm i @ukic/web-components@next
-- npx @ukic/codemod <dir> <test>
+- npx @ukic/codemod@next <dir> <test>
 ```
 
 ## Breaking changes


### PR DESCRIPTION
## Summary of the changes
Update codemod instructions to include "@next" in the npx command so that it always uses the latest version. Prevents it running the oldest version which does not have some changes e.g. it does not run on all files that need changing.

I have tested this by comparing running the npx command with vs. without "@next" on a repo with v2 ICDS components.

(Equivalent to PR [#3356](https://github.com/mi6/ic-ui-kit/pull/3356))

## Related issue
mi6/ic-ui-kit#3297

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
