### PR TITLE
update install instructions to use v2 latest

### DIFF
--- a/src/content/structured/get-started/angular.mdx
+++ b/src/content/structured/get-started/angular.mdx
@@ -26,11 +26,11 @@ In the root of your project:
 
 ```shell
 // using npm
-npm install @ukic/web-components @ukic/fonts
+npm install @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 
 // using yarn
 rm package-lock.json
-yarn add @ukic/web-components @ukic/fonts
+yarn add @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 ```
 
 ## Step two

--- a/src/content/structured/get-started/gatsby.mdx
+++ b/src/content/structured/get-started/gatsby.mdx
@@ -27,11 +27,11 @@ In the root of your project:
 
 ```shell
 // using npm
-npm install @ukic/react @ukic/fonts
+npm install @ukic/react@v2-latest @ukic/fonts@v2-latest
 
 // using yarn
 rm package-lock.json
-yarn add @ukic/react @ukic/fonts
+yarn add @ukic/react@v2-latest @ukic/fonts@v2-latest
 ```
 
 ## Step Two

--- a/src/content/structured/get-started/install-components.mdx
+++ b/src/content/structured/get-started/install-components.mdx
@@ -28,10 +28,10 @@ contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/struc
 
 ```shell
 // Web components, Angular, Vue, Svelte
-npm install @ukic/web-components @ukic/fonts
+npm install @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 
 // React
-npm install @ukic/react @ukic/fonts
+npm install @ukic/react@v2-latest @ukic/fonts@v2-latest
 ```
 
 ## Using the components

--- a/src/content/structured/get-started/nextjs.mdx
+++ b/src/content/structured/get-started/nextjs.mdx
@@ -23,7 +23,7 @@ Set the following in the `next.config.js` file.
 ```jsx
 const nextConfig = {
   //other configuration
-  transpilePackages: ["@ukic/react"],
+  transpilePackages: ["@ukic/react@v2-latest"],
 };
 
 module.exports = nextConfig;
@@ -52,7 +52,7 @@ const nextConfig = {
   //other configuration
 };
 
-const withTM = require("next-transpile-modules")(["@ukic/react"]);
+const withTM = require("next-transpile-modules")(["@ukic/react@v2-latest"]);
 module.exports = withTM(nextConfig);
 ```
 

--- a/src/content/structured/get-started/react.mdx
+++ b/src/content/structured/get-started/react.mdx
@@ -27,11 +27,11 @@ In the root of your project:
 
 ```shell
 // using npm
-npm install @ukic/react @ukic/fonts
+npm install @ukic/react@v2-latest @ukic/fonts@v2-latest
 
 // using yarn
 rm package-lock.json
-yarn add @ukic/react @ukic/fonts
+yarn add @ukic/react@v2-latest @ukic/fonts@v2-latest
 ```
 
 ## Step two

--- a/src/content/structured/get-started/releases-versioning.mdx
+++ b/src/content/structured/get-started/releases-versioning.mdx
@@ -85,10 +85,10 @@ Canary components can be installed in the same way as our core `@ukic/` packages
 
 ```shell
 // Canary Web Components
-npm i @ukic/canary-web-components @ukic/fonts
+npm i @ukic/canary-web-components@v2-latest @ukic/fonts@v2-latest
 
 // Canary React
-npm i @ukic/canary-react @ukic/fonts
+npm i @ukic/canary-react@v2-latest @ukic/fonts@v2-latest
 ```
 
 A difference between our Canary packages and our core `@ukic/` packages is that canary package versions follow a `<version>-canary.<build-number>` pattern.

--- a/src/content/structured/get-started/svelte.mdx
+++ b/src/content/structured/get-started/svelte.mdx
@@ -26,11 +26,11 @@ In the root of your project:
 
 ```shell
 // using npm
-npm install @ukic/web-components @ukic/fonts
+npm install @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 
 // using yarn
 rm package-lock.json
-yarn add @ukic/web-components @ukic/fonts
+yarn add @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 ```
 
 ## Step two

--- a/src/content/structured/get-started/vue.mdx
+++ b/src/content/structured/get-started/vue.mdx
@@ -26,11 +26,11 @@ In the root of your project:
 
 ```shell
 // using npm
-npm install @ukic/web-components @ukic/fonts
+npm install @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 
 // using yarn
 rm package-lock.json
-yarn add @ukic/web-components @ukic/fonts
+yarn add @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 ```
 
 ## Step two

--- a/src/content/structured/get-started/web-components.mdx
+++ b/src/content/structured/get-started/web-components.mdx
@@ -18,11 +18,11 @@ In the root of your project:
 
 ```shell
 // using npm
-npm install @ukic/web-components @ukic/fonts
+npm install @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 
 // using yarn
 rm package-lock.json
-yarn add @ukic/web-components @ukic/fonts
+yarn add @ukic/web-components@v2-latest @ukic/fonts@v2-latest
 ```
 
 ## Step two


### PR DESCRIPTION
## Summary of the changes

update all instructions for installing components to target v2

## Related issue

#1495 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
