### PR TITLE
fix(root): show notice when JavaScript is disabled

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -20,8 +20,16 @@ export const wrapPageElement = ({ element, props }) =>
     <Layout {...props}>{element}</Layout>
   );
 
-export const onRenderBody = ({ setHeadComponents }) => {
+export const onRenderBody = ({ setHeadComponents, setPreBodyComponents }) => {
   setHeadComponents([
     <link key="tokens" rel="stylesheet" href={withPrefix("/tokens.css")} />,
+  ]);
+  setPreBodyComponents([
+    <noscript key="no-js-notice">
+      <div className="no-js-notice" role="status">
+        <strong>JavaScript is disabled.</strong> Please enable JavaScript in your
+        browser for the best experience and to use all features of this site.
+      </div>
+    </noscript>,
   ]);
 };

--- a/src/styles/gatsby-override.css
+++ b/src/styles/gatsby-override.css
@@ -11,3 +11,11 @@ ic-typography label {
 }
 
 ic-link > a:visited { color: var(--ic-color-hyperlink-visited) !important; }
+
+.no-js-notice {
+  padding: var(--ic-space-sm) var(--ic-space-lg);
+  font: var(--ic-font-body);
+  color: CanvasText;
+  background-color: Canvas;
+  border-bottom: var(--ic-border-width) solid currentColor;
+}


### PR DESCRIPTION
## Summary

Add a site-wide notice for users browsing the guidance site with JavaScript disabled.

The notice is rendered within the SSR layout using a native `<noscript>` element, so the existing page remains visible below it when JavaScript is unavailable.

## Change

- render the notice above the existing page navigation within the SSR layout;
- explain that JavaScript is required for the best experience and full site functionality;
- style the notice using existing spacing and typography tokens and system colours.

Closes #186