### PR TITLE
fix(root): correct link to design principles

### DIFF
--- a/src/content/structured/community/index.mdx
+++ b/src/content/structured/community/index.mdx
@@ -1,7 +1,7 @@
 ---
 path: "/community"
 
-date: "2024-09-12"
+date: "2026-05-29"
 
 title: "Community"
 
@@ -18,7 +18,7 @@ We hope to demonstrate our approach to software and inclusive design.
 
 - See our [roadmap](/community/roadmap) for an overview of recent work, current focus and work we have planned.
 - Learn how you can [contribute](/community/contribute) using the [contribution criteria](/community/contribute-criteria).
-- How our community approaches design through our [design principles](/get-started/design-principles).
+- How our community approaches design through our [design principles](/get-started/design/design-principles).
 
 ## More open source from the Intelligence Community
 


### PR DESCRIPTION
## Summary of the changes

Identified by a team-mate, one of the links to Design Principles page had an incorrect url