### PR TITLE
1600 comp details table overlaps anchor nav

### DIFF
--- a/src/components/ComponentDetails/PropTable/PropDescription/index.tsx
+++ b/src/components/ComponentDetails/PropTable/PropDescription/index.tsx
@@ -3,20 +3,33 @@ import CodeAttribute from "../../../CodeAttribute";
 import "./index.css";
 import { backtickToCodeBlock } from "../../../../utils/helpers";
 
-const PropDescription: React.FC<{
+interface PropDescriptionProps {
   description: string;
   typeName?: string;
   type?: string;
   required: boolean;
-  deprecation: string | undefined;
-}> = ({ description, type, typeName, required, deprecation }) => {
+  deprecation?: string;
+  compact?: boolean;
+}
+
+const PropDescription: React.FC<PropDescriptionProps> = ({
+  description,
+  type,
+  typeName,
+  required,
+  deprecation,
+  compact,
+}) => {
   let displayedType: string | null = null;
   if (type) {
     displayedType =
       typeName && typeName !== type ? `${typeName} - ${type}` : type;
   }
   return (
-    <div className="prop-description">
+    <div
+      className="prop-description"
+      style={compact ? { maxWidth: 240 } : undefined}
+    >
       {!!description && (
         <ic-typography>{backtickToCodeBlock(description)}</ic-typography>
       )}

--- a/src/components/ComponentDetails/PropTable/index.tsx
+++ b/src/components/ComponentDetails/PropTable/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react";
 import { JsonDocsProp } from "@ukic/docs";
+import { IcTypography } from "@ukic/react";
 import AttributeTable from "../../AttributeTable";
 import AttributeCards from "../../AttributeCards";
 import AttributeName from "../AttributeName";
@@ -53,6 +54,23 @@ const PropTable: React.FC<PropTableProps> = ({ propData, typeLibrary }) => {
     []
   );
 
+  const typeOfDefaultValue = (
+    value: any,
+    startCharacter: string,
+    endCharacter: string
+  ) =>
+    typeof value === "string" &&
+    value.trim().startsWith(startCharacter) &&
+    value.trim().endsWith(endCharacter);
+
+  const hasObjectDefaultValue = useMemo(
+    () =>
+      propData.some(({ default: defaultValue }) =>
+        typeOfDefaultValue(defaultValue, "{", "}")
+      ),
+    [propData]
+  );
+
   const data = useMemo(
     () =>
       propData
@@ -83,9 +101,34 @@ const PropTable: React.FC<PropTableProps> = ({ propData, typeLibrary }) => {
                   type={type}
                   required={required}
                   deprecation={deprecation}
+                  compact={hasObjectDefaultValue}
                 />
               ),
-              default: defaultValue,
+              default: (() => {
+                if (typeOfDefaultValue(defaultValue, "{", "}")) {
+                  return (
+                    <IcTypography
+                      style={{
+                        whiteSpace: "pre-wrap",
+                        wordBreak: "break-word",
+                        overflowWrap: "break-word",
+                        fontSize: "0.82em",
+                        margin: 0,
+                      }}
+                    >
+                      {defaultValue}
+                    </IcTypography>
+                  );
+                }
+                if (typeOfDefaultValue(defaultValue, "`", "`")) {
+                  return (
+                    <code className="language-text">
+                      {defaultValue ? defaultValue.trim().slice(1, -1) : ""}
+                    </code>
+                  );
+                }
+                return defaultValue;
+              })(),
               key: name,
             };
           }
@@ -93,7 +136,7 @@ const PropTable: React.FC<PropTableProps> = ({ propData, typeLibrary }) => {
         .sort(
           (a, b) => b.description.props.required - a.description.props.required
         ),
-    [propData, typeLibrary]
+    [propData, typeLibrary, hasObjectDefaultValue]
   );
 
   return (


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update component details default value to display like an object to fix issue where component details table would overlap the anchor nav

## Related issue

#1600

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
