### PR TITLE
docs(root): update horizontal card guidance and code examples

### DIFF
--- a/src/content/structured/components/card-horizontal/code.mdx
+++ b/src/content/structured/components/card-horizontal/code.mdx
@@ -3,7 +3,7 @@ path: "/components/card-horizontal/code"
 
 navPriority: 7
 
-date: "2025-09-08"
+date: "2025-10-10"
 
 title: "Card (horizontal)"
 
@@ -23,7 +23,7 @@ tabs:
 ---
 
 import { IcCardHorizontal } from "@ukic/canary-react";
-import { IcTypography } from "@ukic/react";
+import { IcTypography, IcStatusTag, IcButton } from "@ukic/react";
 
 ## Component demo
 
@@ -46,7 +46,7 @@ export const snippetsDefault = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -86,7 +86,7 @@ export const snippetsDefault = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -134,7 +134,11 @@ export const snippetsDefault = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -354,7 +358,7 @@ export const snippetsWithImage = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -394,7 +398,7 @@ export const snippetsWithImage = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -442,7 +446,11 @@ export const snippetsWithImage = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -481,7 +489,7 @@ export const snippetsWithImageNonSVG = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <img
-    slot="image"
+    slot="image-left"
     src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
     alt="Coffee illustration"
     style="object-fit:cover"
@@ -508,7 +516,7 @@ export const snippetsWithImageNonSVG = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <img
-    slot="image"
+    slot="image-left"
     src="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
     alt="Coffee illustration"
     style={{ objectFit: "cover" }}
@@ -543,7 +551,7 @@ export const snippetsWithImageNonSVG = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <div slot="image">
+    <div slot="image-left">
       <SimpleImage
         imageSrc="https://images.freeimages.com/image/large-previews/334/a-cup-of-coffee-5696540.jpeg"
         imageAlt="Coffee illustration"
@@ -554,6 +562,139 @@ export const snippetsWithImageNonSVG = [
         }}
       />
     </div>
+  </IcCardHorizontal>
+</ComponentPreview>
+
+### Image - right
+
+Use the `image-right` slot to display the image on the right of the card content.
+
+export const snippetsImageRight = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-card-horizontal 
+  heading="Americano order" 
+  message="Extras: Double espresso shot and oat milk."
+>
+  <svg
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+  </svg>
+  <svg
+    slot="image-right"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1600 900"
+  >
+    <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+    <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+    <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+    <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+    <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+    <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+    <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+    <polygon fill="#b80066" points="641 695 886 900 367 900" />
+    <polygon fill="#960052" points="587 900 641 695 886 900" />
+    <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+    <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+    <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+    <polygon fill="#880088" points="943 900 1210 900 971 687" />
+  </svg>
+</ic-card-horizontal>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcCardHorizontal
+  heading="Americano order"
+  message="Extras: Double espresso shot and oat milk."
+>
+  <SlottedSVG
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+  </SlottedSVG>
+  <SlottedSVG
+    slot="image-right"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1600 900"
+  >
+    <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+    <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+    <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+    <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+    <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+    <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+    <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+    <polygon fill="#b80066" points="641 695 886 900 367 900" />
+    <polygon fill="#960052" points="587 900 641 695 886 900" />
+    <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+    <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+    <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+    <polygon fill="#880088" points="943 900 1210 900 971 687" />
+  </SlottedSVG>
+</IcCardHorizontal>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsImageRight}>
+  <IcCardHorizontal
+    heading="Americano order"
+    message="Extras: Double espresso shot and oat milk."
+  >
+    <svg
+      slot="icon"
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      fill="#000000"
+    >
+      <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
+    </svg>
+    <svg
+      slot="image-right"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
+      <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+      <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+      <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+      <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+      <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+      <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+      <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+      <polygon fill="#b80066" points="641 695 886 900 367 900" />
+      <polygon fill="#960052" points="587 900 641 695 886 900" />
+      <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+      <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+      <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+      <polygon fill="#880088" points="943 900 1210 900 971 687" />
+    </svg>
   </IcCardHorizontal>
 </ComponentPreview>
 
