### PR TITLE
752 guidance on how to load web components from cdn

### DIFF
--- a/src/content/structured/get-started/web-components.mdx
+++ b/src/content/structured/get-started/web-components.mdx
@@ -3,16 +3,20 @@ path: "/get-started/development/install-components/web-components"
 
 navPriority: 9
 
-date: "2024-12-23"
+date: "2025-12-03"
 
 title: "Web components"
 
 subTitle: "How to use the web components."
 
 contribute: "https://github.com/mi6/ic-design-system/tree/main/src/content/structured/get-started/web-components.mdx"
+
+tags: ["webpack", "cdn"]
 ---
 
-## Step one
+## NPM install
+
+### Step one
 
 In the root of your project:
 
@@ -25,7 +29,7 @@ rm package-lock.json
 yarn add @ukic/web-components @ukic/fonts
 ```
 
-## Step two
+### Step two
 
 Import `defineCustomElements` in your file. Where you do this will depend on your framework or build tool, but the format is as follows:
 
@@ -33,7 +37,7 @@ Import `defineCustomElements` in your file. Where you do this will depend on you
 import { defineCustomElements } from "@ukic/web-components/loader";
 ```
 
-## Step three
+### Step three
 
 Call `defineCustomElements` in your file. Again, the file you edit will depend on your framework or build tool, but the format is as follows:
 
@@ -43,7 +47,7 @@ Call `defineCustomElements` in your file. Again, the file you edit will depend o
 defineCustomElements();
 ```
 
-## Step four
+### Step four
 
 Depending on your framework or build tool, this can be included in either a CSS file or JavaScript\TypeScript file.
 
@@ -75,7 +79,7 @@ If you would like to import these styles to apply them to the rest of your proje
 @import "@ukic/web-components/dist/core/normalize.css";
 ```
 
-## Step five
+### Step five
 
 In your HTML, you can now declare a component as follows:
 
@@ -83,7 +87,7 @@ In your HTML, you can now declare a component as follows:
 <ic-status-tag label="Neutral"></ic-status-tag>
 ```
 
-## Webpack example
+## Webpack
 
 Webpack is a tool for bundling web applications. This example assumes the following config in `webpack.config.js`. For more detailed information on Webpack configuration, please refer to the Webpack documentation.
 
@@ -153,3 +157,55 @@ You can now use any of the components so long as your HTML page includes the out
   </body>
 </html>
 ```
+
+## From a CDN
+
+It is also possible to import the web components from a CDN. Below are two examples of using a CDN within your `index.html` to import ICDS components.
+
+By default these CDNs request the latest version, to request a specific version add `@VERSION` onto the package name in the `src` string. E.g `.../web-components@3.2.0/...`.
+
+### jsdelivr
+
+```html
+<html>
+  <head>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@ukic/web-components/dist/core/core.esm.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.jsdelivr.net/npm/@ukic/web-components/dist/core/core.css"
+    />
+  </head>
+  <body>
+    <ic-status-tag label="Neutral"></ic-status-tag>
+  </body>
+</html>
+```
+
+See [jsdeliver's website](https://www.jsdelivr.com/) for more information.
+
+### unpkg
+
+```html
+<html>
+  <head>
+    <script
+      type="module"
+      src="https://unpkg.com/@ukic/web-components/dist/core/core.esm.js"
+    ></script>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://unpkg.com/@ukic/web-components/dist/core/core.css"
+    />
+  </head>
+  <body>
+    <ic-status-tag label="Neutral"></ic-status-tag>
+  </body>
+</html>
+```
+
+See [unpkg's website](https://unpkg.com/) for more information.


### PR DESCRIPTION
## Summary of the changes

Get Started -> Web Components now has CDN instructions (provided by valued contributor @ad9242).
Did some basic restructuring of the page headings too. 

## Related issue

#752 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
