### PR TITLE
fix(root): implement icon variant of back to top at small screen sizes

### DIFF
--- a/src/components/Layout/index.css
+++ b/src/components/Layout/index.css
@@ -107,6 +107,14 @@ ic-top-navigation form.not-loaded {
   display: none;
 }
 
+.ic-back-to-top.default {
+  display: block;
+}
+
+.ic-back-to-top.icon {
+  display: none;
+}
+
 @media screen and (max-width: 1200px) {
   .content {
     padding: var(--ic-space-md);
@@ -138,6 +146,15 @@ ic-top-navigation form.not-loaded {
 
   ic-top-navigation form {
     width: 100%;
+  }
+
+  .ic-back-to-top.default {
+    display: none;
+  }
+
+  .ic-back-to-top.icon {
+    display: block;
+    --ic-z-index-back-to-top: calc(var(--ic-z-index-classification-banner) + 1);
   }
 }
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -262,6 +262,21 @@ const Layout: React.FC<LayoutProps> = ({
 
   const isLocalStorageEnabled = () => localStorageConsent;
 
+  const getBackToTopStyle = () =>
+    !homepage && isNearBottom
+      ? ({
+          "--footer-offset": "6.75rem",
+        } as React.CSSProperties)
+      : undefined;
+
+  const defaultBackToTop = () => (
+    <ic-back-to-top target="main" style={getBackToTopStyle()} />
+  );
+
+  const iconBackToTop = () => (
+    <ic-back-to-top target="main" variant="icon" style={getBackToTopStyle()} />
+  );
+
   return (
     <>
       <Helmet>
@@ -333,16 +348,10 @@ const Layout: React.FC<LayoutProps> = ({
                   {" "}
                 </a>
                 {cloneElement(children, { location: location.pathname })}
-                <ic-back-to-top
-                  target="main"
-                  style={
-                    !homepage && isNearBottom
-                      ? ({
-                          "--footer-offset": "6.75rem",
-                        } as React.CSSProperties)
-                      : undefined
-                  }
-                />
+                <div className="ic-back-to-top default">
+                  {defaultBackToTop()}
+                </div>
+                <div className="ic-back-to-top icon">{iconBackToTop()}</div>
               </main>
             </div>
             <div className="footer">


### PR DESCRIPTION
## Summary of the changes

Implemented icon only variant of back to top for smaller viewports.

## Related issue
#959 


## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
