### PR TITLE
docs(root): link Canary installation guidance

### DIFF
--- a/src/components/ComponentDetails/index.tsx
+++ b/src/components/ComponentDetails/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import componentJson from "@ukic/docs";
 import canaryComponentJson from "@ukic/canary-docs";
+import { IcLink } from "@ukic/react";
 import EventTable from "./EventTable";
 import MethodTable from "./MethodTable";
 import PropTable from "./PropTable";
@@ -19,6 +20,25 @@ const ComponentDetails: React.FC<{ component: string; canary?: boolean }> = ({
 
   return (
     <>
+      {canary && (
+        <p>
+          Canary components are installed from separate packages. See the{" "}
+          <IcLink
+            href="https://mi6.github.io/ic-ui-kit/branches/canary/develop/react/?path=/docs/getting-started--docs"
+            target="_blank"
+          >
+            Canary React installation guidance
+          </IcLink>{" "}
+          or the{" "}
+          <IcLink
+            href="https://mi6.github.io/ic-ui-kit/branches/canary/develop/web-components/?path=/docs/getting-started--docs"
+            target="_blank"
+          >
+            Canary web components installation guidance
+          </IcLink>
+          .
+        </p>
+      )}
       {props.length > 0 && (
         <PropTable propData={props} typeLibrary={typeLibrary} />
       )}


### PR DESCRIPTION
## Summary

Make Canary package installation guidance available consistently from Canary component code documentation.

## Change

When `ComponentDetails` is rendering Canary component metadata, it now links to the UI Kit getting-started guidance for both Canary React and Canary web components.

Using the shared component-details path means the guidance is available across all current Canary component code pages without duplicating installation text in each page.

Closes #1055