### PR TITLE
fix(root): fix issue with tree view collapsing with second level item click

### DIFF
--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -125,6 +125,18 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
     });
   };
 
+  const handleKeyUp = (
+    // eslint-disable-next-line no-undef
+    e: React.KeyboardEvent<HTMLIcTreeItemElement>,
+    treeItem: TreeItem
+  ) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      handleNavigation(treeItem.data.fields.slug);
+    }
+  };
+
   const renderTreeItems = (item: TreeItem) => {
     let hasChildren = item.children && item.children.length > 0;
 
@@ -132,35 +144,31 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
       hasChildren = false;
     }
 
-    // eslint-disable-next-line no-undef
-    const handleKeyUp = (e: React.KeyboardEvent<HTMLIcTreeItemElement>) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        handleNavigation(item.data.fields.slug);
-      }
-    };
-
     const handleKeyUpParent = (
       // eslint-disable-next-line no-undef
       e: React.KeyboardEvent<HTMLIcTreeItemElement>
     ) => {
-      if (e.key === "Enter") {
+      if (e.key === "Enter" || e.key === " ") {
         e.preventDefault();
+        e.stopPropagation();
         setTreeChange(true);
+        setIsExpanded(!isExpanded);
       }
     };
+
+    const isAnyChildSelected = (treeItem: TreeItem): boolean =>
+      treeItem.children.some(
+        (child: any) =>
+          isCurrentPage(child.data.fields.slug, false) ||
+          (hasChildren && isAnyChildSelected(child))
+      );
 
     const isChildSelected = (treeItem: TreeItem) => {
       const isOverviewSelected = isCurrentPage(
         treeItem.data.fields.slug,
         false
       );
-
-      const isAnyChildSelected = treeItem.children.some((child: any) =>
-        isCurrentPage(child.data.fields.slug, false)
-      );
-
-      return isOverviewSelected || isAnyChildSelected;
+      return isOverviewSelected || isAnyChildSelected(treeItem);
     };
 
     const [isExpanded, setIsExpanded] = useState(
@@ -179,11 +187,14 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
         selected={!hasChildren && isCurrentPage(item.data.fields.slug, false)}
         onClick={(e) => {
           e.preventDefault();
+          e.stopPropagation(); // Prevent click on child firing parent click handler
           return hasChildren
             ? handleParentClick()
             : handleNavigation(item.data.fields.slug);
         }}
-        onKeyUp={hasChildren ? handleKeyUpParent : handleKeyUp}
+        onKeyUp={(e) =>
+          hasChildren ? handleKeyUpParent(e) : handleKeyUp(e, item)
+        }
         expanded={isExpanded}
       >
         {hasChildren && (
@@ -194,9 +205,10 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
             selected={isCurrentPage(item.data.fields.slug, true)}
             onClick={(e) => {
               e.preventDefault();
+              e.stopPropagation();
               handleNavigation(item.data.fields.slug);
             }}
-            onKeyUp={handleKeyUp}
+            onKeyUp={(e) => handleKeyUp(e, item)}
           />
         )}
         {hasChildren &&
@@ -298,6 +310,7 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
               e.preventDefault();
               handleNavigation(currentNavSection.data.fields.slug);
             }}
+            onKeyUp={(e) => handleKeyUp(e, currentNavSection)}
             selected={isCurrentPage(currentNavSection.data.fields.slug, true)}
           />
         )}


### PR DESCRIPTION
## Summary of the changes
Updated the tree view on the website to not collapse when a second level / grandchild item is selected.

Also fixed some other small issues I noticed:
- Expanding a parent tree item which is a child caused its parent to collapse
- Using Enter to expand parent tree items wasn't working
- You couldn't use Space to expand or select tree items
- Wasn't possible to select the first tree item in the tree view using the keyboard ([#1478](https://github.com/mi6/ic-design-system/issues/1478))

There is still an issue where using Space to select items causes the whole page to scroll. This is a component issue, captured in mi6/ic-ui-kit#3152 (comment added to ticket).

## Related issue
#1471 and #1478

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
