### PR TITLE
docs(root): update migrating to v3 page with Ic-Dialog and Ic-Select changes

### DIFF
--- a/src/content/structured/get-started/migrating-to-v3.mdx
+++ b/src/content/structured/get-started/migrating-to-v3.mdx
@@ -94,6 +94,7 @@ Given a directory, it will scan over files and find any relevant ICDS components
 - The `max-length/maxLength` prop has been removed. Instead, use the `max-characters/maxCharacters` prop and the `hide-char-count/hideCharCount` prop to hide the character count visually.
 - The `small` prop has been removed. Please use `size="small"` instead.
 - The `size=”default”` prop has been removed. Please use `size="medium"` instead.
+- The `button-props/buttonProps` prop has been removed from the `ic-dialog` (`IcDialog`) component and replaced with the `dialog-controls` slot.
 
 ### 4. Class name changes
 
@@ -113,6 +114,8 @@ Given a directory, it will scan over files and find any relevant ICDS components
 - The `ic-toast` (`IcToast`) component now shows a dismiss button when the toast is hovered over or focused.
 - The shadow DOM has been removed from `ic-radio` (`IcRadio`) and may affect current tests.
 - `ic-multi-select` (`IcMultiSelect`) is no longer a standalone component. The multi-select functionality can now be achieved using the `ic-select` (`IcSelect`) component and its `multiple` prop.
+- The `ic-select` (`IcSelect`) component's searchable variant now clears the input field when it loses focus if the value does not match any of the items in the list of options.
+- The `ic-select` (`IcSelect`) component's `onIcChange/icChange` event is no longer emitted on each keystroke or controlled by the `debounce` prop. The `onIcInput/icInput` event should be used for handling changes based on keystrokes and is controlled by the `debounce` prop.
 
 ```tsx
 // v2


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

docs(root): update migrating to v3 page with Ic-Dialog and Ic-Select changes

## Related issue

#1436

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [v3 develop branch](https://github.com/mi6/ic-design-system/tree/develop)
