### PR TITLE
docs(root): added typography variants to typograghy.config and index

### DIFF
--- a/src/content/structured/styles/components/TypographicScale/index.tsx
+++ b/src/content/structured/styles/components/TypographicScale/index.tsx
@@ -6,7 +6,8 @@ import { TypographyConfig, TypographyVariant } from "./typography.config";
 const ExampleElement: React.FC<{
   variant: TypographyVariant;
   title: string;
-}> = ({ variant, title }) => {
+  textDecoration?: string;
+}> = ({ variant, title, textDecoration }) => {
   if (variant === "link")
     return (
       <ic-typography variant="body" data-class="additional-padding">
@@ -22,7 +23,35 @@ const ExampleElement: React.FC<{
         {title}
       </ic-button>
     );
-  return <ic-typography variant={variant}>{title}</ic-typography>;
+
+  switch (textDecoration) {
+    case "underline":
+      return (
+        <ic-typography variant={variant} underline>
+          {title}
+        </ic-typography>
+      );
+    case "strikethrough":
+      return (
+        <ic-typography variant={variant} strikethrough>
+          {title}
+        </ic-typography>
+      );
+    case "bold":
+      return (
+        <ic-typography variant={variant} bold>
+          {title}
+        </ic-typography>
+      );
+    case "italic":
+      return (
+        <ic-typography variant={variant} italic>
+          {title}
+        </ic-typography>
+      );
+    default:
+      return <ic-typography variant={variant}>{title}</ic-typography>;
+  }
 };
 
 const TypographicScale: React.FC<{
@@ -38,9 +67,14 @@ const TypographicScale: React.FC<{
         fontWeight,
         letterSpacing,
         lineHeight,
+        textDecoration,
       }) => (
         <>
-          <ExampleElement variant={variant} title={title} />
+          <ExampleElement
+            variant={variant}
+            title={title}
+            textDecoration={textDecoration}
+          />
           <ic-typography variant="caption" data-class="internal-caption">
             {`${fontFamily} • ${fontWeight} • ${fontSize}rem • Line-height: ${lineHeight}rem • Letter-spacing: ${letterSpacing}`}
           </ic-typography>

--- a/src/content/structured/styles/components/TypographicScale/typography.config.ts
+++ b/src/content/structured/styles/components/TypographicScale/typography.config.ts
@@ -7,6 +7,7 @@ export interface TypographyConfig {
   title: string;
   fontFamily: "Nunito sans" | "Open sans" | "Source Code Pro";
   fontWeight: "ExtraBold" | "Bold" | "Regular" | "SemiBold";
+  textDecoration?: "strikethrough" | "bold" | "italic" | "underline";
 
   /** Value expected in `rem` units */
   fontSize: number;
@@ -130,6 +131,47 @@ export const TypographyText: TypographyConfig[] = [
     fontSize: 0.75,
     lineHeight: 1.5,
     letterSpacing: "0.025rem",
+  },
+  // body strikethrough
+  {
+    variant: "body",
+    title: "Body Strikethrough",
+    fontFamily: "Open sans",
+    fontWeight: "Regular",
+    textDecoration: "strikethrough",
+    fontSize: 1,
+    lineHeight: 1.5,
+    letterSpacing: "0.005rem",
+  },
+  {
+    variant: "body",
+    title: "Body Underline",
+    fontFamily: "Open sans",
+    fontWeight: "Regular",
+    textDecoration: "underline",
+    fontSize: 1,
+    lineHeight: 1.5,
+    letterSpacing: "0.005rem",
+  },
+  {
+    variant: "body",
+    title: "Body Italic",
+    fontFamily: "Open sans",
+    fontWeight: "Regular",
+    textDecoration: "italic",
+    fontSize: 1,
+    lineHeight: 1.5,
+    letterSpacing: "0.005rem",
+  },
+  {
+    variant: "body",
+    title: "Body Bold",
+    fontFamily: "Open sans",
+    fontWeight: "Regular",
+    textDecoration: "bold",
+    fontSize: 1,
+    lineHeight: 1.5,
+    letterSpacing: "0.005rem",
   },
 ];
 


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Added strikethrough, bold, underline and italic to the typography variants. Edited typography.config.ts and index.tsx

## Related issue

#390

## Checklist

- [ ] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [ ] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
