### PR TITLE
fix(root): clip HMGCC logo at the breakpoint where the footer logos start to wrap

### DIFF
--- a/src/components/Layout/index.css
+++ b/src/components/Layout/index.css
@@ -140,7 +140,7 @@ ic-top-navigation form.not-loaded {
   }
 }
 
-@media screen and (max-width: 576px) {
+@media screen and (max-width: 690px) {
   .logo-wrapper {
     gap: var(--ic-space-lg);
   }
@@ -171,10 +171,14 @@ ic-top-navigation form.not-loaded {
   }
 
   .logo-wrapper > ic-footer-link:nth-child(3) {
-    width: 2.875rem;
+    width: 2.75rem;
   }
 
   .logo-wrapper > ic-footer-link:nth-child(3) svg {
     transform: translate(0, -1px);
+  }
+
+  .logo-wrapper > ic-footer-link:nth-child(4) {
+    width: 3rem;
   }
 }


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Clip the HMGCC logo to the icon when the footer logos began to wrap onto more than one line

## Related issue

Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
