### PR TITLE
1720 internal issue 3129   layout and spacing guidance needs a reciprocal link

### DIFF
--- a/src/content/structured/styles/layout-spacing.mdx
+++ b/src/content/structured/styles/layout-spacing.mdx
@@ -175,3 +175,5 @@ Sometimes other page elements exist outside of the grid and influence how it is 
   state="none"
   caption="Grid influencers, such as a fixed width side navigation, cause the grid to compress into the remaining available space."
 />
+
+For guidance on how these spacing and layout rules are applied within components, see [Layout grid](/components/layout/layout-grid).


### PR DESCRIPTION
Added a link to “Layout Grid” on the “Layout and Spacing” page at the bottom to help users move easily between related topics. 