### PR TITLE
docs(root): add guidance and code pages for IcTimeInput

### DIFF
--- a/src/content/structured/components/time-input/code.mdx
+++ b/src/content/structured/components/time-input/code.mdx
@@ -1,0 +1,1630 @@
+---
+path: "/components/time-input/code"
+
+date: "2025-08-20"
+
+title: "Time input"
+
+status: "CANARY"
+
+subTitle: "Time input allows users to enter a specific time in a standardised format for scheduling or time-based tasks."
+
+tabs:
+  [
+    { title: "Guidance", path: "/components/time-input" },
+    { title: "Code", path: "/components/time-input/code" },
+  ]
+---
+
+import { useState } from "react";
+import { IcButton, IcLink, IcTypography } from "@ukic/react";
+import { IcTimeInput } from "@ukic/canary-react";
+
+## Component demo
+
+export const snippetsDefault = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input
+  label="What time would you like to collect your coffee?"
+></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  label="What time would you like to collect your coffee?"
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsDefault}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    onChange={({ detail }) => console.log(detail.value)}
+  />
+</ComponentPreview>
+
+## Time input details
+
+<ComponentDetails component="ic-time-input" canary />
+
+## Variants
+
+### With values
+
+#### String
+
+export const snippetsStringValue = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input 
+  label="What time would you like to collect your coffee?"
+  value="13:45:00"
+></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  value="13:45:00"
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsStringValue}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    value="13:45:00"
+  />
+</ComponentPreview>
+
+#### Date object
+
+export const snippetsDateObject = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input
+  id="time-input-default-time-date"
+  label="What time would you like to collect your coffee?"
+></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>
+  <script>
+  let timeInputDate = document.querySelector(
+    "#time-input-default-time-date"
+  );
+  timeInputDate.value = new Date("2025-07-14T15:30:45");
+</script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  value={new Date("2025-07-14T15:30:45")}
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsDateObject}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    value={new Date("2025-07-14T15:30:45")}
+  />
+</ComponentPreview>
+
+#### Zulu time
+
+export const snippetsZulu = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?"></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>
+  <script>
+    let timeInputDate = document.querySelector(
+      "#time-input-default-zulu-time"
+    );
+    timeInputDate.value = "15:30:45Z";
+  </script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  id="time-input-default-zulu-time"
+  label="What time would you like to collect your coffee?"
+  value="15:30:45Z"
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsZulu}>
+  <IcTimeInput
+    id="time-input-default-zulu-time"
+    label="What time would you like to collect your coffee?"
+    value="15:30:45Z"
+  />
+</ComponentPreview>
+
+### Required
+
+To set the time input as a required field, set the `required` prop to `true`. This will add an asterisk at the end of the time input label.
+
+export const snippetsRequired = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?" required="true"></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput label="What time would you like to collect your coffee?" required />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsRequired}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    required
+  />
+</ComponentPreview>
+
+### IcChange event
+
+Retrieving the time input value via `IcChange` returns the time as a Date object.
+
+The event returns the Date object once hour, minute and second have been entered.
+
+export const snippetsIcChange = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?"></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>
+  <script>
+    let timeInput = document.querySelector("ic-time-input");
+    timeInput.addEventListener("icChange", function (event) {
+      console.log(event.detail.value, event.detail.utcValue);
+    });
+  </script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  onIcChange={(event) => console.log("icChange", event.detail.value)}
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsIcChange}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    onIcChange={(event) => console.log("icChange", event.detail.value)}
+  />
+</ComponentPreview>
+
+### IcChange with emitTimePartChange
+
+When the `emitTimePartChange` prop is set to `true`, the `IcChange` event will be emitted anytime part of the time input changes (i.e. any change to the hour, minute or second).
+
+export const snippetsIcChangeTimePart = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input emit-time-part-change="true" label="What time would you like to collect your coffee?"></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>
+  <script>
+    const timeInput = document.querySelector("ic-time-input");
+    timeInput.addEventListener("icChange", function (event) {
+      console.log("icChange emitted with every time part change", event.detail);
+    });
+  </script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  emitTimePartChange
+  label="What time would you like to collect your coffee?"
+  onIcChange={(event) =>
+    console.log("icChange emitted with every time part change", event.detail)
+  }
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsIcChangeTimePart}>
+  <IcTimeInput
+    emitTimePartChange
+    label="What time would you like to collect your coffee?"
+    onIcChange={(event) =>
+      console.log("icChange emitted with every time part change", event.detail)
+    }
+  />
+</ComponentPreview>
+
+### Hide label
+
+To hide the label, set the `hideLabel` prop to `true`. The required `label` will still be read out by screen readers.
+
+export const snippetsHideLabel = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?" hide-label="true"></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput label="What time would you like to collect your coffee?" hideLabel />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsHideLabel}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    hideLabel
+  />
+</ComponentPreview>
+
+### Disabled
+
+Set the `disabled` prop to `true` to prevent interaction with the time input.
+
+export const snippetsDisabled = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?" disabled="true"></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput label="What time would you like to collect your coffee?" disabled />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsDisabled}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    disabled
+  />
+</ComponentPreview>
+
+### Sizes
+
+export const snippetsSizes = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?" size="small"></ic-time-input>
+<ic-time-input label="What time would you like to collect your coffee?"></ic-time-input>
+<ic-time-input label="What time would you like to collect your coffee?" size="large"></ic-time-input>`,
+      long: `.parent-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ic-space-md);
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput label="What time would you like to collect your coffee?" size="small" />
+<IcTimeInput label="What time would you like to collect your coffee?" />
+<IcTimeInput label="What time would you like to collect your coffee?" size="large" />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return ( 
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return ( 
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview
+  snippets={snippetsSizes}
+  style={{
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    alignItems: "center",
+  }}
+>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    size="small"
+  />
+  <IcTimeInput label="What time would you like to collect your coffee?" />
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    size="large"
+  />
+</ComponentPreview>
+
+### Custom helper text
+
+Use the helper text to add additional detail for the time input. Display custom content using the `helper-text` slot.
+
+export const snippetsCustomHelperText = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?" helper-text="We will have your order ready for you at this time"></ic-time-input>
+<ic-time-input label="What time would you like to collect your coffee?">
+  <ic-typography variant="caption" slot="helper-text">
+    <span>
+      For special requests, <ic-link href="#">contact us</ic-link> before choosing a time
+    </span>
+  </ic-typography>
+</ic-time-input>`,
+      long: `.parent-container {
+    display: flex;
+    flex-direction: column;
+    padding: var(--ic-space-md);
+    gap: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: ` <IcTimeInput label="What time would you like to collect your coffee?" helperText="We will have your order ready for you at this time" />
+<IcTimeInput label="What time would you like to collect your coffee?">
+  <IcTypography variant="caption" slot="helper-text">
+    <span>
+      For special requests,{" "}
+      <IcLink href="#">contact us</IcLink> before choosing a time
+    </span>
+  </IcTypography>
+</IcTimeInput>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview
+  snippets={snippetsCustomHelperText}
+  style={{
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    alignItems: "center",
+  }}
+>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    helperText="We will have your order ready for you at this time"
+  />
+  <IcTimeInput label="What time would you like to collect your coffee?">
+    <IcTypography
+      style={{ marginBottom: "0" }}
+      variant="caption"
+      slot="helper-text"
+    >
+      <span>
+        For special requests,{`${" "}`}
+        <IcLink href="#">contact us</IcLink> before choosing a time
+      </span>
+    </IcTypography>
+  </IcTimeInput>
+</ComponentPreview>
+
+### Hide helper text
+
+export const snippetsHideHelperText = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input
+  label="What time would you like to collect your coffee?"
+  helper-text="We will have your order ready for you at this time"
+  hide-helper-text="true"
+></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  helperText="We will have your order ready for you at this time"
+  hideHelperText
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsHideHelperText}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    helperText="We will have your order ready for you at this time"
+    hideHelperText
+  />
+</ComponentPreview>
+
+### Custom validation
+
+Validation on time input is set via the `validationStatus` and `validationText` props.
+
+`validationStatus` will set the style of the validation message. `validationStatus` accepts:
+
+- `error`
+- `warning`
+- `success`
+
+`validationStatus` is required for the `validationText` to appear.
+
+export const snippetsValidation = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input
+  label="What time would you like to collect your coffee?"
+  validation-status="error"
+  validation-text="There is a coffee shortage forecast for that time. Please choose a different time."
+></ic-time-input>
+<ic-time-input
+  label="What time would you like to collect your coffee?"
+  validation-status="warning"
+  validation-text="Please be aware that there may be a coffee shortage at that time."
+></ic-time-input>
+<ic-time-input
+  label="What time would you like to collect your coffee?"
+  validation-status="success"
+  validation-text="Your coffee will be available for you to collect at this time."
+></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  validationStatus="error"
+  validationText="There is a coffee shortage forecast for that time. Please choose a different time."
+/>
+<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  validationStatus="warning"
+  validationText="Please be aware that there may be a coffee shortage at that time."
+/>
+<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  validationStatus="success"
+  validationText="Your coffee will be available for you to collect at this time."
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)"
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)"
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview
+  snippets={snippetsValidation}
+  style={{
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    alignItems: "center",
+  }}
+>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    validationStatus="error"
+    validationText="There is a coffee shortage forecast for that time. Please choose a different time."
+  />
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    validationStatus="warning"
+    validationText="Please be aware that there may be a coffee shortage at that time."
+  />
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    validationStatus="success"
+    validationText="Your coffee will be available for you to collect at this time."
+  />
+</ComponentPreview>
+
+### Disabled times
+
+To disable specific times in the time input, set the `disableTimes` prop. The `disableTimes` prop accepts an array of time objects or strings. Each time object can have a `start` and `end` property to define a range of disabled times, or it can be a single time string to disable that specific time. The time can be in any format supported as `timeFormat`, in ISO 8601 time string format (HH:MM:SS) or as a JavaScript Date object.
+
+export const snippetsDisabledTimes = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input 
+  id="time-input-default-disable-time" 
+  label="What time would you like to collect your coffee?"
+></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>
+  <script>
+    const timeInputDate = document.querySelector(
+      "#time-input-default-disable-time"
+    );
+    timeInputDate.disableTimes = [{ start: "08:00", end: "10:00" }, "13:20"];
+  </script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+    id="time-input-default-disable-time"
+    label="What time would you like to collect your coffee?"
+    disableTimes={[
+      {
+        start: "08:00",
+        end: "10:00",
+      },
+      "13:20",
+    ]}
+  />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsDisabledTimes}>
+  <IcTimeInput
+    id="time-input-default-disable-time"
+    label="What time would you like to collect your coffee?"
+    disableTimes={[
+      {
+        start: "08:00",
+        end: "10:00",
+      },
+      "13:20",
+    ]}
+  />
+</ComponentPreview>
+
+### Time period
+
+export const snippetsTimePeriod = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?" time-period="12" ></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput label="What time would you like to collect your coffee?" timePeriod="12" />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsTimePeriod}>
+  <IcTimeInput label="12-hour time" timePeriod="12" />
+</ComponentPreview>
+
+### Time format (HH:MM)
+
+export const snippetsTimeFormat = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input label="What time would you like to collect your coffee?" time-format="HH:MM" ></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput label="What time would you like to collect your coffee?" timeFormat="HH:MM" />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsTimeFormat}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    timeFormat="HH:MM"
+  />
+</ComponentPreview>
+
+### Min and max
+
+It is possible to set a minimum and maximum time range using the `min` and `max` props. If a time is set and it is earlier the minimum or later the maximum time, a validation error will appear.
+
+The `min` and `max` props accept the same time formats as the `value` prop.
+
+export const snippetsMinMax = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input
+  label="What time would you like to collect your coffee?"
+  min="08:00:00"
+  max="16:00:00"
+></ic-time-input>`,
+      long: `.parent-container {
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  min="08:00:00"
+  max="16:00:00"
+/>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsMinMax}>
+  <IcTimeInput
+    label="What time would you like to collect your coffee?"
+    min="08:00:00"
+    max="16:00:00"
+  />
+</ComponentPreview>
+
+### Form
+
+export const snippetsForm = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<form class="parent-form">
+  <ic-time-input 
+    label="What time would you like to collect your coffee?"
+    value="13:45:00"
+  ></ic-time-input>
+  <div class="button-container">
+    <ic-button type="submit" value="Submit"></ic-button>
+    <ic-button type="reset" value="Reset"></ic-button>
+  </div>
+</form>`,
+      long: `.parent-form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ic-space-md);
+    padding: var(--ic-space-md);
+  }
+  .button-container {
+    display: flex;
+    gap: var(--ic-space-md);
+  }
+</style>
+<body>
+  {shortCode}
+  <script>
+    document.querySelector("form").addEventListener("submit", (ev) => {
+      ev.preventDefault();
+      console.log(ev);
+    });
+  </script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `const formSubmit = (ev) => {
+  ev.preventDefault();
+  console.log(ev);
+};
+return (
+  <form onSubmit={formSubmit} className={classes.parentForm}>
+    <IcTimeInput
+      label="What time would you like to collect your coffee?"
+      value="13:45:00"
+    />
+    <div className={classes.buttonContainer}>
+      <IcButton type="submit">Submit</IcButton>
+      <IcButton type="reset">Reset</IcButton>
+    </div>
+  </form>
+)`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentForm: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)",
+  },
+  buttonContainer: {
+    display: "flex",
+    gap: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentForm: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)",
+  },
+  buttonContainer: {
+    display: "flex",
+    gap: "var(--ic-space-md)",
+  },
+});
+{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+export const FormTimeInput = () => {
+  const formSubmit = (ev) => {
+    ev.preventDefault();
+    console.log(ev);
+  };
+  return (
+    <form
+      onSubmit={formSubmit}
+      style={{ display: "flex", flexDirection: "column", gap: "8px" }}
+    >
+      <IcTimeInput
+        label="What time would you like to collect your coffee?"
+        value="13:45:00"
+      />
+      <div style={{ display: "flex", gap: "8px" }}>
+        <IcButton type="submit">Submit</IcButton>
+        <IcButton type="reset">Reset</IcButton>
+      </div>
+    </form>
+  );
+};
+
+<ComponentPreview snippets={snippetsForm}>
+  <FormTimeInput />
+</ComponentPreview>
+
+### With clearing value
+
+The time input can be cleared by setting the `value` attribute to one of the following:
+
+- empty string
+- `null`
+- `undefined`
+
+export const snippetsClearingValue = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-time-input
+  id="time-input-clear-value"
+  label="What time would you like to collect your coffee?"
+  value="08:30:00"
+></ic-time-input>
+<div class="button-container">
+  <ic-button id="update">Update date</ic-button>
+  <ic-button id="null-btn">Set null</ic-button>
+  <ic-button id="empty-btn">Set empty string</ic-button>
+  <ic-button id="undef-btn">Set undefined</ic-button>
+</div>`,
+      long: `.parent-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ic-space-md);
+    padding: var(--ic-space-md);
+  }
+  .button-container {
+    display: flex;
+    gap: var(--ic-space-md);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>
+  <script>
+    const input = document.querySelector("#time-input-clear-value");
+    const btn = document.querySelector("#update");
+    btn.addEventListener("click", () => {
+      input.value = "08:30:00";
+    });
+    const btn2 = document.querySelector("#null-btn");
+    btn2.addEventListener("click", () => {
+      input.value = null;
+    });
+    const btn3 = document.querySelector("#empty-btn");
+    btn3.addEventListener("click", () => {
+      input.value = "";
+    });
+    const btn4 = document.querySelector("#undef-btn");
+    btn4.addEventListener("click", () => {
+      input.value = undefined;
+    });
+  </script>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTimeInput
+  label="What time would you like to collect your coffee?"
+  value={value}
+/>
+<div className={classes.buttonContainer}>
+  <IcButton onClick={() => handleUpdate()}>Update time</IcButton>
+  <IcButton onClick={() => handleClearValue(null)}>Set null</IcButton>
+  <IcButton onClick={() => handleClearValue("")}>
+    Set empty string
+  </IcButton>
+  <IcButton onClick={() => handleClearValue(undefined)}>
+    Set undefined
+  </IcButton>
+</div>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const [value, setValue] = useState("08:30:00");
+const handleUpdate = () => {
+  setValue("08:30:00");
+};
+const handleClearValue = (currentValue) => {
+  setValue(currentValue);
+};
+const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)",
+  },
+  buttonContainer: {
+    display: "flex",,
+    gap: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const [value, setValue] = useState("08:30:00");
+const handleUpdate = () => {
+  setValue("08:30:00");
+};
+const handleClearValue = (currentValue) => {
+  setValue(currentValue);
+};
+const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "var(--ic-space-md)",
+    padding: "var(--ic-space-md)",
+  },
+  buttonContainer: {
+    display: "flex",
+    gap: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}> 
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+export const WithClearingValue = () => {
+  const [value, setValue] = useState("08:30:00");
+  const handleUpdate = () => {
+    setValue("08:30:00");
+  };
+  const handleClearValue = (currentValue) => {
+    setValue(currentValue);
+  };
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+      <IcTimeInput
+        label="When would you like to collect your coffee?"
+        value={value}
+      />
+      <div
+        style={{
+          display: "flex",
+          gap: "8px",
+        }}
+      >
+        <IcButton onClick={() => handleUpdate()}>Update time</IcButton>
+        <IcButton onClick={() => handleClearValue(null)}>Set null</IcButton>
+        <IcButton onClick={() => handleClearValue("")}>
+          Set empty string
+        </IcButton>
+        <IcButton onClick={() => handleClearValue(undefined)}>
+          Set undefined
+        </IcButton>
+      </div>
+    </div>
+  );
+};
+
+<ComponentPreview snippets={snippetsClearingValue}>
+  <WithClearingValue />
+</ComponentPreview>

--- a/src/content/structured/components/time-input/guidance.mdx
+++ b/src/content/structured/components/time-input/guidance.mdx
@@ -1,0 +1,72 @@
+---
+path: "/components/time-input"
+
+navPriority: 42
+
+date: "2025-08-20"
+
+title: "Time input"
+
+status: "CANARY"
+
+subTitle: "Time input allows users to enter a specific time in a standardised format for scheduling or time-based tasks."
+
+contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/components/time-input"
+
+tabs:
+  [
+    { title: "Guidance", path: "/components/time-input" },
+    { title: "Code", path: "/components/time-input/code" },
+  ]
+
+tags: ["Time field", "Time entry"]
+---
+
+import { IcAlert, IcLink } from "@ukic/react";
+import { IcTimeInput } from "@ukic/canary-react";
+
+<IcAlert
+  heading="Canary component"
+  variant="info"
+  message="This component is new and its guidance will be updated over time."
+/>
+
+## Canary components
+
+Canary components are unstable components that are released for testing purposes.
+
+We value any feedback from users willing to try them in their applications.
+
+These components should not be used in production apps without understanding the risk that changes may occur in order to fix bugs or improve functionality.
+
+For more information on Canary components, read our approach to [releases and versions](/get-started/releases-versions).
+
+<p>
+  Additional details on the props and events for this component can be found in
+  the{" "}
+  <IcLink
+    href="https://mi6.github.io/ic-ui-kit/branches/canary/main/web-components/?path=/docs/web-components-time-input--docs"
+    target="_blank"
+  >
+    Canary web components
+  </IcLink>{" "}
+  and{" "}
+  <IcLink
+    href="https://mi6.github.io/ic-ui-kit/branches/canary/main/react/?path=/docs/react-components-time-input--docs"
+    target="_blank"
+  >
+    Canary React
+  </IcLink>{" "}
+  storybooks.
+</p>
+
+## Component demo
+
+An example of the time input component.
+
+<ComponentPreview>
+  <IcTimeInput
+    label="Select coffee collection time"
+    helperText="Enter in format HH:MM:SS"
+  />
+</ComponentPreview>

--- a/src/content/structured/components/toasts/guidance.mdx
+++ b/src/content/structured/components/toasts/guidance.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/toast"
 
-navPriority: 42
+navPriority: 43
 
 date: "2025-08-11"
 

--- a/src/content/structured/components/toggle-buttons/guidance.mdx
+++ b/src/content/structured/components/toggle-buttons/guidance.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/toggle-button"
 
-navPriority: 43
+navPriority: 44
 
 date: "2025-03-04"
 

--- a/src/content/structured/components/tooltips/guidance.mdx
+++ b/src/content/structured/components/tooltips/guidance.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/tooltip"
 
-navPriority: 44
+navPriority: 45
 
 date: "2023-02-03"
 

--- a/src/content/structured/components/top-nav/guidance.mdx
+++ b/src/content/structured/components/top-nav/guidance.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/top-navigation"
 
-navPriority: 45
+navPriority: 46
 
 date: "2023-02-03"
 

--- a/src/content/structured/components/tree-view/accessibility.mdx
+++ b/src/content/structured/components/tree-view/accessibility.mdx
@@ -1,8 +1,6 @@
 ---
 path: "/components/tree-view/accessibility"
 
-navPriority: 42
-
 date: "2024-08-23"
 
 title: "Tree view"

--- a/src/content/structured/components/tree-view/code.mdx
+++ b/src/content/structured/components/tree-view/code.mdx
@@ -1,8 +1,6 @@
 ---
 path: "/components/tree-view/code"
 
-navPriority: 43
-
 date: "2025-07-22"
 
 title: "Tree view"

--- a/src/content/structured/components/tree-view/guidance.mdx
+++ b/src/content/structured/components/tree-view/guidance.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/tree-view"
 
-navPriority: 46
+navPriority: 47
 
 date: "2024-08-23"
 

--- a/src/content/structured/components/typography/guidance.mdx
+++ b/src/content/structured/components/typography/guidance.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/typography"
 
-navPriority: 47
+navPriority: 48
 
 date: "2023-11-27"
 

--- a/src/icds-pages-data.json
+++ b/src/icds-pages-data.json
@@ -196,6 +196,11 @@
       "subTitle": "How to change the theme and brand colours of some components."
     },
     {
+      "path": "/components/time-input",
+      "title": "Time input",
+      "subTitle": "Time input allows users to enter a specific time in a standardised format for scheduling or time-based tasks."
+    },
+    {
       "path": "/components/toast",
       "title": "Toast",
       "subTitle": "Toasts give brief, non-critical updates about events that happen in an app. Toasts are sometimes called 'snackbars'."


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

- Add stand in-guidance and code pages for IcTimeInput
- Update canary-component-names.json file
- Update navPriority for guidance pages that follow the Time Input guidance page

## Related issue
#1614 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
