### PR TITLE
docs(root): remove sentence about date picker announcing escape key usage

### DIFF
--- a/src/content/structured/components/inputs/date-picker/accessibility.mdx
+++ b/src/content/structured/components/inputs/date-picker/accessibility.mdx
@@ -38,8 +38,6 @@ When moving to a date selection, screen readers will announce in the format “M
 
 When focussing the date picker calendar dates, screen readers will announce the date as weekday, date, month and year sequentially, for example “Choose Wednesday, 8 November 2023”.
 
-When focus is trapped in the date picker dropdown screen, reader should announce route to exit focus. For example, “ic-date-picker, 03 July 2024, press ESC to exit”.
-
 The date picker will only open when users select the date picker icon from within date input.
 
 ## Based on


### PR DESCRIPTION
## Summary of the changes

Removed sentence which says that the date picker announces that you can press the escape key to close the dropdown. The date picker doesn't actually do this (I think because it's already a well-known method of closing dropdowns) so felt it was best to remove the sentence.

## Related issue

N/A
