### PR TITLE
feat(root): updated colours page to always display latest colours

### DIFF
--- a/src/content/structured/styles/colour.mdx
+++ b/src/content/structured/styles/colour.mdx
@@ -3,7 +3,7 @@ path: "/styles/colour"
 
 navPriority: 1
 
-date: "2025-02-11"
+date: "2025-04-07"
 
 title: "Colour"
 
@@ -29,6 +29,9 @@ import {
   ColoursArchitecturalStateLayers,
   ColoursBlue,
   ColoursBlueStateLayers,
+  ColoursDarkBlue,
+  ColoursLightBlue,
+  ColoursLinksPrimitive,
   ColoursRed,
   ColoursGreen,
   ColoursPurple,
@@ -69,9 +72,29 @@ The primitive tokens are grouped as follows;
 
 <ColorTable config={ColoursBlueStateLayers} />
 
+### Brand
+
+<ColorTable config={ColoursBrand} />
+
+### Dark blue
+
+<ColorTable config={ColoursDarkBlue} />
+
+### Focus
+
+<ColorTable config={ColoursFocus} />
+
 ### Green
 
 <ColorTable config={ColoursGreen} />
+
+### Light blue
+
+<ColorTable config={ColoursLightBlue} />
+
+### Link
+
+<ColorTable config={ColoursLinksPrimitive} />
 
 ### Purple
 
@@ -91,7 +114,7 @@ These tokens carry meaning and explain the intent of their use. A semantic token
 
 For example, `border/error/default = Color/Red/800` (This token is for a border in an error state.)
 
-Semantic tokens are grouped as follows (`Key = Colour name | CSS token | Light & Dark hex value`);
+Semantic tokens are grouped as follows, with colours displaying the light and dark tokens where necessary;
 
 ### Action
 
@@ -105,19 +128,11 @@ Semantic tokens are grouped as follows (`Key = Colour name | CSS token | Light &
 
 <ColorTable config={ColoursBorders} />
 
-### Brand
-
-<ColorTable config={ColoursBrand} />
-
 ### Classification
 
 <ColorTable config={ColoursClassification} />
 
-### Focus
-
-<ColorTable config={ColoursFocus} />
-
-### Icons
+### Icon
 
 <ColorTable config={ColoursIcons} />
 

--- a/src/content/structured/styles/components/ColourTable/colours.config.ts
+++ b/src/content/structured/styles/components/ColourTable/colours.config.ts
@@ -1,564 +1,83 @@
 export interface ColorConfig {
   name: string;
   token: string;
-  hex: string;
-  hexDark?: string;
+  darkToken?: string;
 }
 
-export const ColoursText: ColorConfig[] = [
-  {
-    name: "Primary text",
-    token: "--ic-color-text-primary",
-    hex: "#0b0c0c",
-    hexDark: "#ffffff",
-  },
-  {
-    name: "Secondary text",
-    token: "--ic-color-text-secondary",
-    hex: "#41464d",
-    hexDark: "#e1e3e5",
-  },
-  {
-    name: "Tertiary text",
-    token: "--ic-color-text-tertiary",
-    hex: "#6c7580",
-    hexDark: "#c4c8cd",
-  },
-  {
-    name: "Inverse text",
-    token: "--ic-color-text-inverse",
-    hex: "#fff",
-    hexDark: "#0b0c0c",
-  },
-  {
-    name: "Disabled text",
-    token: "--ic-color-text-disabled",
-    hex: "#c4c8cd",
-    hexDark: "#575e68",
-  },
-];
-
-export const ColoursAction: ColorConfig[] = [
-  {
-    name: "Action default",
-    token: "--ic-action-default",
-    hex: "#1759bc",
-    hexDark: "#488fe3",
-  },
-  {
-    name: "Action default hover",
-    token: "--ic-action-default-hover",
-    hex: "#0b399c",
-    hexDark: "#77b4f0",
-  },
-  {
-    name: "Action default pressed",
-    token: "--ic-action-default-pressed",
-    hex: "#07277e",
-    hexDark: "#98c9f5",
-  },
-  {
-    name: "Action default selected",
-    token: "--ic-action-default-selected",
-    hex: "#1759bc1a",
-    hexDark: "#124db3",
-  },
-  {
-    name: "Action destructive",
-    token: "--ic-action-destructive",
-    hex: "#d4351c",
-    hexDark: "#f66d63",
-  },
-  {
-    name: "Action destructive hover",
-    token: "--ic-action-destructive-hover",
-    hex: "#ad1e0e",
-    hexDark: "#f15b4e",
-  },
-  {
-    name: "Action destructive pressed",
-    token: "--ic-action-destructive-pressed",
-    hex: "#8b1209",
-    hexDark: "#dd3b25",
-  },
-  {
-    name: "Action neutral",
-    token: "--ic-action-neutral",
-    hex: "#e1e3e5",
-    hexDark: "#2c2f34",
-  },
-];
-
-export const ColoursBackgrounds: ColorConfig[] = [
-  {
-    name: "Background primary",
-    token: "--ic-color-background-primary",
-    hex: "#ffffff",
-    hexDark: "#2c2f34",
-  },
-  {
-    name: "Background secondary",
-    token: "--ic-color-background-secondary",
-    hex: "#f9fafa",
-    hexDark: "#41464d",
-  },
-  {
-    name: "Background active",
-    token: "--ic-color-background-active",
-    hex: "#1759bc",
-    hexDark: "#488fe3",
-  },
-  {
-    name: "Background hover",
-    token: "--ic-color-background-hover",
-    hex: "#c4c8cd",
-    hexDark: "#2c2f34",
-  },
-  {
-    name: "Background pressed",
-    token: "--ic-color-background-pressed",
-    hex: "#a7acb3",
-    hexDark: "#41464d",
-  },
-  {
-    name: "Background disabled",
-    token: "--ic-color-background-disabled",
-    hex: "#e8e9eb",
-    hexDark: "#a7acb3",
-  },
-  {
-    name: "Background success",
-    token: "--ic-color-background-success",
-    hex: "#00703c",
-    hexDark: "#81f2bb",
-  },
-  {
-    name: "Background warning",
-    token: "--ic-color-background-warning",
-    hex: "#ffc107",
-    hexDark: "#ffd12e",
-  },
-  {
-    name: "Background destructive",
-    token: "--ic-color-background-destructive",
-    hex: "#d4351c",
-    hexDark: "#f66d63",
-  },
-  {
-    name: "Background destructive hover",
-    token: "--ic-color-background-destructive-hover",
-    hex: "#ad1e0e",
-    hexDark: "#f15b4e",
-  },
-  {
-    name: "Background destructive pressed",
-    token: "--ic-color-background-destructive-pressed",
-    hex: "#8b1209",
-    hexDark: "#dd3b25",
-  },
-  {
-    name: "Background neutral",
-    token: "--ic-color-background-neutral",
-    hex: "#2c2f34",
-    hexDark: "#0b0c0c",
-  },
-];
-
-export const ColoursBorders: ColorConfig[] = [
-  {
-    name: "Border neutral default",
-    token: "--ic-color-border-neutral-default",
-    hex: "#a7acb3",
-  },
-  {
-    name: "Border neutral black",
-    token: "--ic-color-border-neutral-black",
-    hex: "#000000",
-  },
-  {
-    name: "Border neutral white",
-    token: "--ic-color-border-neutral-white",
-    hex: "#ffffff",
-  },
-  {
-    name: "Border neutral grey",
-    token: "--ic-color-border-neutral-grey",
-    hex: "#f4f4f5",
-    hexDark: "#8a919b",
-  },
-  {
-    name: "Border neutral hover",
-    token: "--ic-color-border-neutral-hover",
-    hex: "#6c7580",
-    hexDark: "#c4c8cd",
-  },
-  {
-    name: "Border neutral pressed",
-    token: "--ic-color-border-neutral-pressed",
-    hex: "#575e68",
-    hexDark: "#c4c8cd",
-  },
-  {
-    name: "Border neutral disabled",
-    token: "--ic-color-border-neutral-disabled",
-    hex: "#c4c8cd",
-    hexDark: "#575e68",
-  },
-  {
-    name: "Border success",
-    token: "--ic-color-border-success",
-    hex: "#00703c",
-    hexDark: "#81f2bb",
-  },
-  {
-    name: "Border success hover",
-    token: "--ic-color-border-success-hover",
-    hex: "#0e462b",
-    hexDark: "#6dedaf",
-  },
-  {
-    name: "Border success pressed",
-    token: "--ic-color-border-success-pressed",
-    hex: "#0e3020",
-    hexDark: "#4cdf98",
-  },
-  {
-    name: "Border warning",
-    token: "--ic-color-border-warning",
-    hex: "#d07932",
-    hexDark: "#ffd12e",
-  },
-  {
-    name: "Border warning hover",
-    token: "--ic-color-border-warning-hover",
-    hex: "#b3673c",
-    hexDark: "#ffc107",
-  },
-  {
-    name: "Border warning pressed",
-    token: "--ic-color-border-warning-pressed",
-    hex: "#8f553e",
-    hexDark: "#f8ae10",
-  },
-  {
-    name: "Border error",
-    token: "--ic-color-border-error",
-    hex: "#d4351c",
-    hexDark: "#f66d63",
-  },
-  {
-    name: "Border error hover",
-    token: "--ic-color-border-error-hover",
-    hex: "#ad1e0e",
-    hexDark: "#f15b4e",
-  },
-  {
-    name: "Border error pressed",
-    token: "--ic-color-border-error-pressed",
-    hex: "#8b1209",
-    hexDark: "#dd3b25",
-  },
-  {
-    name: "Border action",
-    token: "--ic-color-border-action",
-    hex: "#1759bc",
-    hexDark: "#488fe3",
-  },
-  {
-    name: "Border action hover",
-    token: "--ic-color-border-action-hover",
-    hex: "#0b399c",
-    hexDark: "#77b4f0",
-  },
-  {
-    name: "Border action pressed",
-    token: "--ic-color-border-action-pressed",
-    hex: "#07277e",
-    hexDark: "#98c9f5",
-  },
-];
-
-export const ColoursLinks: ColorConfig[] = [
-  {
-    name: "Hyperlink default",
-    token: "--ic-color-hyperlink-default",
-    hex: "#1759bc",
-    hexDark: "#5da0ea",
-  },
-  {
-    name: "Hyperlink visited",
-    token: "--ic-color-hyperlink-visited",
-    hex: "#330072",
-    hexDark: "#c988fd",
-  },
-  {
-    name: "Hyperlink visited monochrome",
-    token: "--ic-color-hyperlink-visited-monochrome",
-    hex: "#41464d",
-    hexDark: "#b0b0b0",
-  },
-];
-
-export const ColoursStatus: ColorConfig[] = [
-  {
-    name: "Status success",
-    token: "--ic-status-success",
-    hex: "#e8fef3",
-    hexDark: "#0e3020",
-  },
-  {
-    name: "Status warning",
-    token: "--ic-status-warning",
-    hex: "#fffbd8",
-    hexDark: "#7a4c3c",
-  },
-  {
-    name: "Status error",
-    token: "--ic-status-error",
-    hex: "#ffe4e3",
-    hexDark: "#610a05",
-  },
-  {
-    name: "Status anomalous",
-    token: "--ic-status-anomalous",
-    hex: "#efdbff",
-    hexDark: "#350f54",
-  },
-  {
-    name: "Status info",
-    token: "--ic-status-info",
-    hex: "#e1f0fc",
-    hexDark: "#041144",
-  },
-  {
-    name: "Status unknown",
-    token: "--ic-status-unknown",
-    hex: "#f4f4f5",
-    hexDark: "#2c2f34",
-  },
-];
-
-export const ColoursIcons: ColorConfig[] = [
-  {
-    name: "Icon grey",
-    token: "--ic-color-icon-grey",
-    hex: "#c4c8cd",
-    hexDark: "#6c7580",
-  },
-  {
-    name: "Icon hover",
-    token: "--ic-color-icon-hover",
-    hex: "#c4c8cd",
-    hexDark: "#2c2f34",
-  },
-  {
-    name: "Icon pressed",
-    token: "--ic-color-icon-pressed",
-    hex: "#a7acb3",
-    hexDark: "#41464d",
-  },
-  {
-    name: "Icon disabled",
-    token: "--ic-color-icon-disabled",
-    hex: "#a7acb3",
-    hexDark: "#6c7580",
-  },
-  {
-    name: "Icon action default",
-    token: "--ic-color-icon-action-default",
-    hex: "#1759bc",
-    hexDark: "#488fe3",
-  },
-  {
-    name: "Icon error",
-    token: "--ic-color-icon-error",
-    hex: "#f66d63",
-    hexDark: "#d4351c",
-  },
-  {
-    name: "Icon brand",
-    token: "--ic-color-icon-brand",
-    hex: "#ffffff",
-  },
-  {
-    name: "Icon neutral",
-    token: "--ic-color-icon-neutral",
-    hex: "#0b0c0c",
-  },
-  {
-    name: "Icon inverted",
-    token: "--ic-color-icon-inverted",
-    hex: "#ffffff",
-  },
-];
-
-export const ColoursClassification = [
-  {
-    name: "Classification not set",
-    token: "--ic-classification-not-set",
-    hex: "#616161",
-  },
-  {
-    name: "Classification official",
-    token: "--ic-classification-official",
-    hex: "#2b71c7",
-  },
-  {
-    name: "Classification official-sensitive",
-    token: "--ic-classification-official-sensitive",
-    hex: "#2b71c7",
-  },
-  {
-    name: "Classification secret",
-    token: "--ic-classification-secret",
-    hex: "#f39c2c",
-  },
-  {
-    name: "Classification top-secret",
-    token: "--ic-classification-top-secret",
-    hex: "#a00",
-  },
-];
+/** Primitive tokens */
 
 export const ColoursArchitectural: ColorConfig[] = [
   {
     name: "Architectural 20",
     token: "--ic-architectural-20",
-    hex: "#f9fafa",
   },
   {
     name: "Architectural 40",
     token: "--ic-architectural-40",
-    hex: "#f4f4f5",
   },
   {
     name: "Architectural 60",
     token: "--ic-architectural-60",
-    hex: "#f4f4f5",
   },
   {
     name: "Architectural 80",
     token: "--ic-architectural-80",
-    hex: "#e8e9eb",
   },
   {
     name: "Architectural 100",
     token: "--ic-architectural-100",
-    hex: "#e1e3e5",
   },
   {
     name: "Architectural 200",
     token: "--ic-architectural-200",
-    hex: "#c4c8cd",
   },
   {
     name: "Architectural 300",
     token: "--ic-architectural-300",
-    hex: "#a7acb3",
   },
   {
     name: "Architectural 400",
     token: "--ic-architectural-400",
-    hex: "#8a919b",
   },
   {
     name: "Architectural 500",
     token: "--ic-architectural-500",
-    hex: "#6c7580",
   },
   {
     name: "Architectural 600",
     token: "--ic-architectural-600",
-    hex: "#575e68",
   },
   {
     name: "Architectural 700",
     token: "--ic-architectural-700",
-    hex: "#41464d",
   },
   {
     name: "Architectural 750",
     token: "--ic-architectural-750",
-    hex: "#3b3e45",
   },
   {
     name: "Architectural 800",
     token: "--ic-architectural-800",
-    hex: "#2c2f34",
   },
   {
     name: "Architectural 850",
     token: "--ic-architectural-850",
-    hex: "#232629",
   },
   {
     name: "Architectural 900",
     token: "--ic-architectural-900",
-    hex: "#17191c",
   },
   {
     name: "Architectural 950",
     token: "--ic-architectural-950",
-    hex: "#0b0c0c",
   },
   {
     name: "Architectural white",
     token: "--ic-architectural-white",
-    hex: "#ffffff",
   },
   {
     name: "Architectural black",
     token: "--ic-architectural-black",
-    hex: "#000000",
-  },
-];
-
-export const ColoursBrand: ColorConfig[] = [
-  {
-    name: "Brand blue (Primary)",
-    token: "--ic-brand-blue-primary",
-    hex: "#1b3c79",
-  },
-  {
-    name: "Brand yellow (Primary)",
-    token: "--ic-brand-yellow-primary",
-    hex: "#ffc93c",
-  },
-];
-
-export const ColoursFocus: ColorConfig[] = [
-  {
-    name: "Focus inner",
-    token: "--ic-color-focus-inner",
-    hex: "#0044d7",
-  },
-  {
-    name: "Focus outer",
-    token: "--ic-color-focus-outer",
-    hex: "#80a1e8",
-  },
-];
-
-export const ColoursKeyline: ColorConfig[] = [
-  {
-    name: "Keyline",
-    token: "--ic-color-keyline",
-    hex: "#c4c8cd",
-  },
-  {
-    name: "Keyline light",
-    token: "--ic-color-keyline-light",
-    hex: "#e1e3e5",
-  },
-  {
-    name: "Keyline lighten",
-    token: "--ic-color-keyline-lighten",
-    hex: "#ffffff33",
-  },
-  {
-    name: "Keyline darken",
-    token: "--ic-color-keyline-darken",
-    hex: "#00000033",
   },
 ];
 
@@ -566,62 +85,50 @@ export const ColoursArchitecturalStateLayers: ColorConfig[] = [
   {
     name: "700 10%",
     token: "--ic-architectural-700-state-layer-10",
-    hex: "#41464d1a",
   },
   {
     name: "700 20%",
     token: "--ic-architectural-700-state-layer-20",
-    hex: "#41464d33",
   },
   {
     name: "700 24%",
     token: "--ic-architectural-700-state-layer-24",
-    hex: "#41464d3d",
   },
   {
     name: "700 34%",
     token: "--ic-architectural-700-state-layer-34",
-    hex: "#41464d57",
   },
   {
     name: "White 10%",
     token: "--ic-architectural-white-state-layer-10",
-    hex: "#ffffff1a",
   },
   {
     name: "White 20%",
     token: "--ic-architectural-white-state-layer-20",
-    hex: "#ffffff33",
   },
   {
     name: "White 24%",
     token: "--ic-architectural-white-state-layer-24",
-    hex: "#ffffff3d",
   },
   {
     name: "White 25%",
     token: "--ic-architectural-white-state-layer-25",
-    hex: "#ffffff40",
   },
   {
     name: "White 30%",
     token: "--ic-architectural-white-state-layer-30",
-    hex: "#ffffff40",
   },
   {
     name: "White 34%",
     token: "--ic-architectural-white-state-layer-34",
-    hex: "#ffffff57",
   },
   {
     name: "White 40%",
     token: "--ic-architectural-white-state-layer-40",
-    hex: "#ffffff66",
   },
   {
     name: "White 50%",
     token: "--ic-architectural-white-state-layer-50",
-    hex: "#ffffff80",
   },
 ];
 
@@ -629,97 +136,82 @@ export const ColoursBlue: ColorConfig[] = [
   {
     name: "Blue 0",
     token: "--ic-blue-0",
-    hex: "#e1f0fc",
   },
   {
     name: "Blue 50",
     token: "--ic-blue-50",
-    hex: "#c3e1f9",
   },
   {
     name: "Blue 100",
     token: "--ic-blue-100",
-    hex: "#98c9f5",
   },
   {
     name: "Blue 200",
     token: "--ic-blue-200",
-    hex: "#77b4f0",
   },
   {
     name: "Blue 300",
     token: "--ic-blue-300",
-    hex: "#5da0ea",
   },
   {
     name: "Blue 400",
     token: "--ic-blue-400",
-    hex: "#488fe3",
   },
   {
     name: "Blue 500",
     token: "--ic-blue-500",
-    hex: "#377fdb",
   },
   {
     name: "Blue 600",
     token: "--ic-blue-600",
-    hex: "#2a71d2",
   },
   {
     name: "Blue 700",
     token: "--ic-blue-700",
-    hex: "#2064c8",
   },
   {
     name: "Blue 800",
     token: "--ic-blue-800",
-    hex: "#1759bc",
   },
   {
     name: "Blue 900",
     token: "--ic-blue-900",
-    hex: "#124db3",
   },
   {
     name: "Blue 1000",
     token: "--ic-blue-1000",
-    hex: "#0e43a8",
   },
   {
     name: "Blue 1100",
     token: "--ic-blue-1100",
-    hex: "#0b399c",
   },
   {
     name: "Blue 1200",
     token: "--ic-blue-1200",
-    hex: "#09308e",
   },
   {
     name: "Blue 1300",
     token: "--ic-blue-1300",
-    hex: "#07277e",
   },
   {
     name: "Blue 1400",
     token: "--ic-blue-1400",
-    hex: "#1b3c79",
   },
   {
     name: "Blue 1500",
     token: "--ic-blue-1500",
-    hex: "#122e63",
   },
   {
     name: "Blue 1600",
     token: "--ic-blue-1600",
-    hex: "#041144",
   },
   {
     name: "Blue 1700",
     token: "--ic-blue-1700",
-    hex: "#020b2e",
+  },
+  {
+    name: "Blue 1800",
+    token: "--ic-blue-1800",
   },
 ];
 
@@ -727,32 +219,91 @@ export const ColoursBlueStateLayers: ColorConfig[] = [
   {
     name: "800 10%",
     token: "--ic-blue-800-state-layer-10",
-    hex: "#1759bc1a",
   },
   {
     name: "800 20%",
     token: "--ic-blue-800-state-layer-20",
-    hex: "#1759bc33",
   },
   {
     name: "800 24%",
     token: "--ic-blue-800-state-layer-24",
-    hex: "#1759bc3d",
   },
   {
     name: "800 30%",
     token: "--ic-blue-800-state-layer-30",
-    hex: "#1759bc4d",
   },
   {
     name: "800 34%",
     token: "--ic-blue-800-state-layer-34",
-    hex: "#1759bc57",
+  },
+  {
+    name: "800 40%",
+    token: "--ic-blue-800-state-layer-40",
   },
   {
     name: "800 50%",
     token: "--ic-blue-800-state-layer-50",
-    hex: "#1759bc80",
+  },
+];
+
+export const ColoursBrand: ColorConfig[] = [
+  {
+    name: "Brand blue (Primary)",
+    token: "--ic-brand-blue-primary",
+  },
+];
+
+export const ColoursDarkBlue: ColorConfig[] = [
+  {
+    name: "Dark blue 0",
+    token: "--ic-dark-blue-0",
+  },
+  {
+    name: "Dark blue 20",
+    token: "--ic-dark-blue-20",
+  },
+  {
+    name: "Dark blue 40",
+    token: "--ic-dark-blue-40",
+  },
+  {
+    name: "Dark blue 60",
+    token: "--ic-dark-blue-60",
+  },
+  {
+    name: "Dark blue 80",
+    token: "--ic-dark-blue-80",
+  },
+  {
+    name: "Dark blue 100",
+    token: "--ic-dark-blue-100",
+  },
+  {
+    name: "Dark blue 500",
+    token: "--ic-dark-blue-500",
+  },
+  {
+    name: "Dark blue 700",
+    token: "--ic-dark-blue-700",
+  },
+  {
+    name: "Dark blue 800",
+    token: "--ic-dark-blue-800",
+  },
+  {
+    name: "Dark blue 900",
+    token: "--ic-dark-blue-900",
+  },
+];
+
+export const ColoursFocus: ColorConfig[] = [
+  {
+    name: "Focus inner",
+    token: "--ic-color-focus-inner",
+  },
+  {
+    name: "Focus outer",
+    token: "--ic-color-focus-outer",
   },
 ];
 
@@ -760,92 +311,120 @@ export const ColoursGreen: ColorConfig[] = [
   {
     name: "Green 0",
     token: "--ic-green-0",
-    hex: "#e8fef3",
   },
   {
     name: "Green 50",
     token: "--ic-green-50",
-    hex: "#d1fde7",
   },
   {
     name: "Green 100",
     token: "--ic-green-100",
-    hex: "#b2fad6",
   },
   {
     name: "Green 200",
     token: "--ic-green-200",
-    hex: "#97f6c8",
   },
   {
     name: "Green 300",
     token: "--ic-green-300",
-    hex: "#81f2bb",
   },
   {
     name: "Green 400",
     token: "--ic-green-400",
-    hex: "#6dedaf",
   },
   {
     name: "Green 500",
     token: "--ic-green-500",
-    hex: "#5ce7a3",
   },
   {
     name: "Green 600",
     token: "--ic-green-600",
-    hex: "#4cdf98",
   },
   {
     name: "Green 700",
     token: "--ic-green-700",
-    hex: "#3ed78d",
   },
   {
     name: "Green 800",
     token: "--ic-green-800",
-    hex: "#31cd83",
   },
   {
     name: "Green 900",
     token: "--ic-green-900",
-    hex: "#26c278",
   },
   {
     name: "Green 1000",
     token: "--ic-green-1000",
-    hex: "#1bb56c",
   },
   {
     name: "Green 1100",
     token: "--ic-green-1100",
-    hex: "#12a661",
   },
   {
     name: "Green 1200",
     token: "--ic-green-1200",
-    hex: "#0b9655",
   },
   {
     name: "Green 1300",
     token: "--ic-green-1300",
-    hex: "#058449",
   },
   {
     name: "Green 1400",
     token: "--ic-green-1400",
-    hex: "#00703c",
   },
   {
     name: "Green 1600",
     token: "--ic-green-1600",
-    hex: "#0e462b",
   },
   {
     name: "Green 1700",
     token: "--ic-green-1700",
-    hex: "#0e3020",
+  },
+  {
+    name: "Green 1800",
+    token: "--ic-green-1800",
+  },
+];
+
+export const ColoursLightBlue: ColorConfig[] = [
+  {
+    name: "Light blue 0",
+    token: "--ic-light-blue-0",
+  },
+  {
+    name: "Light blue 100",
+    token: "--ic-light-blue-100",
+  },
+  {
+    name: "Light blue 600",
+    token: "--ic-light-blue-600",
+  },
+  {
+    name: "Light blue 1000",
+    token: "--ic-light-blue-1000",
+  },
+  {
+    name: "Light blue 1400",
+    token: "--ic-light-blue-1400",
+  },
+];
+
+export const ColoursLinksPrimitive: ColorConfig[] = [
+  {
+    name: "Link default",
+    token: "--ic-color-link-default",
+  },
+  {
+    name: "Link hover",
+    token: "--ic-color-link-hover",
+  },
+  {
+    name: "Link visited",
+    token: "--ic-color-link-visited",
+  },
+  {
+    name: "Link visited contrast",
+    token: "--ic-color-link-visited-contrast",
   },
 ];
 
@@ -853,87 +432,70 @@ export const ColoursPurple: ColorConfig[] = [
   {
     name: "Purple 0",
     token: "--ic-purple-0",
-    hex: "#f9f2ff",
   },
   {
     name: "Purple 50",
     token: "--ic-purple-50",
-    hex: "#efdbff",
   },
   {
     name: "Purple 100",
     token: "--ic-purple-100",
-    hex: "#e4c5ff",
   },
   {
     name: "Purple 200",
     token: "--ic-purple-200",
-    hex: "#d5a2fe",
   },
   {
     name: "Purple 300",
     token: "--ic-purple-300",
-    hex: "#c988fd",
   },
   {
     name: "Purple 400",
     token: "--ic-purple-400",
-    hex: "#bf74fc",
   },
   {
     name: "Purple 500",
     token: "--ic-purple-500",
-    hex: "#b764fb",
   },
   {
     name: "Purple 600",
     token: "--ic-purple-600",
-    hex: "#b057f9",
   },
   {
     name: "Purple 700",
     token: "--ic-purple-700",
-    hex: "#ab4df7",
   },
   {
     name: "Purple 800",
     token: "--ic-purple-800",
-    hex: "#a645f5",
   },
   {
     name: "Purple 900",
     token: "--ic-purple-900",
-    hex: "#a13ef2",
   },
   {
     name: "Purple 1000",
     token: "--ic-purple-1000",
-    hex: "#9c38ee",
   },
   {
     name: "Purple 1100",
     token: "--ic-purple-1100",
-    hex: "#9733e8",
   },
   {
     name: "Purple 1200",
     token: "--ic-purple-1200",
-    hex: "#902fe0",
   },
   {
     name: "Purple 1300",
     token: "--ic-purple-1300",
-    hex: "#882ad5",
   },
   {
     name: "Purple 1400",
     token: "--ic-purple-1400",
-    hex: "#7c25c2",
   },
   {
     name: "Purple 1800",
     token: "--ic-purple-1800",
-    hex: "#350f54",
   },
 ];
 
@@ -941,82 +503,70 @@ export const ColoursRed: ColorConfig[] = [
   {
     name: "Red 0",
     token: "--ic-red-0",
-    hex: "#ffe4e3",
   },
   {
     name: "Red 50",
     token: "--ic-red-50",
-    hex: "#fec9c8",
   },
   {
     name: "Red 100",
     token: "--ic-red-100",
-    hex: "#fca19e",
   },
   {
     name: "Red 200",
     token: "--ic-red-200",
-    hex: "#f9837d",
   },
   {
     name: "Red 300",
     token: "--ic-red-300",
-    hex: "#f66d63",
   },
   {
     name: "Red 400",
     token: "--ic-red-400",
-    hex: "#f15b4e",
   },
   {
     name: "Red 500",
     token: "--ic-red-500",
-    hex: "#ec4e3d",
   },
   {
     name: "Red 600",
     token: "--ic-red-600",
-    hex: "#e54330",
   },
   {
     name: "Red 700",
     token: "--ic-red-700",
-    hex: "#dd3b25",
   },
   {
     name: "Red 800",
     token: "--ic-red-800",
-    hex: "#d4351c",
   },
   {
     name: "Red 900",
     token: "--ic-red-900",
-    hex: "#c92c16",
   },
   {
     name: "Red 1000",
     token: "--ic-red-1000",
-    hex: "#bc2411",
   },
   {
     name: "Red 1100",
     token: "--ic-red-1100",
-    hex: "#ad1e0e",
   },
   {
     name: "Red 1300",
     token: "--ic-red-1300",
-    hex: "#8b1209",
   },
   {
     name: "Red 1500",
     token: "--ic-red-1500",
-    hex: "#610a05",
   },
   {
     name: "Red 1700",
     token: "--ic-red-1700",
-    hex: "#330403",
+  },
+  {
+    name: "Red 1800",
+    token: "--ic-red-1800",
   },
 ];
 
@@ -1024,86 +574,622 @@ export const ColoursYellow: ColorConfig[] = [
   {
     name: "Yellow 0",
     token: "--ic-yellow-0",
-    hex: "#fffbd8",
   },
   {
     name: "Yellow 50",
     token: "--ic-yellow-50",
-    hex: "#fff7b0",
   },
   {
     name: "Yellow 100",
     token: "--ic-yellow-100",
-    hex: "#ffed83",
   },
   {
     name: "Yellow 200",
     token: "--ic-yellow-200",
-    hex: "#ffe058",
   },
   {
     name: "Yellow 300",
     token: "--ic-yellow-300",
-    hex: "#ffd12e",
   },
   {
     name: "Yellow 400",
     token: "--ic-yellow-400",
-    hex: "#ffc107",
   },
   {
     name: "Yellow 500",
     token: "--ic-yellow-500",
-    hex: "#f8ae10",
   },
   {
     name: "Yellow 600",
     token: "--ic-yellow-600",
-    hex: "#f09d19",
   },
   {
     name: "Yellow 700",
     token: "--ic-yellow-700",
-    hex: "#e78f22",
   },
   {
     name: "Yellow 800",
     token: "--ic-yellow-800",
-    hex: "#dc832a",
   },
   {
     name: "Yellow 900",
     token: "--ic-yellow-900",
-    hex: "#d07932",
   },
   {
     name: "Yellow 1000",
     token: "--ic-yellow-1000",
-    hex: "#c26f38",
   },
   {
     name: "Yellow 1100",
     token: "--ic-yellow-1100",
-    hex: "#b3673c",
   },
   {
     name: "Yellow 1200",
     token: "--ic-yellow-1200",
-    hex: "#a25e3f",
   },
   {
     name: "Yellow 1300",
     token: "--ic-yellow-1300",
-    hex: "#8f553e",
   },
   {
     name: "Yellow 1400",
     token: "--ic-yellow-1400",
-    hex: "#7a4c3c",
   },
   {
     name: "Yellow 1700",
     token: "--ic-yellow-1700",
-    hex: "#342521",
+  },
+  {
+    name: "Yellow 1800",
+    token: "--ic-yellow-1800",
+  },
+];
+
+/** Semantic tokens */
+
+export const ColoursAction: ColorConfig[] = [
+  {
+    name: "Action default",
+    token: "--ic-action-default-light",
+    darkToken: "--ic-action-default-dark",
+  },
+  {
+    name: "Action hover",
+    token: "--ic-action-default-hover-light",
+    darkToken: "--ic-action-default-hover-dark",
+  },
+  {
+    name: "Action pressed",
+    token: "--ic-action-default-pressed-light",
+    darkToken: "--ic-action-default-pressed-dark",
+  },
+  {
+    name: "Action selected",
+    token: "--ic-action-default-selected-light",
+    darkToken: "--ic-action-default-selected-dark",
+  },
+  {
+    name: "Action destructive default",
+    token: "--ic-action-destructive-light",
+    darkToken: "--ic-action-destructive-dark",
+  },
+  {
+    name: "Action destructive hover",
+    token: "--ic-action-destructive-hover-light",
+    darkToken: "--ic-action-destructive-hover-dark",
+  },
+  {
+    name: "Action destructive pressed",
+    token: "--ic-action-destructive-pressed-light",
+    darkToken: "--ic-action-destructive-pressed-dark",
+  },
+  {
+    name: "Action monochrome",
+    token: "--ic-action-monochrome",
+    darkToken: "--ic-action-monochrome-dark",
+  },
+  {
+    name: "Action monochrome hover",
+    token: "--ic-action-monochrome-hover",
+    darkToken: "--ic-action-monochrome-hover-dark",
+  },
+  {
+    name: "Action monochrome pressed",
+    token: "--ic-action-monochrome-pressed",
+    darkToken: "--ic-action-monochrome-pressed-dark",
+  },
+  {
+    name: "Action neutral",
+    token: "--ic-action-neutral-light",
+    darkToken: "--ic-action-neutral-dark",
+  },
+];
+
+export const ColoursBackgrounds: ColorConfig[] = [
+  {
+    name: "Background primary",
+    token: "--ic-color-background-primary-light",
+    darkToken: "--ic-color-background-primary-dark",
+  },
+  {
+    name: "Background secondary",
+    token: "--ic-color-background-secondary-light",
+    darkToken: "--ic-color-background-secondary-dark",
+  },
+  {
+    name: "Background hover",
+    token: "--ic-color-background-hover-default",
+  },
+  {
+    name: "Background hover monochrome",
+    token: "--ic-color-background-hover-light",
+    darkToken: "--ic-color-background-hover-dark",
+  },
+  {
+    name: "Background pressed",
+    token: "--ic-color-background-pressed-default",
+  },
+  {
+    name: "Background pressed monochrome",
+    token: "--ic-color-background-pressed-light",
+    darkToken: "--ic-color-background-pressed-dark",
+  },
+  {
+    name: "Background selected",
+    token: "--ic-color-background-selected",
+  },
+  {
+    name: "Background active",
+    token: "--ic-color-background-active-light",
+    darkToken: "--ic-color-background-active-dark",
+  },
+  {
+    name: "Background neutral",
+    token: "--ic-color-background-neutral-light",
+    darkToken: "--ic-color-background-neutral-dark",
+  },
+  {
+    name: "Background success",
+    token: "--ic-color-background-success-light",
+    darkToken: "--ic-color-background-success-dark",
+  },
+  {
+    name: "Background warning",
+    token: "--ic-color-background-warning-light",
+    darkToken: "--ic-color-background-warning-dark",
+  },
+  {
+    name: "Background destructive",
+    token: "--ic-color-background-destructive-light",
+    darkToken: "--ic-color-background-destructive-dark",
+  },
+  {
+    name: "Background destructive hover",
+    token: "--ic-color-background-destructive-hover-light",
+    darkToken: "--ic-color-background-destructive-hover-dark",
+  },
+  {
+    name: "Background destructive pressed",
+    token: "--ic-color-background-destructive-pressed-light",
+    darkToken: "--ic-color-background-destructive-pressed-dark",
+  },
+  {
+    name: "Background disabled",
+    token: "--ic-color-background-disabled-default",
+    darkToken: "--ic-color-background-disabled-dark",
+  },
+];
+
+export const ColoursBorders: ColorConfig[] = [
+  {
+    name: "Border action default",
+    token: "--ic-color-border-action-default",
+    darkToken: "--ic-color-border-action-default-dark",
+  },
+  {
+    name: "Border action hover",
+    token: "--ic-color-border-action-hover-light",
+    darkToken: "--ic-color-border-action-hover-dark",
+  },
+  {
+    name: "Border action pressed",
+    token: "--ic-color-border-action-pressed-light",
+    darkToken: "--ic-color-border-action-pressed-dark",
+  },
+  {
+    name: "Border error default",
+    token: "--ic-color-border-error-default",
+    darkToken: "--ic-color-border-error-default-dark",
+  },
+  {
+    name: "Border error hover",
+    token: "--ic-color-border-error-hover-light",
+    darkToken: "--ic-color-border-error-hover-dark",
+  },
+  {
+    name: "Border error pressed",
+    token: "--ic-color-border-error-pressed-light",
+    darkToken: "--ic-color-border-error-pressed-dark",
+  },
+  {
+    name: "Border neutral default",
+    token: "--ic-color-border-neutral-default",
+    darkToken: "--ic-color-border-neutral-default-dark",
+  },
+  {
+    name: "Border neutral hover",
+    token: "--ic-color-border-neutral-hover-default",
+    darkToken: "--ic-color-border-neutral-hover-dark",
+  },
+  {
+    name: "Border neutral pressed",
+    token: "--ic-color-border-neutral-pressed-default",
+    darkToken: "--ic-color-border-neutral-pressed-dark",
+  },
+  {
+    name: "Border neutral disabled",
+    token: "--ic-color-border-neutral-disabled-light",
+    darkToken: "--ic-color-border-neutral-disabled-dark",
+  },
+  {
+    name: "Border neutral grey",
+    token: "--ic-color-border-neutral-grey-light",
+    darkToken: "--ic-color-border-neutral-grey-dark",
+  },
+  {
+    name: "Border success default",
+    token: "--ic-color-border-success-default",
+    darkToken: "--ic-color-border-success-default-dark",
+  },
+  {
+    name: "Border success hover",
+    token: "--ic-color-border-success-hover-light",
+    darkToken: "--ic-color-border-success-hover-dark",
+  },
+  {
+    name: "Border success pressed",
+    token: "--ic-color-border-success-pressed-light",
+    darkToken: "--ic-color-border-success-pressed-dark",
+  },
+  {
+    name: "Border warning default",
+    token: "--ic-color-border-warning-default",
+    darkToken: "--ic-color-border-warning-default-dark",
+  },
+  {
+    name: "Border warning hover",
+    token: "--ic-color-border-warning-hover-light",
+    darkToken: "--ic-color-border-warning-hover-dark",
+  },
+  {
+    name: "Border warning pressed",
+    token: "--ic-color-border-warning-pressed-light",
+    darkToken: "--ic-color-border-warning-pressed-dark",
+  },
+];
+
+export const ColoursClassification: ColorConfig[] = [
+  {
+    name: "Classification not-set",
+    token: "--ic-classification-not-set",
+  },
+  {
+    name: "Classification official",
+    token: "--ic-classification-official",
+  },
+  {
+    name: "Classification official-sensitive",
+    token: "--ic-classification-official-sensitive",
+  },
+  {
+    name: "Classification secret",
+    token: "--ic-classification-secret",
+  },
+  {
+    name: "Classification top-secret",
+    token: "--ic-classification-top-secret",
+  },
+];
+
+export const ColoursIcons: ColorConfig[] = [
+  {
+    name: "Icon brand",
+    token: "--ic-color-icon-brand",
+  },
+  {
+    name: "Icon neutral",
+    token: "--ic-color-icon-neutral",
+  },
+  {
+    name: "Icon inverted",
+    token: "--ic-color-icon-inverted",
+  },
+  {
+    name: "Icon hover",
+    token: "--ic-color-icon-hover-light",
+    darkToken: "--ic-color-icon-hover-dark",
+  },
+  {
+    name: "Icon pressed",
+    token: "--ic-color-icon-pressed-light",
+    darkToken: "--ic-color-icon-pressed-dark",
+  },
+  {
+    name: "Icon disabled",
+    token: "--ic-color-icon-disabled-light",
+    darkToken: "--ic-color-icon-disabled-dark",
+  },
+  {
+    name: "Icon disabled mid",
+    token: "--ic-color-icon-disabled-mid",
+  },
+  {
+    name: "Icon grey",
+    token: "--ic-color-icon-grey-default",
+  },
+  {
+    name: "Icon grey light",
+    token: "--ic-color-icon-grey-light",
+  },
+  {
+    name: "Icon grey lighter",
+    token: "--ic-color-icon-grey-lighter",
+  },
+  {
+    name: "Icon grey dark",
+    token: "--ic-color-icon-grey-dark",
+  },
+  {
+    name: "Icon grey darker",
+    token: "--ic-color-icon-grey-darker",
+  },
+  {
+    name: "Icon action default",
+    token: "--ic-color-icon-action-default-light",
+    darkToken: "--ic-color-icon-action-default-dark",
+  },
+  {
+    name: "Icon action hover",
+    token: "--ic-color-icon-action-hover",
+    darkToken: "--ic-color-icon-action-hover-dark",
+  },
+  {
+    name: "Icon action pressed",
+    token: "--ic-color-icon-action-pressed",
+    darkToken: "--ic-color-icon-action-pressed-dark",
+  },
+  {
+    name: "Icon error",
+    token: "--ic-color-icon-error-light",
+    darkToken: "--ic-color-icon-error-dark",
+  },
+  {
+    name: "Icon action dark",
+    token: "--ic-color-icon-action-dark",
+  },
+];
+
+export const ColoursKeyline: ColorConfig[] = [
+  {
+    name: "Keyline",
+    token: "--ic-color-keyline",
+  },
+  {
+    name: "Keyline light",
+    token: "--ic-color-keyline-light",
+  },
+  {
+    name: "Keyline lighten",
+    token: "--ic-color-keyline-lighten",
+  },
+  {
+    name: "Keyline darken",
+    token: "--ic-color-keyline-darken",
+  },
+];
+
+export const ColoursLinks: ColorConfig[] = [
+  {
+    name: "Hyperlink default",
+    token: "--ic-color-hyperlink-default-light",
+    darkToken: "--ic-color-hyperlink-default-dark",
+  },
+  {
+    name: "Hyperlink visited",
+    token: "--ic-color-hyperlink-visited-light",
+    darkToken: "--ic-color-hyperlink-visited-dark",
+  },
+  {
+    name: "Hyperlink visited monochrome",
+    token: "--ic-color-hyperlink-visited-monochrome-light",
+    darkToken: "--ic-color-hyperlink-visited-monochrome-dark",
+  },
+  {
+    name: "Hyperlink brand",
+    token: "--ic-color-hyperlink-brand",
+  },
+];
+
+export const ColoursStatus: ColorConfig[] = [
+  {
+    name: "Status anomalous default",
+    token: "--ic-status-anomalous-default",
+    darkToken: "--ic-status-anomalous-default-dm",
+  },
+  {
+    name: "Status anomalous contrast",
+    token: "--ic-status-anomalous-contrast",
+  },
+  {
+    name: "Status anomalous",
+    token: "--ic-status-anomalous-light",
+    darkToken: "--ic-status-anomalous-dark",
+  },
+  {
+    name: "Status error default",
+    token: "--ic-status-error-default",
+    darkToken: "--ic-status-error-default-dm",
+  },
+  {
+    name: "Status error contrast",
+    token: "--ic-status-error-contrast",
+  },
+  {
+    name: "Status error light",
+    token: "--ic-status-error-light",
+  },
+  {
+    name: "Status error dark",
+    token: "--ic-status-error-dark",
+    darkToken: "--ic-status-error-dark-dm",
+  },
+  {
+    name: "Status error outlined",
+    token: "--ic-status-error-outlined",
+  },
+  {
+    name: "Status info default",
+    token: "--ic-status-info-default",
+  },
+  {
+    name: "Status info contrast",
+    token: "--ic-status-info-contrast",
+  },
+  {
+    name: "Status info light",
+    token: "--ic-status-info-light",
+    darkToken: "--ic-status-info-light-dm",
+  },
+  {
+    name: "Status info dark",
+    token: "--ic-status-info-dark",
+    darkToken: "--ic-status-info-dark-dm",
+  },
+  {
+    name: "Status neutral default",
+    token: "--ic-status-unknown-default",
+    darkToken: "--ic-status-unknown-default-dm",
+  },
+  {
+    name: "Status neutral contrast",
+    token: "--ic-status-unknown-contrast",
+  },
+  {
+    name: "Status neutral light",
+    token: "--ic-status-unknown-light",
+    darkToken: "--ic-status-unknown-light-dm",
+  },
+  {
+    name: "Status neutral mid",
+    token: "--ic-status-unknown-mid",
+  },
+  {
+    name: "Status neutral dark",
+    token: "--ic-status-unknown-dark",
+    darkToken: "--ic-status-unknown-dark-dm",
+  },
+  {
+    name: "Status neutral outlined",
+    token: "--ic-status-unknown-outlined",
+  },
+  {
+    name: "Status success default",
+    token: "--ic-status-success-default",
+    darkToken: "--ic-status-success-default-dm",
+  },
+  {
+    name: "Status success contrast",
+    token: "--ic-status-success-contrast",
+    darkToken: "--ic-status-success-contrast-dm",
+  },
+  {
+    name: "Status success",
+    token: "--ic-status-success-light",
+    darkToken: "--ic-status-success-dark",
+  },
+  {
+    name: "Status success outlined",
+    token: "--ic-status-success-outlined",
+  },
+  {
+    name: "Status warning default",
+    token: "--ic-status-warning-default",
+    darkToken: "--ic-status-warning-default-dm",
+  },
+  {
+    name: "Status warning contrast",
+    token: "--ic-status-warning-contrast",
+  },
+  {
+    name: "Status warning light",
+    token: "--ic-status-warning-light",
+  },
+  {
+    name: "Status warning dark",
+    token: "--ic-status-warning-dark",
+    darkToken: "--ic-status-warning-dark-dm",
+  },
+  {
+    name: "Status warning outlined",
+    token: "--ic-status-warning-outlined",
+  },
+];
+
+export const ColoursText: ColorConfig[] = [
+  {
+    name: "Brand text",
+    token: "--ic-color-brand-text",
+  },
+  {
+    name: "Primary text",
+    token: "--ic-color-text-primary-light",
+    darkToken: "--ic-color-text-primary-dark",
+  },
+  {
+    name: "Secondary text",
+    token: "--ic-color-text-secondary-light",
+    darkToken: "--ic-color-text-secondary-dark",
+  },
+  {
+    name: "Tertiary text",
+    token: "--ic-color-text-tertiary-light",
+    darkToken: "--ic-color-text-tertiary-dark",
+  },
+  {
+    name: "Inverted text",
+    token: "--ic-color-text-inverted",
+  },
+  {
+    name: "Disabled text",
+    token: "--ic-color-text-disabled-light",
+    darkToken: "--ic-color-text-disabled-dark",
+  },
+  {
+    name: "Disabled mid text",
+    token: "--ic-color-text-disabled-mid",
+  },
+  {
+    name: "Inactive text",
+    token: "--ic-color-text-inactive",
+  },
+  {
+    name: "Action text",
+    token: "--ic-color-text-action-light",
+    darkToken: "--ic-color-text-action-dark",
+  },
+  {
+    name: "Action hover text",
+    token: "--ic-color-text-action-hover-light",
+    darkToken: "--ic-color-text-action-hover-dark",
+  },
+  {
+    name: "Action pressed text",
+    token: "--ic-color-text-action-pressed-light",
+    darkToken: "--ic-color-text-action-pressed-dark",
+  },
+  {
+    name: "Error text",
+    token: "--ic-color-text-error-dark",
+    darkToken: "--ic-color-text-error-light",
   },
 ];

--- a/src/content/structured/styles/components/ColourTable/index.css
+++ b/src/content/structured/styles/components/ColourTable/index.css
@@ -1,32 +1,28 @@
-.circle {
+.color {
   height: var(--ic-space-lg);
-  width: var(--ic-space-lg);
-  border-radius: 50%;
+  width: calc(var(--ic-space-lg) * 3);
+  border-radius: var(--ic-border-radius);
   border: 1px solid var(--ic-color-border-neutral-default);
 }
 
-.palette {
+.color-row {
   display: flex;
   align-items: center;
-  gap: var(--ic-space-xs);
-  border-radius: var(--ic-border-radius);
+  gap: var(--ic-space-lg);
+}
+
+.color-swatch {
   padding: var(--ic-space-xs);
+  border-radius: var(--ic-border-radius);
   background-color: var(--ic-color-background-primary-light);
 }
 
-.palette.dark {
+.color-swatch.dark {
   background-color: var(--ic-architectural-900);
 }
 
-@media screen and (min-width: 1201px) {
-  .color-circles {
-    display: flex;
-    gap: var(--ic-space-xs);
-  }
-}
-
 @media (forced-colors: active) {
-  .circle {
+  .color {
     forced-color-adjust: none;
   }
 }

--- a/src/content/structured/styles/components/ColourTable/index.tsx
+++ b/src/content/structured/styles/components/ColourTable/index.tsx
@@ -1,20 +1,17 @@
 import clsx from "clsx";
 import React from "react";
-
 import { ColorConfig } from "./colours.config";
 import "./index.css";
 
-const PaletteRow: React.FC<{
-  hex: string;
-  dark?: boolean;
-}> = ({ hex, dark }) => (
-  <div className={clsx("palette", dark && "dark")}>
-    <div style={{ backgroundColor: hex }} className="circle">
-      &nbsp;
+const ColorRow: React.FC<{ token: string; dark?: boolean }> = ({
+  token,
+  dark,
+}) => (
+  <div className="color-row">
+    <div className={clsx("color-swatch", dark && "dark")}>
+      <div style={{ backgroundColor: `var(${token})` }} className="color" />
     </div>
-    <ic-typography variant="code-large" theme={dark ? "dark" : "light"}>
-      {hex}
-    </ic-typography>
+    <ic-typography variant="code-small">{token}</ic-typography>
   </div>
 );
 
@@ -22,14 +19,11 @@ const ColorTable: React.FC<{
   config: ColorConfig[];
 }> = ({ config }) => (
   <ic-data-list>
-    {config.map(({ hex, hexDark, name, token }) => (
+    {config.map(({ name, token, darkToken }) => (
       <ic-data-row key={name} label={name}>
-        <ic-typography slot="value" variant="code-small">
-          {token}
-        </ic-typography>
-        <div className="color-circles" slot="end-component">
-          <PaletteRow hex={hex} />
-          {hexDark && <PaletteRow hex={hexDark} dark />}
+        <div slot="value">
+          <ColorRow token={token} />
+          {darkToken && <ColorRow token={darkToken} dark />}
         </div>
       </ic-data-row>
     ))}


### PR DESCRIPTION
## Summary of the changes
- Refactored the `colours.config.ts` file to have each colour take its respective css token, rather than manually setting hex codes, so that as changes are made to the ui-kit it will update the colours page automatically.
- Updated the layout of the `ColorTable` to display each colour's token next to the swatch, rather than the hex code. Also removed the "global token" reference in place of the individual tokens, as not every colour has one.

Some of the colours are not reflected on the page as they are waiting for the next release and on [other PRs](https://github.com/mi6/ic-ui-kit/pull/3410) and [issues](https://github.com/mi6/ic-ui-kit/issues/3363). However, the token name should indicate that it will pull through the correct value when displayed after the release.

## Related issue
#1461 

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
