### PR TITLE
docs: explain status tag announcements

### DIFF
--- a/src/content/structured/components/feedback-progress/status-tags/accessibility.mdx
+++ b/src/content/structured/components/feedback-progress/status-tags/accessibility.mdx
@@ -30,6 +30,10 @@ Status tags use colours that have been designed for maximum legibility across a 
 
 Status tags can have `aria-labelledby` or `aria-label` tags that provide additional content to the visible label. However, the visible label must be included within the accessible label.
 
+Set the `announced` prop when a status tag needs to announce updates to assistive technology. This adds `role="status"`, making the status tag a live region. Screen readers announce subsequent changes to the status tag label, but do not announce its initial value when the component first renders.
+
+Only use `announced` for status information that should be surfaced when it changes. Static status tags do not need to be live regions.
+
 ## Based on
 
 The status tag component has been based on the following resources:


### PR DESCRIPTION
## Summary

Clarify the accessibility guidance for status tags when dynamic changes need to be announced to assistive technology.

## Change

- document the `announced` prop;
- explain that it adds `role="status"` and makes the tag a live region;
- clarify that subsequent label changes are announced, while the initial value is not;
- advise using live-region behaviour only for status information that should be surfaced when it changes.

This matches the current `ic-status-tag` implementation in `ic-ui-kit`.

Closes #235