### PR TITLE
docs(root): add code example for new data list css prop

### DIFF
--- a/src/content/structured/components/data-list/code.mdx
+++ b/src/content/structured/components/data-list/code.mdx
@@ -886,3 +886,152 @@ return (
     </IcDataRow>
   </IcDataList>
 </ComponentPreview>
+
+### Label width CSS prop
+
+export const snippetsLabelWidth = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-data-list heading="Order details" style="--data-row-label-width:30rem">
+  <ic-data-row label="Order name" value="Michael">
+    <ic-link href="#" slot="end-component">
+      Edit
+    </ic-link>
+  </ic-data-row>
+  <ic-data-row label="Drink" value="Americano">
+    <ic-link href="#" slot="end-component">
+      Edit
+    </ic-link>
+  </ic-data-row>
+  <ic-data-row label="Milk option" value="Soya milk">
+    <ic-link href="#" slot="end-component">
+      Edit
+    </ic-link>
+  </ic-data-row>
+  <ic-data-row label="Price" value="£3.25">
+    <ic-link href="#" slot="end-component">
+      Edit
+    </ic-link>
+  </ic-data-row>
+  <ic-data-row label="Payment method">
+    <ic-typography variant="body" slot="value">
+      VISA ending 5896
+    </ic-typography>
+    <ic-link href="#" slot="end-component">
+      Edit
+    </ic-link>
+  </ic-data-row>
+  <ic-data-row label="Download receipt" value="CoffeeOrder_X46w32.pdf">
+    <ic-button variant="icon" aria-label="Download" slot="end-component">
+      <svg viewBox="0 0 24 24" height="24" width="24">
+        <path
+          d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
+          fill="currentColor"
+        />
+      </svg>
+    </ic-button>
+  </ic-data-row>
+</ic-data-list>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcDataList heading="Order details" style={{ "--data-row-label-width": "30rem" }}>
+  <IcDataRow label="Order name" value="Michael">
+    <IcLink href="#" slot="end-component">
+      Edit
+    </IcLink>
+  </IcDataRow>
+  <IcDataRow label="Drink" value="Americano">
+    <IcLink href="#" slot="end-component">
+      Edit
+    </IcLink>
+  </IcDataRow>
+  <IcDataRow label="Milk option" value="Soya milk">
+    <IcLink href="#" slot="end-component">
+      Edit
+    </IcLink>
+  </IcDataRow>
+  <IcDataRow label="Price" value="£3.25">
+    <IcLink href="#" slot="end-component">
+      Edit
+    </IcLink>
+  </IcDataRow>
+  <IcDataRow label="Payment method">
+    <IcTypography variant="body" slot="value">
+      VISA ending 5896
+    </IcTypography>
+    <IcLink href="#" slot="end-component">
+      Edit
+    </IcLink>
+  </IcDataRow>
+  <IcDataRow label="Download receipt" value="CoffeeOrder_X46w32.pdf">
+    <IcButton variant="icon" aria-label="Download" slot="end-component">
+      <SlottedSVG viewBox="0 0 24 24" height="24" width="24">
+        <path
+          d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
+          fill="currentColor"
+        />
+      </SlottedSVG>
+    </IcButton>
+  </IcDataRow>
+</IcDataList>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsLabelWidth}>
+  <IcDataList heading="Order details" style={{ width: "90%", "--data-row-label-width": "30rem" }}>
+    <IcDataRow label="Order name" value="Michael">
+      <IcLink href="#" onClick={(e) => e.preventDefault()} slot="end-component">
+        Edit
+      </IcLink>
+    </IcDataRow>
+    <IcDataRow label="Drink" value="Americano">
+      <IcLink href="#" onClick={(e) => e.preventDefault()} slot="end-component">
+        Edit
+      </IcLink>
+    </IcDataRow>
+    <IcDataRow label="Milk option" value="Soya milk">
+      <IcLink href="#" onClick={(e) => e.preventDefault()} slot="end-component">
+        Edit
+      </IcLink>
+    </IcDataRow>
+    <IcDataRow label="Price" value="£3.25">
+      <IcLink href="#" onClick={(e) => e.preventDefault()} slot="end-component">
+        Edit
+      </IcLink>
+    </IcDataRow>
+    <IcDataRow label="Payment method">
+      <IcTypography variant="body" slot="value">
+        VISA ending 5896
+      </IcTypography>
+      <IcLink href="#" onClick={(e) => e.preventDefault()} slot="end-component">
+        Edit
+      </IcLink>
+    </IcDataRow>
+    <IcDataRow label="Download receipt" value="CoffeeOrder_X46w32.pdf">
+      <IcButton variant="icon" aria-label="Download" slot="end-component">
+        <svg viewBox="0 0 24 24" height="24" width="24">
+          <path
+            d="M5,20H19V18H5M19,9H15V3H9V9H5L12,16L19,9Z"
+            fill="currentColor"
+          />
+        </svg>
+      </IcButton>
+    </IcDataRow>
+  </IcDataList>
+</ComponentPreview>


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add code example for new data list css prop to control the label width.
This won't work until https://github.com/mi6/ic-ui-kit/pull/3852 has been merged in the next release, but I've tested it by checking the components out locally.

## Related issue

https://github.com/mi6/ic-ui-kit/issues/3732

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