@@ -579,7 +720,7 @@ export const snippetsSmall = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -620,7 +761,7 @@ export const snippetsSmall = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -669,7 +810,11 @@ export const snippetsSmall = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -709,7 +854,7 @@ export const snippetsLarge = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -750,7 +895,7 @@ export const snippetsLarge = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -799,7 +944,11 @@ export const snippetsLarge = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -817,16 +966,17 @@ export const snippetsLarge = [
   </IcCardHorizontal>
 </ComponentPreview>
 
-### Extra large
+### Interaction button
 
-export const snippetsXL = [
+Add an interaction button to appear in line with the card heading.
+
+export const snippetsInteractionButton = [
   {
     technology: "Web component",
     snippets: {
       short: `<ic-card-horizontal 
   heading="Americano order" 
-  message="Extras: Double espresso shot and oat milk. Size: Venti. Order type: Takeaway via drive-through." 
-  size="extra-large"
+  message="Extras: Double espresso shot and oat milk. Size: Grande. Order type: Takeaway." 
 >
   <svg
     slot="icon"
@@ -838,8 +988,26 @@ export const snippetsXL = [
   >
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
+  <ic-button
+    variant="icon-tertiary"
+    title="More information"
+    slot="interaction-button"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      class="bi bi-three-dots-vertical"
+      viewBox="0 0 16 16"
+    >
+      <path
+        d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+      />
+    </svg>
+  </ic-button>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -866,8 +1034,7 @@ export const snippetsXL = [
     snippets: {
       short: `<IcCardHorizontal
   heading="Americano order"
-  message="Extras: Double espresso shot and oat milk. Size: Venti. Order type: Takeaway via drive-through."
-  size="extra-large"
+  message="Extras: Double espresso shot and oat milk. Size: Grande. Order type: Takeaway."
 >
   <SlottedSVG
     slot="icon"
@@ -879,8 +1046,22 @@ export const snippetsXL = [
   >
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
+  <IcButton slot="interaction-button" variant="icon-tertiary" title="More information">
+    <SlottedSVG
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      fill="currentColor"
+      class="bi bi-three-dots-vertical"
+      viewBox="0 0 16 16"
+    >
+      <path
+        d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"
+      />
+    </SlottedSVG>
+  </IcButton>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -913,11 +1094,10 @@ export const snippetsXL = [
   },
 ];
 
-<ComponentPreview snippets={snippetsXL}>
+<ComponentPreview snippets={snippetsInteractionButton}>
   <IcCardHorizontal
     heading="Americano order"
-    message="Extras: Double espresso shot and oat milk. Size: Venti. Order type: Takeaway via drive-through."
-    size="extra-large"
+    message="Extras: Double espresso shot and oat milk. Size: Grande. Order type: Takeaway."
   >
     <svg
       slot="icon"
@@ -929,7 +1109,313 @@ export const snippetsXL = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <IcButton
+      slot="interaction-button"
+      variant="icon-tertiary"
+      title="More information"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        fill="currentColor"
+        class="bi bi-three-dots-vertical"
+        viewBox="0 0 16 16"
+      >
+        <path d="M9.5 13a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm0-5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z" />
+      </svg>
+    </IcButton>
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
+      <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+      <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+      <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+      <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+      <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+      <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+      <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+      <polygon fill="#b80066" points="641 695 886 900 367 900" />
+      <polygon fill="#960052" points="587 900 641 695 886 900" />
+      <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+      <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+      <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+      <polygon fill="#880088" points="943 900 1210 900 971 687" />
+    </svg>
+  </IcCardHorizontal>
+</ComponentPreview>
+
+### Density
+
+Use a spacious density to add padding around the horizontal card image.
+
+export const snippetsSpacious = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-card-horizontal 
+  heading="Americano order" 
+  message="Extras: Double espresso shot and oat milk."
+  density="spacious"
+>
+  <svg
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+  </svg>
+  <svg
+    slot="image-left"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1600 900"
+  >
+    <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+    <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+    <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+    <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+    <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+    <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+    <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+    <polygon fill="#b80066" points="641 695 886 900 367 900" />
+    <polygon fill="#960052" points="587 900 641 695 886 900" />
+    <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+    <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+    <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+    <polygon fill="#880088" points="943 900 1210 900 971 687" />
+  </svg>
+</ic-card-horizontal>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcCardHorizontal
+  heading="Americano order"
+  message="Extras: Double espresso shot and oat milk."
+  density="spacious"
+>
+  <SlottedSVG
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+  </SlottedSVG>
+  <SlottedSVG
+    slot="image-left"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1600 900"
+  >
+    <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+    <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+    <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+    <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+    <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+    <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+    <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+    <polygon fill="#b80066" points="641 695 886 900 367 900" />
+    <polygon fill="#960052" points="587 900 641 695 886 900" />
+    <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+    <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+    <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+    <polygon fill="#880088" points="943 900 1210 900 971 687" />
+  </SlottedSVG>
+</IcCardHorizontal>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsSpacious}>
+  <IcCardHorizontal
+    heading="Americano order"
+    message="Extras: Double espresso shot and oat milk."
+    density="spacious"
+  >
+    <svg
+      slot="icon"
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      fill="#000000"
+    >
+      <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
+    </svg>
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
+      <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+      <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+      <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+      <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+      <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+      <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+      <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+      <polygon fill="#b80066" points="641 695 886 900 367 900" />
+      <polygon fill="#960052" points="587 900 641 695 886 900" />
+      <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+      <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+      <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+      <polygon fill="#880088" points="943 900 1210 900 971 687" />
+    </svg>
+  </IcCardHorizontal>
+</ComponentPreview>
+
+### With subheading and adornment
+
+Using a spacious density opens up the use of the `subheading` prop and the `adornment` slot.
+
+export const snippetsSubheadingAdornment = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-card-horizontal 
+  heading="Americano order" 
+  subheading="To takeaway"
+  message="Extras: Double espresso shot and oat milk."
+  density="spacious"
+>
+  <svg
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+  </svg>
+  <ic-status-tag
+    slot="adornment"
+    label="Pending"
+    size="small"
+  ></ic-status-tag>
+  <svg
+    slot="image-left"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1600 900"
+  >
+    <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+    <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+    <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+    <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+    <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+    <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+    <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+    <polygon fill="#b80066" points="641 695 886 900 367 900" />
+    <polygon fill="#960052" points="587 900 641 695 886 900" />
+    <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+    <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+    <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+    <polygon fill="#880088" points="943 900 1210 900 971 687" />
+  </svg>
+</ic-card-horizontal>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcCardHorizontal
+  heading="Americano order"
+  subheading="To takeaway"
+  message="Extras: Double espresso shot and oat milk."
+  density="spacious"
+>
+  <SlottedSVG
+    slot="icon"
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
+  </SlottedSVG>
+  <IcStatusTag
+    slot="adornment"
+    label="Pending"
+    size="small"
+  />
+  <SlottedSVG
+    slot="image-left"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 1600 900"
+  >
+    <rect fill="#ff7700" width="1600" height="1600" y="-350" />
+    <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
+    <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
+    <polygon fill="#c50022" points="-60 900 398 662 816 900" />
+    <polygon fill="#a3001b" points="337 900 398 662 816 900" />
+    <polygon fill="#be0044" points="1203 546 1552 900 876 900" />
+    <polygon fill="#9c0036" points="1203 546 1552 900 1162 900" />
+    <polygon fill="#b80066" points="641 695 886 900 367 900" />
+    <polygon fill="#960052" points="587 900 641 695 886 900" />
+    <polygon fill="#b10088" points="1710 900 1401 632 1096 900" />
+    <polygon fill="#8f006d" points="1710 900 1401 632 1365 900" />
+    <polygon fill="#aa00aa" points="1210 900 971 687 725 900" />
+    <polygon fill="#880088" points="943 900 1210 900 971 687" />
+  </SlottedSVG>
+</IcCardHorizontal>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsSubheadingAdornment}>
+  <IcCardHorizontal
+    heading="Americano order"
+    subheading="To takeaway"
+    message="Extras: Double espresso shot and oat milk."
+    density="spacious"
+  >
+    <svg
+      slot="icon"
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
+      fill="#000000"
+    >
+      <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
+    </svg>
+    <IcStatusTag slot="adornment" label="Pending" size="small" />
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -971,7 +1457,7 @@ export const snippetsClickable = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1012,7 +1498,7 @@ export const snippetsClickable = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1061,7 +1547,11 @@ export const snippetsClickable = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -1104,7 +1594,7 @@ export const snippetsClickableHref = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1146,7 +1636,7 @@ export const snippetsClickableHref = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1196,7 +1686,11 @@ export const snippetsClickableHref = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -1238,7 +1732,7 @@ export const snippetsWrapped = [
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
     </svg>
     <svg
-      slot="image"
+      slot="image-left"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 1600 900"
     >
@@ -1280,7 +1774,7 @@ export const snippetsWrapped = [
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
     </SlottedSVG>
     <SlottedSVG
-      slot="image"
+      slot="image-left"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 1600 900"
     >
@@ -1336,7 +1830,7 @@ export const snippetsWrapped = [
         <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
       </svg>
       <svg
-        slot="image"
+        slot="image-left"
         xmlns="http://www.w3.org/2000/svg"
         viewBox="0 0 1600 900"
       >
@@ -1383,7 +1877,7 @@ export const snippetsDisabled = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1425,7 +1919,7 @@ export const snippetsDisabled = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1475,7 +1969,11 @@ export const snippetsDisabled = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -1515,7 +2013,7 @@ export const snippetsSlottedHeading = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1554,7 +2052,7 @@ export const snippetsSlottedHeading = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1605,7 +2103,11 @@ export const snippetsSlottedHeading = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -1645,7 +2147,7 @@ export const snippetsThemeDark = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1694,7 +2196,7 @@ export const snippetsThemeDark = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1768,7 +2270,11 @@ return (
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -1812,7 +2318,7 @@ export const snippetsTruncation = [
     />
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1853,7 +2359,7 @@ export const snippetsTruncation = [
     <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1902,7 +2408,11 @@ export const snippetsTruncation = [
       <path d="M0 0h24v24H0V0z" fill="none" />
       <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />
@@ -1944,7 +2454,7 @@ export const snippetsCustomWidth = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </svg>
   <svg
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -1985,7 +2495,7 @@ export const snippetsCustomWidth = [
     <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z"/>
   </SlottedSVG>
   <SlottedSVG
-    slot="image"
+    slot="image-left"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 1600 900"
   >
@@ -2034,7 +2544,11 @@ export const snippetsCustomWidth = [
     >
       <path d="M2,21V19H20V21H2M20,8V5H18V8H20M20,3A2,2 0 0,1 22,5V8A2,2 0 0,1 20,10H18V13A4,4 0 0,1 14,17H8A4,4 0 0,1 4,13V3H20M16,5H6V13A2,2 0 0,0 8,15H14A2,2 0 0,0 16,13V5Z" />
     </svg>
-    <svg slot="image" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+    <svg
+      slot="image-left"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 1600 900"
+    >
       <rect fill="#ff7700" width="1600" height="1600" y="-350" />
       <polygon fill="#cc0000" points="957 450 539 900 1396 900" />
       <polygon fill="#aa0000" points="957 450 872.9 900 1396 900" />

--- a/src/content/structured/components/card-horizontal/guidance.mdx
+++ b/src/content/structured/components/card-horizontal/guidance.mdx
@@ -3,7 +3,7 @@ path: "/components/card-horizontal"
 
 navPriority: 10
 
-date: "2025-09-09"
+date: "2025-10-23"
 
 title: "Card (horizontal)"
 
@@ -31,6 +31,18 @@ import {
   Fig2HorizontalCardDark,
   Fig3HorizontalCardLight,
   Fig3HorizontalCardDark,
+  Fig4HorizontalCardLight,
+  Fig4HorizontalCardDark,
+  Fig5HorizontalCardLight,
+  Fig5HorizontalCardDark,
+  Fig6HorizontalCardLight,
+  Fig6HorizontalCardDark,
+  Fig7HorizontalCardLight,
+  Fig7HorizontalCardDark,
+  Fig8HorizontalCardLight,
+  Fig8HorizontalCardDark,
+  Fig9HorizontalCardLight,
+  Fig9HorizontalCardDark,
 } from "./images";
 
 <IcAlert
@@ -72,7 +84,7 @@ For more information on Canary components, read our approach to [releases and ve
 
 A horizontal card uses the same structure as clickable and static vertical cards, although presenting the content in a horizontal layout with the image on either the left or right.
 
-Horizontal cards do not currently contain an interaction area.
+Horizontal cards do not currently contain an interaction area as they are designed for display rather than function. Horizontal cards are best suited for presenting a summary of information with an image in a pleasing way. The card can be clicked on to find out more about the item on a dedicated page.
 
 ## Component demo
 
@@ -105,6 +117,18 @@ Horizontal cards do not currently contain an interaction area.
     </svg>
   </IcCardHorizontal>
 </ComponentPreview>
+
+## Component variants
+
+The horizontal card has two main variants:
+
+### Density
+
+Two options are available for density: default and spacious.
+
+### Size
+
+There are three size variants: small, medium and large.
 
 ## When to use
 
@@ -148,39 +172,94 @@ Use the small size when available width is limited and use the large size for a 
   caption="Don’t vertically align horizontal cards of different sizes."
 />
 
-## Layout
+## Density
 
-A horizontal card with a default layout has no margin between the image and card border, for a more compact styling.
+A horizontal card with a default density has no margin between the image and card border, for a more compact styling.
 
 <DoDontCaution
   imageSrc={[Fig3HorizontalCardLight, Fig3HorizontalCardDark]}
-  imageAlt="Horizontal card with a default layout, an image of a Latte is displayed on the left which meets the border edge of the card with no margin. To the right is a heading and content describing a Latte coffee."
+  imageAlt="Horizontal card with a default density, an image of a Latte is displayed on the left which meets the border edge of the card with no margin. To the right is a heading and content describing a Latte coffee."
   state="none"
-  caption="Default layout does not include a margin around an image."
+  caption="Default density does not include a margin around an image."
+/>
+
+A horizontal card with a spacious density maintains a 16-pixel margin between the image and card border.
+
+<DoDontCaution
+  imageSrc={[Fig4HorizontalCardLight, Fig4HorizontalCardDark]}
+  imageAlt="Horizontal card with a spacious density, an image of a Latte is displayed on the left with a small margin surrounding it. To the right is a heading and content describing a Latte coffee."
+  state="none"
+  caption="Spacious density includes a margin around an image."
 />
 
 ## Content
 
 Horizontal card content is similar to the static and clickable variants of [Vertical card](/components/card-vertical); however, it does not include an interaction area.
 
+<DoDontCaution
+  imageSrc={[Fig5HorizontalCardLight, Fig5HorizontalCardDark]}
+  imageAlt="A horizontal card showing each element of content to be displayed; heading, image, content and expandable areas."
+  state="none"
+  caption="A horizontal card includes a heading area, image area, content area and an expandable area."
+/>
+
 ### 1. Heading area
 
 The default horizontal card layout cannot contain a subheading or adornment due to space limitations.
+
+<DoDontCaution
+  imageSrc={[Fig6HorizontalCardLight, Fig6HorizontalCardDark]}
+  imageAlt="The anatomy of a horizontal card with default density showing the heading area and annotations for each of the three elements displayed."
+  state="none"
+  caption="A horizontal card’s heading area with default density, which can include three elements; icon, heading and menu button."
+/>
 
 The heading area can contain:
 
 - A: Icon/Avatar
 - B: Heading
+- C: Card menu
+
+A spacious horizontal card can contain a subheading and an adornment.
+
+<DoDontCaution
+  imageSrc={[Fig7HorizontalCardLight, Fig7HorizontalCardDark]}
+  imageAlt="The anatomy of a horizontal card with spacious layout showing the heading area and annotations for each of the five elements displayed."
+  state="none"
+  caption="A horizontal card’s heading area with spacious density, which can include five elements."
+/>
+
+The spacious density heading area can contain:
+
+- A: Icon/Avatar
+- B: Heading
+- C: Subheading
+- D: Adornment
+- E: Card menu
 
 ### 2. Image
 
 If an image is displayed, it can be placed to the left or right of the content.
+
+<DoDontCaution
+  imageSrc={[Fig8HorizontalCardLight, Fig8HorizontalCardDark]}
+  imageAlt="Two horizontal cards, both showing an image of an Espresso, a heading label of Espresso, subheading of ‘Short and sweet’ with collapsed content describing an Espresso coffee. The top image has the image placed to the left of the content, while the bottom image shows the image placed to the right."
+  state="good"
+  caption="Place images either on the left or the right of cards, if content is present."
+/>
 
 ### 3. Content area
 
 Add a descriptive message within the card content section. Static cards can include a 'see more' link to expand hidden content.
 
 Since clickable cards can only contain one interaction, text can't be hidden.
+
+<DoDontCaution
+  imageSrc={[Fig9HorizontalCardLight, Fig9HorizontalCardDark]}
+  imageAlt="Two columns of horizontal cards. The left-hand column contains a static card with a menu, a clickable card and finally a static card with collapsed content section. The second column contains two clickable cards, a static card with a menu and another clickable card."
+  state="bad"
+  caption="Don’t mix card variants when arranged in a group."
+/>
 
 ## Related components
 

--- a/src/data/canary-component-names.json
+++ b/src/data/canary-component-names.json
@@ -6,6 +6,7 @@
     "IcDateInput",
     "IcDatePicker",
     "IcPaginationBar",
+    "IcTableOfContents",
     "IcTimeInput",
     "IcTreeItem",
     "IcTreeView"
@@ -17,12 +18,12 @@
     "ic-date-input",
     "ic-date-picker",
     "ic-pagination-bar",
+    "ic-table-of-contents",
     "ic-time-input",
     "ic-tree-item",
     "ic-tree-view"
   ],
   "canaryTypes": [
-    "IcCardSizes",
     "IcDataTableSortOrderOptions",
     "IcDataTableDensityOptions",
     "IcDataTableColumnDataTypes",

--- a/src/icds-pages-data.json
+++ b/src/icds-pages-data.json
@@ -6,6 +6,11 @@
       "subTitle": "Accordions are expandable and collapsible sections that are used to show and hide additional content."
     },
     {
+      "path": "/components/action-chip",
+      "title": "Action chip",
+      "subTitle": "Action chips are functional versions of Chips."
+    },
+    {
       "path": "/components/alert",
       "title": "Alert",
       "subTitle": "Alerts display a short important message in a way that attracts attention without interrupting the current task."
@@ -48,7 +53,7 @@
     {
       "path": "/components/chip",
       "title": "Chip",
-      "subTitle": "Chips are used to filter and present data."
+      "subTitle": "Chips help people view summary information, filter data or trigger actions."
     },
     {
       "path": "/components/classification-banner",
@@ -188,7 +193,7 @@
     {
       "path": "/components/table-of-contents",
       "title": "Table of contents",
-      "subTitle": "A table of contents allows navigation through a page’s contents using links to its headings."
+      "subTitle": "A table of contents allows users to quickly navigate through a page's content using links to its headings."
     },
     {
       "path": "/components/tabs",


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

NOTE: You'll need to build the component updates locally from https://github.com/mi6/ic-ui-kit/pull/4015 and install them locally on the site in order to see the code examples working.

Update horizontal card guidance and code examples to include spacious variant, interaction button slot, subheading, and adornment slot.

Some prettier updates are also in this PR.

## Related issue

#1076

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
