### PR TITLE
fix(root): update code examples height to stop page moving when tabs …

### DIFF
--- a/src/components/CodePreview/index.css
+++ b/src/components/CodePreview/index.css
@@ -77,15 +77,28 @@
   justify-content: flex-start !important;
 }
 
-.code-window:focus-within {
+.code-tab-panel {
+  display: block;
+  overflow: auto;
+  width: 100%;
+}
+
+.code-tab-panel:focus-within {
   box-shadow: var(--ic-border-focus);
   border-radius: var(--ic-border-radius) !important;
+}
+
+.code-tab-panel.hidden {
+  visibility: hidden;
+  position: absolute;
 }
 
 .snippet {
   margin: 0 !important;
   border-radius: 0 !important;
   padding-bottom: var(--ic-space-sm);
+  overflow: visible !important;
+  min-width: fit-content;
 }
 
 .snippet:focus {

--- a/src/content/structured/components/buttons/code.mdx
+++ b/src/content/structured/components/buttons/code.mdx
@@ -28,7 +28,7 @@ export const snippetsDefault = [
   {
     technology: "Web component",
     snippets: {
-      short: `<ic-button id='my-button' variant="primary">Add to order</ic-button>
+      short: `<ic-button id="my-button" variant="primary">Add to order</ic-button>
 <ic-button variant="secondary">View coffees</ic-button>
 <ic-button variant="tertiary">Find out more</ic-button>
 <ic-button variant="destructive">Cancel order</ic-button>`,


### PR DESCRIPTION
## Summary of the changes
Updated CodePreview component so web component and React tab panels both have the same height - to prevent the page from moving up and down when switching the tabs. Also the set height is updated when clicking "Show more code" and switching React languages. 

I changed the tab panels' display to be controlled using the `visibility` CSS property rather than `display`; an element with `display: none` has a height of 0 so it didn't allow for getting and setting the heights.

## Related issue

#1392

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
