### PR TITLE
Add spaces between OS names and versions in `report-bug.md`.

### DIFF
--- a/.github/ISSUE_TEMPLATE/report-bug.md
+++ b/.github/ISSUE_TEMPLATE/report-bug.md
@@ -28,7 +28,7 @@ If you can, add screenshots to show the problem. If you need to show a code exam
 
 - Type: [e.g. Desktop, mobile]
 - Device: [e.g. iPhone, MacBook, ThinkPad]
-- OS version: [e.g. macOS13, iOS16, Android 13]
+- OS version: [e.g. macOS 13, iOS 16, Android 13]
 - Browser version: [e.g. Chrome 115, Safari 16]
 
 ### 🧐 Expected behaviour


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

I noticed that macOS 13 and iOS 16 were misspelled as "macOS13" and "iOS16", respectively, which I've remediated.

If the brand names were officially formatted in that manner, the concatenation would be sensical. However, they're not, and it's not even consistent with the other OS entrants in the adjacent CommonMark.

## Related issue

I *noticed* this when filing https://github.com/mi6/ic-design-system/issues/1594#issue-3237047991. However, this isn't worth an issue.

## Checklist

1. [X] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.

   This is an accessibility improvement, because the screen readers shall now pause when they should.

1. [X] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)