### PR TITLE
fix(root): render secondary navigation items as links

### DIFF
--- a/src/components/SubsectionNav/index.tsx
+++ b/src/components/SubsectionNav/index.tsx
@@ -191,6 +191,7 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
       <IcTreeItem
         key={item.data.id}
         label={item.data.frontmatter.title}
+        href={hasChildren ? undefined : item.data.fields.slug}
         selected={!hasChildren && isCurrentPage(item.data.fields.slug)}
         onClick={(e) => {
           e.preventDefault();
@@ -310,6 +311,7 @@ const SubsectionNav: React.FC<SubsectionNavProps> = ({
         {isRoot && (
           <IcTreeItem
             label={currentNavSection.data.frontmatter.title}
+            href={currentNavSection.data.fields.slug}
             onClick={(e) => {
               e.preventDefault();
               handleNavigation(currentNavSection.data.fields.slug);


### PR DESCRIPTION
## Summary

Make the guidance site's tree-view secondary navigation render navigable items as actual links.

## Change

- Use the existing `IcTreeItem` `href` prop for leaf navigation items.
- Render parent overview items and root navigation items as links.
- Keep expandable parent items as expansion controls.
- Remove the Gatsby navigation interception from items that are now native links.

## Why

`IcTreeItem` already supports `href` specifically for this purpose and renders an `<a>` element when it is supplied.

This improves navigation semantics and allows standard browser link behaviour such as opening component and style pages in a new tab.

Closes #1785