### PR TITLE
feat(root): add a code example and guidance for transparent button

### DIFF
--- a/src/content/structured/components/inputs/buttons/code.mdx
+++ b/src/content/structured/components/inputs/buttons/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/inputs/button/code"
 
-date: "2026-01-22"
+date: "2026-02-26"
 
 title: "Button"
 
@@ -746,6 +746,84 @@ return (
   </IcButton>
   <IcButton variant="primary">Add to order</IcButton>
   <IcButton variant="primary" size="large">
+    Add to order
+  </IcButton>
+</ComponentPreview>
+
+### Transparent Background
+
+export const snippetsTransparentBackground = [
+  {
+    technology: "Web component",
+    snippets: {
+      short: `<ic-button variant="secondary" transparent-background="true">Add to order</ic-button>
+<ic-button variant="tertiary" transparent-background="true">Add to order</ic-button>`,
+      long: `.parent-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--ic-space-xs);
+    padding: var(--ic-space-md);
+  }
+</style>
+<body>  
+  <div class="parent-container">
+    {shortCode}
+  </div>`,
+    },
+  },
+  {
+    technology: "React",
+    snippets: {
+      short: `<IcButton variant="secondary" transparentBackground>Add to order</IcButton>
+<IcButton variant="tertiary" transparentBackground>Add to order</IcButton>`,
+      long: [
+        {
+          language: "Typescript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "var(--ic-space-xs)",
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+        {
+          language: "Javascript",
+          snippet: `const useStyles = createUseStyles({
+  parentContainer: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "var(--ic-space-xs)",
+    padding: "var(--ic-space-md)",
+  },
+});
+const classes = useStyles();
+return (
+  <div className={classes.parentContainer}>
+    {shortCode}
+  </div>
+)`,
+        },
+      ],
+    },
+  },
+];
+
+<ComponentPreview
+  style={{ background: "var(--ic-color-background-neutral)", gap: "0.5rem" }}
+  snippets={snippetsTransparentBackground}
+>
+  <IcButton variant="secondary" transparentBackground>
+    Add to order
+  </IcButton>
+  <IcButton variant="tertiary" transparentBackground>
     Add to order
   </IcButton>
 </ComponentPreview>

--- a/src/content/structured/components/inputs/buttons/guidance.mdx
+++ b/src/content/structured/components/inputs/buttons/guidance.mdx
@@ -3,7 +3,7 @@ path: "/components/inputs/button"
 
 navPriority: 1
 
-date: "2024-05-10"
+date: "2026-02-26"
 
 title: "Button"
 
@@ -208,6 +208,16 @@ Use large buttons only for high emphasis actions that sit independently from oth
   state="good"
   caption="Use large buttons for standalone, higher priority actions."
 />
+
+## Transparent Button
+
+Use the `transparent-background/transparentBackground` prop to create a button with a transparent background. This is useful when you want a button to blend into a coloured or image background, or when you need a button that visually de-emphasizes itself compared to other actions.
+
+**Important:** When using transparent background buttons, ensure that the button text and icon maintain sufficient contrast against the background to meet accessibility requirements. This helps all users, including those with visual impairments, to perceive and interact with the button.
+
+Refer to WCAG 2.1 Success Criterion 1.4.3: Contrast Minimum
+(https://www.w3.org/TR/WCAG22/#contrast-minimum) for guidance on minimum contrast ratios.
+As a rule of thumb, text and icons should have a contrast ratio of at least 4.5:1 against the background. You can check using online contrast checker tools.
 
 ## Layout and placement
 


### PR DESCRIPTION
Add guidance and a code example for using the transparent background prop, with information about what it's for and meeting contrast requirements

<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

(Repeat PR) Added guidance and a code example for using the transparent background prop, with information about what it's for and meeting contrast requirements with a link to relevant WCAG success criteria.

## Related issue

#1661 

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)