### PR TITLE
1283 add examples of adding non svg image into components

### DIFF
--- a/src/components/SlottedImage/index.tsx
+++ b/src/components/SlottedImage/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+
+interface SimpleImageProps {
+  imageSrc: string;
+  imageAlt?: string;
+  imageStyle?: React.CSSProperties;
+}
+
+const SimpleImage: React.FC<SimpleImageProps> = ({
+  imageSrc,
+  imageAlt = "",
+  imageStyle,
+}) => <img src={imageSrc} alt={imageAlt} style={imageStyle} loading="lazy" />;
+
+export default SimpleImage;

--- a/src/content/structured/components/card-horizontal/code.mdx
+++ b/src/content/structured/components/card-horizontal/code.mdx
@@ -3,7 +3,7 @@ path: "/components/card-horizontal/code"
 
 navPriority: 7
 
-date: "2024-08-30"
+date: "2025-05-23"
 
 title: "Card (horizontal)"
 
@@ -449,6 +449,103 @@ export const snippetsWithImage = [
       <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
       <polygon fill="#880088" points="943 900 1210 900 971 687" />
     </svg>
+  </IcCardHorizontal>
+</ComponentPreview>
+
+### Non-svg image
+
+export const snippetsWithImageNonSVG = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-card-horizontal 
+  heading="Americano order" 
+  message="Extras: Double espresso shot and oat milk."
+>
+  <svg
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+  </svg>
+  <img
+    slot="image"
+    src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+    alt="Coffee illustration"
+    style="object-fit:cover"
+  />
+</ic-card-horizontal>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcCardHorizontal
+  heading="Americano order"
+  message="Extras: Double espresso shot and oat milk."
+>
+  <SlottedSVG
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+  </SlottedSVG>
+  <img
+    slot="image"
+    src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+    alt="Coffee illustration"
+    style={{ objectFit: "cover" }}
+  />
+</IcCardHorizontal>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsWithImageNonSVG}>
+  <IcCardHorizontal
+    heading="Americano order"
+    message="Extras: Double espresso shot and oat milk."
+  >
+    <svg
+      slot="icon"
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      fill="#000000"
+    >
+      <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
+    </svg>
+    <div slot="image">
+      <SimpleImage
+        imageSrc="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+        imageAlt="Coffee illustration"
+        imageStyle={{
+          height: "var(--image-size)",
+          width: "var(--image-size)",
+          objectFit: "cover",
+        }}
+      />
+    </div>
   </IcCardHorizontal>
 </ComponentPreview>
 

--- a/src/content/structured/components/card-vertical/code.mdx
+++ b/src/content/structured/components/card-vertical/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/card-vertical/code"
 
-date: "2024-05-31"
+date: "2025-05-23"
 
 title: "Card (vertical)"
 
@@ -900,7 +900,21 @@ return (
         },
         {
           language: "Javascript",
-          snippet: `{shortCode}`,
+          snippet: `const useStyles = createUseStyles({
+  card: {
+    width: "22.5rem",
+  },
+  cardImage: {
+    height: "100%",
+    width: "100%",
+    maxHeight: "20.375rem",
+    maxWidth: "20.375rem",
+  },
+});
+const classes = useStyles();
+return (
+  {shortCode}
+)`,
         },
       ],
     },
