### PR TITLE
fix(root): correct fonts version lookup

### DIFF
--- a/.github/workflows/check-versions-to-develop-design-system.yml
+++ b/.github/workflows/check-versions-to-develop-design-system.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install latest components
         run: |
           DOCS_VERSION=$(npm view @ukic/docs version)
-          FONTS_VERSION=$(npm view @ukic/fonts verion)
+          FONTS_VERSION=$(npm view @ukic/fonts version)
           REACT_VERSION=$(npm view @ukic/react version)
           WEB_COMPS_VERSION=$(npm view @ukic/web-components version)
           CANARY_DOCS_VERSION=$(npm view @ukic/canary-docs version)


### PR DESCRIPTION
## Summary

Fix the `@ukic/fonts` version lookup in the check-versions workflow.

The workflow currently queries a misspelled npm metadata field, `verion`, which can leave `FONTS_VERSION` unresolved.

## Change

Replace:

`npm view @ukic/fonts verion`

with:

`npm view @ukic/fonts version`

No other workflow behaviour is changed.

Closes #1875