### PR TITLE
Add code examples for recent ui kit updates

### DIFF
--- a/src/content/structured/components/feedback-progress/skeleton/code.mdx
+++ b/src/content/structured/components/feedback-progress/skeleton/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/feedback-progress/skeleton/code"
 
-date: "2024-05-31"
+date: "2026-01-22"
 
 title: "Skeleton"
 
@@ -182,11 +182,101 @@ return (
   </IcSkeleton>
 </ComponentPreview>
 
-### Set width and height
+### Set width and height with props
+
+export const snippetsSetWidthAndHeightProps = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-typography variant="h4">
+  <h4>Height and width set</h4>
+</ic-typography>
+<ic-skeleton height="12.5rem" width="25.125rem"></ic-skeleton>
+<ic-typography variant="h4">
+  <h4>Height set</h4>
+</ic-typography>
+<ic-skeleton height="5rem"></ic-skeleton>
+<ic-typography variant="h4">
+  <h4>Width set</h4>
+</ic-typography>
+<ic-skeleton width="25.125rem"></ic-skeleton>`,
+      long: `.parent-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--ic-space-xs);
+  }
+</style>
+<body>
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcTypography variant="h4">
+  <h4>Height and width set</h4>
+</IcTypography>
+<IcSkeleton
+  height="12.5rem"
+  width="12.5rem"
+/>
+<IcTypography variant="h4">
+  <h4>Height set</h4>
+</IcTypography>
+<IcSkeleton height="5rem" />
+<IcTypography variant="h4">
+  <h4>Width set</h4>
+</IcTypography>
+<IcSkeleton width="25.125rem" />`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `<>
+  {shortCode}
+</>`,
+        },
+        {
+          language: "Javascript",
+          snippet: `<>
+  {shortCode}
+</>`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsSetWidthAndHeightProps}>
+  <div
+    style={{
+      display: "flex",
+      flexDirection: "column",
+      gap: "0.5rem",
+      maxWidth: "100%",
+    }}
+  >
+    <IcTypography variant="h4">
+      <h4>Height and width set</h4>
+    </IcTypography>
+    <IcSkeleton height="12.5rem" width="12.5rem" />
+    <IcTypography variant="h4">
+      <h4>Height set</h4>
+    </IcTypography>
+    <IcSkeleton height="5rem" />
+    <IcTypography variant="h4">
+      <h4>Width set</h4>
+    </IcTypography>
+    <IcSkeleton width="25.125rem" />
+  </div>
+</ComponentPreview>
+
+### Set width and height with inline styling
 
 CSS changes directly to `Skeleton` must be applied with inline styling.
 
-export const snippetsSetWidthAndHeight = [
+export const snippetsSetWidthAndHeightCSS = [
   {
     technology: "Web component",
     snippets: {
@@ -260,7 +350,7 @@ export const snippetsSetWidthAndHeight = [
   },
 ];
 
-<ComponentPreview snippets={snippetsSetWidthAndHeight}>
+<ComponentPreview snippets={snippetsSetWidthAndHeightCSS}>
   <div
     style={{
       display: "flex",

--- a/src/content/structured/components/feedback-progress/stepper/code.mdx
+++ b/src/content/structured/components/feedback-progress/stepper/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/feedback-progress/stepper/code"
 
-date: "2024-05-31"
+date: "2026-01-22"
 
 title: "Stepper"
 
@@ -324,6 +324,68 @@ export const customConnectorWidth = [
     <IcStep heading="Order coffee" type="completed" />
     <IcStep heading="Pay for order" type="current" />
     <IcStep heading="Collect" type="disabled" />
+  </IcStepper>
+</ComponentPreview>
+
+### Heading slot
+
+export const snippetsHeadingSlot = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-stepper>
+  <ic-step type="completed">
+    <span slot="heading">Order coffee</span>
+  </ic-step>
+  <ic-step type="current">
+    <span slot="heading">Pay for order</span>
+  </ic-step>
+  <ic-step type="disabled">
+    <span slot="heading">Collect</span>
+  </ic-step>
+</ic-stepper>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcStepper>
+  <IcStep type="completed">
+    <span slot="heading">Order coffee</span>
+  </IcStep>
+  <IcStep type="current">
+    <span slot="heading">Pay for order</span>
+  </IcStep>
+  <IcStep type="disabled">
+    <span slot="heading">Collect</span>
+  </IcStep>
+</IcStepper>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsHeadingSlot}>
+  <IcStepper>
+    <IcStep type="completed">
+      <span slot="heading">Order coffee</span>
+    </IcStep>
+    <IcStep type="current">
+      <span slot="heading">Pay for order</span>
+    </IcStep>
+    <IcStep type="disabled">
+      <span slot="heading">Collect</span>
+    </IcStep>
   </IcStepper>
 </ComponentPreview>
 

--- a/src/content/structured/components/inputs/buttons/code.mdx
+++ b/src/content/structured/components/inputs/buttons/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/inputs/button/code"
 
-date: "2024-05-31"
+date: "2026-01-22"
 
 title: "Button"
 
@@ -361,7 +361,22 @@ export const snippetsIcon = [
     <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>
   </svg>
 </ic-button>
-`,
+<ic-button 
+  variant="icon-primary" 
+  aria-label="refresh"
+  loading="true"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="#000000"
+  >
+    <path d="M0 0h24v24H0V0z" fill="none"></path>
+    <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>
+  </svg>
+</ic-button>`,
       long: `.parent-container {
     display: flex;
     flex-wrap: wrap;
@@ -426,6 +441,22 @@ export const snippetsIcon = [
 <IcButton 
   variant="icon-destructive" 
   aria-label="refresh"
+>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height="24"
+    viewBox="0 0 24 24"
+    width="24"
+    fill="#000000"
+  >
+    <path d="M0 0h24v24H0V0z" fill="none"></path>
+    <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"></path>
+  </svg>
+</IcButton>
+<IcButton 
+  variant="icon-primary" 
+  aria-label="refresh"
+  loading
 >
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -525,6 +556,18 @@ return (
       width="24"
       height="24"
       viewBox="0 0 24 24"
+      fill="#000000"
+    >
+      <path d="M0 0h24v24H0V0z" fill="none" />
+      <path d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z" />
+    </svg>
+  </IcButton>
+  <IcButton variant="icon-primary" aria-label="refresh" loading>
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      height="24"
+      viewBox="0 0 24 24"
+      width="24"
       fill="#000000"
     >
       <path d="M0 0h24v24H0V0z" fill="none" />

--- a/src/content/structured/components/inputs/checkboxes/code.mdx
+++ b/src/content/structured/components/inputs/checkboxes/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/inputs/checkbox/code"
 
-date: "2024-05-31"
+date: "2026-01-22"
 
 title: "Checkbox"
 
@@ -299,6 +299,54 @@ export const snippetsSettingEachCheckboxSize = [
   <IcCheckbox value="valueName1" label="Extra shot (50p)" size="small" />
   <IcCheckbox value="valueName2" label="Extra shot (50p)" />
   <IcCheckbox value="valueName3" label="Extra shot (50p)" size="large" />
+</ComponentPreview>
+
+### Disabled
+
+export const snippetsDisabled = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-checkbox-group label="Select your extras" disabled="true" name="disabled-checkbox-group">
+  <ic-checkbox value="extra" label="Extra shot (50p)"></ic-checkbox>
+  <ic-checkbox value="Soya milk" label="Soya milk" checked ></ic-checkbox>
+  <ic-checkbox value="keep cup" label="Takeaway cup"></ic-checkbox>
+</ic-checkbox-group>`,
+      long: `{shortCode}`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcCheckboxGroup label="Select your extras" disabled name="disabled-checkbox-group">
+  <IcCheckbox value="extra" label="Extra shot (50p)" />
+  <IcCheckbox value="Soya milk" label="Soya milk" checked />
+  <IcCheckbox value="keep cup" label="Takeaway cup" />
+</IcCheckboxGroup>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `{shortCode}`,
+        },
+        {
+          language: "Javascript",
+          snippet: `{shortCode}`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview snippets={snippetsDisabled}>
+  <IcCheckboxGroup
+    label="Select your extras"
+    disabled
+    name="disabled-checkbox-group"
+  >
+    <IcCheckbox value="extra" label="Extra shot (50p)" />
+    <IcCheckbox value="Soya milk" label="Soya milk" checked />
+    <IcCheckbox value="keep cup" label="Takeaway cup" />
+  </IcCheckboxGroup>
 </ComponentPreview>
 
 ### Conditional


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Add code examples for recent ui kit updates - circular loading icon button, disabled checkbox group, height and width props on skeleton, and heading slot on stepper.

Note: we don't seem to have dismiss label code examples for chip or dialog so I haven't added one for alert. I did try to see if it would be a simple code example to add but `dismissLabel` resolves to `dismisslabel` instead of `dismiss-label` in the DOM so it doesn't appear correctly (just for Gatsby, the Stackblitz were fine) . I will open a ticket to add the code example so we can figure out how to override it.

## Related issue

https://github.com/mi6/ic-ui-kit/issues/4078
https://github.com/mi6/ic-ui-kit/issues/3891
https://github.com/mi6/ic-ui-kit/issues/3638
https://github.com/mi6/ic-ui-kit/issues/1837

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
