### PR TITLE
chore(root): code preview mismatch in data list small

### DIFF
--- a/src/content/structured/components/data-list/code.mdx
+++ b/src/content/structured/components/data-list/code.mdx
@@ -427,10 +427,42 @@ export const smallSnippet = [
 
 <ComponentPreview snippets={smallSnippet}>
   <IcDataList heading="Personal details" size="small" style={{ width: "90%" }}>
-    <IcDataRow label="Name" value="Michael Johnson" />
-    <IcDataRow label="Date of birth" value="16 October 1995" />
-    <IcDataRow label="Telephone" value="07449 7654873" />
-    <IcDataRow label="Email" value="mjohnson@coffee.gov" />
+    <IcDataRow label="Name" value="Michael Johnson">
+      <IcStatusTag
+        status="success"
+        label="confirmed"
+        variant="filled"
+        slot="end-component"
+        size="small"
+      />
+    </IcDataRow>
+    <IcDataRow label="Date of birth" value="16 October 1995">
+      <IcStatusTag
+        status="warning"
+        label="in review"
+        variant="filled"
+        slot="end-component"
+        size="small"
+      />
+    </IcDataRow>
+    <IcDataRow label="Telephone" value="07449 7654873">
+      <IcStatusTag
+        status="warning"
+        label="in review"
+        variant="filled"
+        slot="end-component"
+        size="small"
+      />
+    </IcDataRow>
+    <IcDataRow label="Email" value="mjohnson@coffee.gov">
+      <IcStatusTag
+        status="success"
+        label="confirmed"
+        variant="filled"
+        slot="end-component"
+        size="small"
+      />
+    </IcDataRow>
     <IcDataRow label="Address">
       <IcTypography variant="body" slot="value">
         383 Coffee Drive
@@ -441,6 +473,12 @@ export const smallSnippet = [
         <br />
         United Kingdom
       </IcTypography>
+      <IcStatusTag
+        label="not confirmed"
+        variant="filled"
+        slot="end-component"
+        size="small"
+      />
     </IcDataRow>
   </IcDataList>
 </ComponentPreview>


### PR DESCRIPTION
The 'size small' component preview on the data list code tab aligns with the code example

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Tell us, in a few words, what the changes are.

Status tags in the end-component slot added

## Related issue

Tell us the issue number. If suggesting an improvement or component, please discuss it with us in an issue first.
#1652

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
