### PR TITLE
fix(root): update code examples height to stop page moving when tabs …

### DIFF
--- a/src/components/CodePreview/index.css
+++ b/src/components/CodePreview/index.css
@@ -77,9 +77,20 @@
   justify-content: flex-start !important;
 }
 
-.code-window:focus-within {
+.code-tab-panel {
+  display: block;
+  overflow: scroll;
+  width: 100%;
+}
+
+.code-tab-panel:focus-within {
   box-shadow: var(--ic-border-focus);
   border-radius: var(--ic-border-radius) !important;
+}
+
+.code-tab-panel.hidden {
+  visibility: hidden;
+  position: absolute;
 }
 
 .snippet {

--- a/src/components/CodePreview/index.tsx
+++ b/src/components/CodePreview/index.tsx
@@ -158,7 +158,7 @@ const ToggleShowButton: React.FC<ToggleShowProps> = ({
 };
 
 const CodeWindow: React.FC<CodeWindowProps> = ({ code, show, language }) => (
-  <div className="code-window">
+  <div>
     {/* eslint-disable jsx-a11y/no-noninteractive-tabindex */}
     {show && (
       <Highlight
@@ -260,6 +260,8 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
 
   const [tabCount, setTabCount] = useState<number>(2);
   const tabContextRef = useRef<HTMLIcTabContextElement | null>(null);
+  const webComponentTabPanelRef = useRef<HTMLIcTabPanelElement | null>(null);
+  const reactTabPanelRef = useRef<HTMLIcTabPanelElement | null>(null);
   const typescriptToggleBtnRef = useRef<HTMLIcToggleButtonElement>(null);
   const javascriptToggleBtnRef = useRef<HTMLIcToggleButtonElement>(null);
 
@@ -277,10 +279,10 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
   const [selectedTab, setSelectedTab] = useState<"Web component" | "React">(
     tabCount === 1 ? "React" : "Web component"
   );
-
   const [selectedLanguage, setSelectedLanguage] = useState<
     "Typescript" | "Javascript"
   >("Typescript");
+  const [codeHeight, setCodeHeight] = useState<string>("auto");
 
   const tabSelectCallback = (ev: CustomEvent) => {
     setSelectedTab(ev.detail.tabLabel);
@@ -293,6 +295,26 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
     });
     window.dispatchEvent(event);
   };
+
+  const updateCodeWindowHeight = (delay: number) =>
+    // Make web component and React code examples same height
+    // to prevent page movement while switching
+    setTimeout(() => {
+      if (webComponentTabPanelRef.current && reactTabPanelRef.current) {
+        setCodeHeight("auto"); // Reset height for measurement
+        setCodeHeight(
+          `${Math.min(
+            webComponentTabPanelRef.current?.clientHeight,
+            reactTabPanelRef.current?.clientHeight
+          )}px`
+        );
+      }
+    }, delay);
+
+  useEffect(() => {
+    const codeHeightTimeout = updateCodeWindowHeight(0);
+    return () => clearTimeout(codeHeightTimeout);
+  }, [selectedTab, selectedLanguage, show, showMore]);
 
   useEffect(() => {
     if (isLocalStorageEnabled()) {
@@ -308,11 +330,15 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
 
     window.addEventListener("tabSelectionChanged", handleTabSelectionChange);
 
+    // Wait on first load to ensure tab panels are rendered before updating their height
+    const codeHeightTimeout = updateCodeWindowHeight(300);
+
     return () => {
       window.removeEventListener(
         "tabSelectionChanged",
         handleTabSelectionChange
       );
+      clearTimeout(codeHeightTimeout);
     };
   }, []);
 
@@ -458,7 +484,7 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
     let shortCodeSnippet: string | undefined = "";
     if (type !== "pattern") shortCodeSnippet = snippet.snippets.short;
 
-    if (selectedTab === "Web component" && snippet.technology !== "React") {
+    if (snippet.technology !== "React") {
       return getCodeSnippetForWebComponent(snippet, shortCodeSnippet);
     }
     // For React code snippets
@@ -646,7 +672,20 @@ const ComponentPreview: React.FC<ComponentPreviewProps> = ({
             />
           </div>
           {snippets.map((snippet, index) => (
-            <IcTabPanel key={snippet.technology} tab-position={index}>
+            <IcTabPanel
+              ref={
+                snippet.technology === "Web component"
+                  ? webComponentTabPanelRef
+                  : reactTabPanelRef
+              }
+              className={clsx(
+                "code-tab-panel",
+                snippet.technology !== selectedTab && tabCount === 2 && "hidden"
+              )}
+              key={snippet.technology}
+              tab-position={index}
+              style={{ height: codeHeight }}
+            >
               <CodeWindow
                 code={getCodeSnippet(snippet)?.codeSnippet || ""}
                 show={show}

--- a/src/content/structured/components/buttons/code.mdx
+++ b/src/content/structured/components/buttons/code.mdx
@@ -28,7 +28,7 @@ export const snippetsDefault = [
   {
     technology: "Web component",
     snippets: {
-      short: `<ic-button id='my-button' variant="primary">Add to order</ic-button>
+      short: `<ic-button id="my-button" variant="primary">Add to order</ic-button>
 <ic-button variant="secondary">View coffees</ic-button>
 <ic-button variant="tertiary">Find out more</ic-button>
 <ic-button variant="destructive">Cancel order</ic-button>`,


### PR DESCRIPTION
## Summary of the changes
Updated CodePreview component so web component and React tab panels both have the same height - to prevent the page from moving up and down when switching the tabs. Also the set height is updated when clicking "Show more code" and switching React languages.

I changed the tab panels' display to be controlled using the `visibility` CSS property rather than `display`; an element with `display: none` has a height of 0 so it didn't allow for getting and setting the heights.

## Related issue

#1392

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
