### PR TITLE
[DRAFT] docs(root): add v3 example table

### DIFF
--- a/src/content/structured/get-started/releases-versioning.mdx
+++ b/src/content/structured/get-started/releases-versioning.mdx
@@ -123,6 +123,137 @@ As the component library matures and new versions arrive, the team will actively
 
 This is to allow the team to provide as much resource as possible on the current version. Any support for the legacy versions will only include security updates and bug fixes. No new features will be added.
 
+## Versioning list - stable
+
+<table>
+  <caption>
+    ic-ui-kit-web-components
+  </caption>
+  <tr>
+    <th>version</th>
+    <th scope="col">hash</th>
+    <th scope="col">build date</th>
+  </tr>
+  <tr>
+    <th scope="row">v3.0.0</th>
+    <td>0xFF</td>
+    <td>3rd of February 2025</td>
+  </tr>
+  <tr>
+    <th scope="row">v3.0.1</th>
+    <td>FFFFF</td>
+    <td>4th of February 2025</td>
+  </tr>
+</table>
+
+<table>
+  <caption>
+    ic-ui-kit-react
+  </caption>
+  <tr>
+    <th>version</th>
+    <th scope="col">hash</th>
+    <th scope="col">build date</th>
+  </tr>
+  <tr>
+    <th scope="row">v3.0.0</th>
+    <td>0xFF</td>
+    <td>3rd of February 2025</td>
+  </tr>
+    <tr>
+    <th scope="row">v3.0.1</th>
+    <td>FFFFF</td>
+    <td>4th of February 2025</td>
+  </tr>
+</table>
+
+<table>
+  <caption>
+    ic-ui-kit-fonts
+  </caption>
+  <tr>
+    <th>version</th>
+    <th scope="col">hash</th>
+    <th scope="col">build date</th>
+  </tr>
+  <tr>
+    <th scope="row">v3.0.0</th>
+    <td>0xFF</td>
+    <td>3rd of February 2025</td>
+  </tr>
+    <tr>
+    <th scope="row">v3.0.1</th>
+    <td>FFFFF</td>
+    <td>4th of February 2025</td>
+  </tr>
+</table>
+
+<table>
+  <caption>
+    ic-ui-kit-nextjs
+  </caption>
+  <tr>
+    <th>version</th>
+    <th scope="col">hash</th>
+    <th scope="col">build date</th>
+  </tr>
+  <tr>
+    <th scope="row">v3.0.0</th>
+    <td>0xFF</td>
+    <td>3rd of February 2025</td>
+  </tr>
+    <tr>
+    <th scope="row">v3.0.1</th>
+    <td>FFFFF</td>
+    <td>4th of February 2025</td>
+  </tr>
+</table>
+
+
+## Versioning list - canary
+
+<table>
+  <caption>
+    ic-ui-kit-canary-web-components
+  </caption>
+  <tr>
+    <th>version</th>
+    <th scope="col">hash</th>
+    <th scope="col">build date</th>
+  </tr>
+  <tr>
+    <th scope="row">v3.0.0</th>
+    <td>0xFF</td>
+    <td>3rd of February 2025</td>
+  </tr>
+  <tr>
+    <th scope="row">v3.0.1</th>
+    <td>FFFFF</td>
+    <td>4th of February 2025</td>
+  </tr>
+</table>
+
+<table>
+  <caption>
+    ic-ui-kit-canary-react
+  </caption>
+  <tr>
+    <th>version</th>
+    <th scope="col">hash</th>
+    <th scope="col">build date</th>
+  </tr>
+  <tr>
+    <th scope="row">v3.0.0</th>
+    <td>0xFF</td>
+    <td>3rd of February 2025</td>
+  </tr>
+    <tr>
+    <th scope="row">v3.0.1</th>
+    <td>FFFFF</td>
+    <td>4th of February 2025</td>
+  </tr>
+</table>
+
 ## Previous versions
 
 <p>


### PR DESCRIPTION
## Summary of the changes

Adds table for v3+ metadata

<img width="1407" alt="Screenshot 2025-04-22 at 22 17 36" src="https://github.com/user-attachments/assets/ff42ded5-78cc-4ffe-a7a4-2c1284191bc5" />

## Related issue

[Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.](https://github.com/mi6/ic-ui-kit/issues/2428)

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [ ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
