### PR TITLE
docs(root): update radio button guidance to reflect new large size prop variant of radio components

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -89,6 +89,12 @@
         "active": true,
         "notes": "requires upgrade to 'lodash' which is a transitive dependency of gatsby."
       }
+    },
+    {
+      "GHSA-r4q5-vmmm-2653": {
+        "active": true,
+        "notes": "requires upgrade to 'axios' which is a transitive dependency of gatsby."
+      }
     }
   ]
 }

--- a/src/content/structured/components/inputs/radio/accessibility.mdx
+++ b/src/content/structured/components/inputs/radio/accessibility.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/inputs/radio/accessibility"
 
-date: "2024-04-15"
+date: "2026-04-15"
 
 title: "Radio button"
 
@@ -25,7 +25,7 @@ When interacting with a radio button on a keyboard, the **tab** key moves the fo
 
 When tabbing to a radio group with no option selected, the focus is applied to the first option in the group without selecting the option. The unselected radio button can be selected using the **space** key when the radio button is focused.
 
-When conditional fields are displayed beneath radio buttons, the conditional field acts as the child of the radio button. When the field is dynamically displayed after selecting a radio button, then it should be announced by the screen reader as required based on the user’s current selection. Tabbing on from the radio group should move focus to the dynamically displayed field, and then onwards through the rest of the tab index.
+When conditional fields are displayed beneath radio buttons, the conditional field acts as the child of the radio button. When the field is dynamically displayed after selecting a radio button, then it should be announced by the screen reader as required based on the user's current selection. Tabbing on from the radio group should move focus to the dynamically displayed field, and then onwards through the rest of the tab index.
 
 ## For Assistive Technology
 
@@ -92,4 +92,4 @@ The radio component has been based on the following resources:
 
 ## Testing
 
-We’ve tested this component against WCAG 2.2 Level AA. It’s been tested with NVDA and VoiceOver, and several different users with different interaction methods.
+We've tested this component against WCAG 2.2 Level AA. It's been tested with NVDA and VoiceOver, and several different users with different interaction methods.

--- a/src/content/structured/components/inputs/radio/code.mdx
+++ b/src/content/structured/components/inputs/radio/code.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/components/inputs/radio/code"
 
-date: "2024-05-31"
+date: "2026-04-22"
 
 title: "Radio button"
 
