### PR TITLE
1604 home page cards heading hierarchy improvement 

### DIFF
--- a/src/templates/Homepage/index.tsx
+++ b/src/templates/Homepage/index.tsx
@@ -139,7 +139,7 @@ const Homepage: React.FC = () => {
                       variant="h4"
                       aria-label={`${item.title}.`}
                     >
-                      <h4>{item.title}</h4>
+                      <p>{item.title}</p>
                     </ic-typography>
                     <ic-typography
                       slot="message"


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update homepage cards to not be a h4 and instead be a p tag under the hood

## Related issue

#1604

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
