### PR TITLE
fix(root): parse issue urgency dropdown

### DIFF
--- a/.github/workflows/add-issue-urgency.yml
+++ b/.github/workflows/add-issue-urgency.yml
@@ -14,8 +14,9 @@ jobs:
 
       - name: Get issue urgency
         env:
-          URGENCY_STRING: ${{ fromJSON(steps.parse.outputs.data).urgency-low-medium-or-high }}
+          PARSED_ISSUE_DATA: ${{ steps.parse.outputs.data }}
         run: |
+          URGENCY_STRING=$(jq -r '."urgency-low-medium-or-high".text // empty' <<< "$PARSED_ISSUE_DATA")
           case "$URGENCY_STRING" in
             "Low"|"Medium"|"High")
               echo "MATCHED_URGENCY=$URGENCY_STRING" >> $GITHUB_ENV


### PR DESCRIPTION
## Summary

Apply the issue-urgency dropdown parsing fix to the Design System repository as well as the UI Kit.

The current workflow uses a hyphenated Issue Forms field ID as dot notation inside a GitHub expression, which fails during workflow evaluation. The parser also returns the selected dropdown value in the field object's `text` property.

## Fix

- pass the parsed issue JSON through an environment variable;
- read `urgency-low-medium-or-high.text` with `jq`;
- preserve the existing Low, Medium, and High validation and project-field update.

Companion fix for mi6/ic-ui-kit#4493.