@@ -322,16 +322,43 @@ export const withHelperText = [
   </IcRadioGroup>
 </ComponentPreview>
 
-### Size small
+### Sizes
 
-export const smallSnippet = [
+export const snippetsSizes = [
   {
     technology: "Web component",
     snippets: {
       short: `<ic-radio-group
   label="Do you have any special requests?"
-  name="radio-group-5"
+  name="radio-group-1"
   size="small"
+>
+  <ic-radio-option
+    value="request"
+    label="Yes, I want to modify my order"
+  ></ic-radio-option>
+  <ic-radio-option
+    value="none"
+    label="No, standard please"
+  ></ic-radio-option>
+</ic-radio-group>
+<ic-radio-group
+  label="Do you have any special requests?"
+  name="radio-group-2"
+>
+  <ic-radio-option
+    value="request"
+    label="Yes, I want to modify my order"
+  ></ic-radio-option>
+  <ic-radio-option
+    value="none"
+    label="No, standard please"
+  ></ic-radio-option>
+</ic-radio-group>
+<ic-radio-group
+  label="Do you have any special requests?"
+  name="radio-group-3"
+  size="large"
 >
   <ic-radio-option
     value="request"
@@ -350,8 +377,23 @@ export const smallSnippet = [
     snippets: {
       short: `<IcRadioGroup
   label="Do you have any special requests?"
-  name="radio-group-5"
+  name="radio-group-1"
   size="small"
+>
+  <IcRadioOption value="request" label="Yes, I want to modify my order" />
+  <IcRadioOption value="none" label="No, standard please" />
+</IcRadioGroup>
+<IcRadioGroup
+  label="Do you have any special requests?"
+  name="radio-group-2"
+>
+  <IcRadioOption value="request" label="Yes, I want to modify my order" />
+  <IcRadioOption value="none" label="No, standard please" />
+</IcRadioGroup>
+<IcRadioGroup
+  label="Do you have any special requests?"
+  name="radio-group-3"
+  size="large"
 >
   <IcRadioOption value="request" label="Yes, I want to modify my order" />
   <IcRadioOption value="none" label="No, standard please" />
@@ -359,22 +401,41 @@ export const smallSnippet = [
       long: [
         {
           language: "Typescript",
-          snippet: `{shortCode}`,
+          snippet: `<>
+  {shortCode}
+</>`,
         },
         {
           language: "Javascript",
-          snippet: `{shortCode}`,
+          snippet: `<>
+  {shortCode}
+</>`,
         },
       ],
     },
   },
 ];
 
-<ComponentPreview snippets={smallSnippet}>
+<ComponentPreview
+  snippets={snippetsSizes}
+  style={{ display: "flex", gap: "1.5rem" }}
+>
   <IcRadioGroup
     label="Do you have any special requests?"
-    name="radio-group-5"
+    name="radio-group-7"
     size="small"
+  >
+    <IcRadioOption value="request" label="Yes, I want to modify my order" />
+    <IcRadioOption value="none" label="No, standard please" />
+  </IcRadioGroup>
+  <IcRadioGroup label="Do you have any special requests?" name="radio-group-8">
+    <IcRadioOption value="request" label="Yes, I want to modify my order" />
+    <IcRadioOption value="none" label="No, standard please" />
+  </IcRadioGroup>
+  <IcRadioGroup
+    label="Do you have any special requests?"
+    name="radio-group-9"
+    size="large"
   >
     <IcRadioOption value="request" label="Yes, I want to modify my order" />
     <IcRadioOption value="none" label="No, standard please" />

--- a/src/content/structured/components/inputs/radio/guidance.mdx
+++ b/src/content/structured/components/inputs/radio/guidance.mdx
@@ -3,7 +3,7 @@ path: "/components/inputs/radio"
 
 navPriority: 5
 
-date: "2023-02-03"
+date: "2026-04-15"
 
 title: "Radio button"
 
@@ -56,12 +56,17 @@ An example of the radio button component.
       value="cookie"
       label="Deluxe chocolate chip cookie (sold out)"
       disabled
-      inactive
     />
     <IcRadioOption value="fruit" label="Banana" />
     <IcRadioOption value="No item" label="No thanks, just my coffee" />
   </IcRadioGroup>
 </ComponentPreview>
+
+## Component variants
+
+### Size
+
+The radio button has three size variants: small, medium, and large.
 
 ## When to use
 
@@ -73,16 +78,16 @@ Use a radio button with a conditional field to display a related additional elem
 
 ## When not to use
 
-Don’t use radio buttons on their own, they should always appear as part of a radio button group.
+Don't use radio buttons on their own, they should always appear as part of a radio button group.
 
-Don’t use radio buttons when the user can select multiple options from the list. Use [checkboxes](/components/inputs/checkbox) instead.
+Don't use radio buttons when the user can select multiple options from the list. Use [checkboxes](/components/inputs/checkbox) instead.
 
 <DoubleDoDontCaution>
   <DoDontCaution
     imageSrc={[Fig1RadioLight, Fig1RadioDark]}
     imageAlt="A radio button group titled ‘What are your favourite coffees?’ with two out of six radio buttons showing as selected."
     state="bad"
-    caption="Don’t use a radio button group to allow multiple selected options from a list."
+    caption="Don't use a radio button group to allow multiple selected options from a list."
   />
   <DoDontCaution
     imageSrc={[Fig2RadioLight, Fig2RadioDark]}
@@ -92,14 +97,14 @@ Don’t use radio buttons when the user can select multiple options from the lis
   />
 </DoubleDoDontCaution>
 
-Don’t use radio buttons to turn something on or off. Use a [switch](/components/inputs/switch) instead.
+Don't use radio buttons to turn something on or off. Use a [switch](/components/inputs/switch) instead.
 
 <DoubleDoDontCaution>
   <DoDontCaution
     imageSrc={[Fig3RadioLight, Fig3RadioDark]}
     imageAlt="A two option radio button group with the label ‘Turn on the coffee machine?’ with options for ‘On’ and ‘Off’."
     state="bad"
-    caption="Don’t use radio buttons to turn something on or off."
+    caption="Don't use radio buttons to turn something on or off."
   />
   <DoDontCaution
     imageSrc={[Fig4RadioLight, Fig4RadioDark]}
@@ -115,11 +120,11 @@ In most circumstances, set a default selected option from a radio button group t
 
 Alternatively, use a radio button group without a default selected option to force people to select an option before moving on. This eliminates bias towards a single option and avoids people skipping over the question by leaving the default selection.
 
-### Sizing
+## Sizing
 
-Use small sized radio button groups to achieve compact layouts. Always use small sized components with other small sized components.
+Use the sizing options for radio button groups to match their size to other components in your app.
 
-### Layout and placement
+## Layout and placement
 
 Stack radio buttons when there are more than two options.
 
@@ -137,7 +142,7 @@ Stack radio buttons when there are more than two options.
     imageSrc={[Fig6RadioLight, Fig6RadioDark]}
     imageAlt="A radio button group asking ‘What milk would you like?’ and showing three options for ‘Dairy’, ‘Soya’  and ‘Nut’ displayed in a row."
     state="bad"
-    caption="Don’t display radio button groups with more than two options in a row."
+    caption="Don't display radio button groups with more than two options in a row."
   />
 </DoubleDoDontCaution>
 
@@ -163,11 +168,11 @@ A radio button input error is when the radio button group itself is responsible 
     imageSrc={[Fig8RadioLight, Fig8RadioDark]}
     imageAlt="A radio button group displayed with no radio button selected with an error message reading ‘Please select an option’."
     state="good"
-    caption="When there’s an issue show an error message next to the entire radio button group."
+    caption="When there's an issue show an error message next to the entire radio button group."
   />
 </DoubleDoDontCaution>
 
-For errors on a radio button’s conditional field, the error is shown only on the conditional field itself and not on the parent radio button group component.
+For errors on a radio button's conditional field, the error is shown only on the conditional field itself and not on the parent radio button group component.
 
 <DoubleDoDontCaution>
   <DoDontCaution
@@ -180,7 +185,7 @@ For errors on a radio button’s conditional field, the error is shown only on t
     imageSrc={[Fig10RadioLight, Fig10RadioDark]}
     imageAlt="A graphic showing two error labels incorrectly applied to a radio button group. One error reading ‘Answer required’ is displayed with an empty input field that is the conditional field of a radio button. The other error, also reading ‘Answer required’ is displayed with the whole radio button group."
     state="bad"
-    caption="Only display the error on the field causing it. Don’t display an error on the field as well as the radio group."
+    caption="Don't display an error on the field as well as the radio group. Only display the error on the field causing it."
   />
 </DoubleDoDontCaution>
 
@@ -193,3 +198,4 @@ Follow the [content style guidelines](/styles/content-style) for radio button gr
 ## Related components
 
 - [Checkbox](/components/inputs/checkbox)
+- [Switch](/components/inputs/switch)


### PR DESCRIPTION
<!-- 🙏 Thank you for your contribution, it is greatly appreciated! -->
<!-- Please check our Contributing Guidance https://github.com/mi6/ic-design-system/blob/develop/CONTRIBUTING.md before creating a PR. -->

<!-- In particular all PRs must be raised against the `develop` branch. -->

## Summary of the changes

Update radio button guidance to reflect new large size prop variant of radio components

## Related issue

#1781

## Checklist

- [x] I have [manually accessibility tested](https://design.sis.gov.uk/accessibility/testing/manual-testing) any changes, if relevant.
- [x] I have raised this pull request against the [develop branch](https://github.com/mi6/ic-design-system/tree/develop)