@@ -1171,6 +1185,120 @@ return (
       <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
       <polygon fill="#880088" points="943 900 1210 900 971 687" />
     </svg>
+  </IcCardVertical>
+</ComponentPreview>
+
+### Non-svg image
+
+export const nonSVGImageSnippets = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-card-vertical 
+  heading="Americano order" 
+  subheading="Name: Michael" 
+  message="Extras: Double espresso shot and oat milk."
+>
+  <img
+    slot="image-top"
+    class="card-image"
+    src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+    alt="Coffee illustration"
+  />
+  <ic-status-tag slot="adornment" status="warning" label="In Progress" size="small"></ic-status-tag>
+</ic-card-vertical>`,
+      long: `ic-card-vertical {
+        width: 22.5rem;
+    }
+    .card-image {
+      height: 100%;
+      width: 100%;
+      maxHeight: 20.375rem;
+      maxWidth: 20.375rem;
+    }
+    </style>
+    <body>
+      {shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcCardVertical
+  heading="Americano order" 
+  subheading="Name: Michael" 
+  message="Extras: Double espresso shot and oat milk."
+  className={classes.card}
+>
+  <img
+    slot="image-top"
+    className={classes.cardImage}
+    src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+    alt="Coffee illustration"
+  />
+  <IcStatusTag slot="adornment" status="warning" label="In Progress" size="small" />
+</IcCardVertical>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  card: {
+    width: "22.5rem",
+  },
+  cardImage: {
+    height: "100%",
+    width: "100%",
+    maxHeight: "20.375rem",
+    maxWidth: "20.375rem",
+  },
+});
+const classes = useStyles();
+return (
+  {shortCode}
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  card: {
+    width: "22.5rem",
+  },
+  cardImage: {
+    height: "100%",
+    width: "100%",
+    maxHeight: "20.375rem",
+    maxWidth: "20.375rem",
+  },
+});
+const classes = useStyles();
+return (
+  {shortCode}
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={nonSVGImageSnippets}>
+  <IcCardVertical
+    heading="Americano order"
+    subheading="Name: Michael"
+    message="Extras: Double espresso shot and oat milk."
+  >
+    <IcStatusTag
+      slot="adornment"
+      status="warning"
+      label="In Progress"
+      size="small"
+    />
+    <div slot="image-top">
+      <SimpleImage
+        imageSrc="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+        imageAlt="Coffee illustration"
+        imageStyle={{ maxWidth: "20.375rem", maxHeight: "20.375rem" }}
+      />
+    </div>
   </IcCardVertical>
 </ComponentPreview>
 

--- a/src/content/structured/components/empty-state/code.mdx
+++ b/src/content/structured/components/empty-state/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/empty-state/code"
 
-date: "2024-05-31"
+date: "2025-05-23"
 
 title: "Empty state"
 
@@ -747,5 +747,79 @@ return (
     >
       Customer support
     </IcLink>
+  </IcEmptyState>
+</ComponentPreview>
+
+### Non-svg image
+
+export const jpgImageSnippets = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-empty-state 
+  image-size="large" 
+  heading="Hmm...there's nothing here" 
+  subheading="We don't currently have any favourite teas, probably because coffee is much better." 
+  body="Take a look at our favourite coffees instead, there's much more of those, or try again."
+>
+  <img
+    slot="image"
+    src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+    alt="Coffee illustration"
+    style="object-fit:cover"
+  />
+</ic-empty-state>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcEmptyState 
+  imageSize="large" 
+  heading="Hmm...there's nothing here" 
+  subheading="We don't currently have any favourite teas, probably because coffee is much better." 
+  body="Take a look at our favourite coffees instead, there's much more of those, or try again."
+>
+  <img
+    slot="image"
+    src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+    alt="Coffee illustration"
+    style={{ objectFit: "cover" }}
+  />
+</IcEmptyState>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={jpgImageSnippets}>
+  <IcEmptyState
+    imageSize="large"
+    heading="Hmm...there's nothing here"
+    subheading="We don't currently have any favourite teas, probably because coffee is much better."
+    body="Take a look at our favourite coffees instead, there's much more of those, or try again."
+  >
+    <div slot="image">
+      <SimpleImage
+        imageSrc="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+        imageAlt="Coffee illustration"
+        imageStyle={{
+          width: "calc(4 * var(--ic-space-xl))",
+          height: "calc(4 * var(--ic-space-xl))",
+          objectFit: "cover",
+          borderRadius: "var(--ic-space-xxs)",
+        }}
+      />
+    </div>
   </IcEmptyState>
 </ComponentPreview>

--- a/src/content/structured/components/hero/code.mdx
+++ b/src/content/structured/components/hero/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/hero/code"
 
-date: "2024-05-31"
+date: "2025-05-23"
 
 title: "Hero"
 
@@ -694,5 +694,112 @@ return (
       <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
       <polygon fill="#880088" points="943 900 1210 900 971 687" />
     </svg>
+  </IcHero>
+</ComponentPreview>
+
+### Non-svg image
+
+export const snippetsImageJpg = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-hero
+  heading="Everything I brew, I brew it for you"
+  subheading="This news is hot off the French press."
+  aligned="full-width"
+>
+  <ic-button variant="primary" slot="interaction">Explore</ic-button>
+  <ic-button variant="secondary" slot="interaction">Check out our new drinks</ic-button>
+  <img
+    slot="secondary"
+    class="card-image"
+    src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+    alt="Coffee illustration"
+  />
+</ic-hero>`,
+      long: `.card-image {
+  width: 18.75rem;
+}
+ic-hero {
+  height: fit-content;
+}
+</style>
+<body>
+  {shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcHero
+  heading="Everything I brew, I brew it for you"
+  subheading="This news is hot off the French press."
+  aligned="full-width"
+  class={classes.hero}
+>
+  <IcButton variant="primary" slot="interaction">Explore</IcButton>
+  <IcButton variant="secondary" slot="interaction">Check out our new drinks</IcButton>
+  <img
+    slot="secondary"
+    className={classes.cardImage}
+    src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+    alt="Coffee illustration"
+  />
+</IcHero>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  cardImage: {
+    width: "18.75rem",
+  },
+  hero: {
+    height: "fit-content",
+  },
+});
+const classes = useStyles();
+return (
+  {shortCode}
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  cardImage: {
+    width: "18.75rem",
+  },
+  hero: {
+    height: "fit-content",
+  },
+});
+const classes = useStyles();
+return (
+  {shortCode}
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsImageJpg}>
+  <IcHero
+    heading="Everything I brew, I brew it for you"
+    subheading="This news is hot off the French press."
+    aligned="full-width"
+  >
+    <IcButton variant="primary" slot="interaction">
+      Explore
+    </IcButton>
+    <IcButton variant="secondary" slot="interaction">
+      Check out our new drinks
+    </IcButton>
+    <div slot="secondary">
+      <SimpleImage
+        imageSrc="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
+        imageAlt="Coffee illustration"
+        imageStyle={{ width: "18.75rem" }}
+      />
+    </div>
   </IcHero>
 </ComponentPreview>

--- a/src/templates/CoreTemplate/index.tsx
+++ b/src/templates/CoreTemplate/index.tsx
@@ -10,6 +10,7 @@ import ComponentGallery from "../../components/ComponentGallery";
 import ComponentDetails from "../../components/ComponentDetails";
 import DoDontCaution from "../../components/DoDontCaution";
 import DoubleDoDontCaution from "../../components/DoubleDoDontCaution";
+import SimpleImage from "../../components/SlottedImage";
 import Header from "../../components/Header";
 import WrappedAlert from "../../components/WrappedAlert";
 import WrappedBlockquote from "../../components/WrappedBlockquote";
@@ -54,6 +55,7 @@ const CoreMDXLayout: React.FC<CoreMDXLayoutProps> = ({
     blockquote: WrappedBlockquote,
     DoDontCaution,
     DoubleDoDontCaution,
+    SimpleImage,
     ThemedVideo,
   };
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add code examples for non-svg images used in components (card, empty state, hero). Add SimpleImage component to make the jpg image appear correctly within ComponentPreview

## Related issue

 #1283

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
