### PR TITLE
chore(root): add two lodash vulnerabilities to allowlist

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -77,6 +77,18 @@
         "active": true,
         "notes": "requires upgrade to 'serialize-javascript' which is a transitive dependency of gatsby."
       }
+    },
+    {
+      "GHSA-r5fr-rjxr-66jc": {
+        "active": true,
+        "notes": "requires upgrade to 'lodash' which is a transitive dependency of gatsby."
+      }
+    },
+    {
+      "GHSA-f23m-r3pf-42rh": {
+        "active": true,
+        "notes": "requires upgrade to 'lodash' which is a transitive dependency of gatsby."
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary of the changes

Add lodash vulnerabilities to allowlist since lodash is a transitive dependency of gatsby

## Checklist

- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
