### PR TITLE
docs(root): add package install info to nextjs docs

### DIFF
--- a/src/content/structured/get-started/nextjs.mdx
+++ b/src/content/structured/get-started/nextjs.mdx
@@ -12,9 +12,21 @@ subTitle: "How to use the components in a Next.js-based application."
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/nextJS.mdx"
 ---
 
+import { IcAlert } from "@ukic/react";
+
 ## Transpile react package
 
 The `@ukic/react` package will need to be transpiled for use with Next.js. The steps required will depend on the version of Next.js you are using.
+
+<IcAlert heading="Packages required for Next.js" variant="info">
+  <ic-typography slot="message">
+    You will need to install the react and fonts packages as per the{" "}
+    <a href="/get-started/development/install-components/react">
+      react installation instructions
+    </a>
+    .
+  </ic-typography>
+</IcAlert>
 
 ### Next.js 13 and later
 


### PR DESCRIPTION
Add reference to needing fonts package on nextjs installation page, linking to react installation page

## Related issue

#1024
