### PR TITLE
fix(root): updated code preview to reset scroll position after changing tabs

### DIFF
--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -262,6 +262,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
   const tabContextRef = useRef<HTMLIcTabContextElement | null>(null);
   const typescriptToggleBtnRef = useRef<HTMLIcToggleButtonElement>(null);
   const javascriptToggleBtnRef = useRef<HTMLIcToggleButtonElement>(null);
+  const prevTabContextTopRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (tabContextRef.current) {
@@ -283,6 +284,11 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
   >("Typescript");
 
   const tabSelectCallback = (ev: CustomEvent) => {
+    if (tabContextRef.current) {
+      prevTabContextTopRef.current =
+        tabContextRef.current.getBoundingClientRect().top;
+    }
+
     setSelectedTab(ev.detail.tabLabel);
     if (isLocalStorageEnabled()) {
       localStorage.setItem("selectedTab", ev.detail.tabLabel);
@@ -293,6 +299,25 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
     });
     window.dispatchEvent(event);
   };
+
+  useEffect(() => {
+    // Reset scroll position when switching tabs
+    if (prevTabContextTopRef.current && tabContextRef.current) {
+      setTimeout(() => {
+        const topDiff =
+          tabContextRef.current!.getBoundingClientRect().top -
+          prevTabContextTopRef.current!;
+        window.scrollTo({
+          top: window.scrollY + topDiff,
+          behavior: window.matchMedia("(prefers-reduced-motion: reduce)")
+            .matches
+            ? "instant"
+            : "smooth",
+        });
+        prevTabContextTopRef.current = null;
+      }, 0);
+    }
+  }, [selectedTab]);
 
   useEffect(() => {
     if (isLocalStorageEnabled()) {


### PR DESCRIPTION
## Summary of the changes
Updated code previews to reset scroll position when switching between Web component and React tabs. Also made it so the scrolling animation is removed if the user has "prefers-reduced-motion" turned on in their browser

There is still some moving about but I think it at least solves the main issue of the user losing where they were on the page

The Button and Chip Code pages are examples of where this functionality can be tested (scroll towards the bottom where the movement is more obvious).

## Related issue
#1392 

## Checklist
- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
