### PR TITLE
fix(root): focus section headings from contents navigation

### DIFF
--- a/src/components/AnchorNav/index.tsx
+++ b/src/components/AnchorNav/index.tsx
@@ -58,11 +58,9 @@ const AnchorNav: React.FC<AnchorNavProps> = ({
     e: React.MouseEvent | React.KeyboardEvent,
     headingId: string
   ): void => {
-    // Move focus to heading when link is selected using Enter key
+    // Move focus to the target heading when the link is selected using Enter.
     if (e.detail === 0) {
-      document
-        .querySelector<HTMLAnchorElement>(`a[href='#${headingId}`)
-        ?.focus();
+      document.getElementById(headingId)?.focus();
     }
 
     // reset the active class on current tab

--- a/src/components/WrappedH2/index.tsx
+++ b/src/components/WrappedH2/index.tsx
@@ -16,7 +16,7 @@ const WrappedH2: React.FC<WrappedH2Props> = ({ children, preview }) =>
     <h2>{children}</h2>
   ) : (
     <ic-typography variant="h2" apply-vertical-margins data-class="h2">
-      <h3 id={slug(children)}>
+      <h3 id={slug(children)} tabIndex={-1}>
         {children}
         <Permalink title={children} sluggedTitle={slug(children)} />
       </h3>


### PR DESCRIPTION
## Summary

Keep the page contents navigation in sync with the section currently being read, and move focus to section headings when contents links are activated.

## Problem

On pages with short sections, including Design principles, observing only the heading elements could cause contents entries to be skipped while scrolling. The previous change also did not reliably move screen-reader focus to the selected heading.

## Fix

- derive the active contents item from the latest heading above the activation line, so each section remains active until the next heading is reached;
- select the final contents item when the page bottom is reached;
- update the URL hash, scroll to, and focus the target heading when a contents link is activated;
- keep section headings programmatically focusable with `tabIndex={-1}`.

## Validation

- verified all nine Design principles headings activate in order while scrolling in a browser;
- verified contents-link activation moves DOM focus to the selected heading and updates the hash;
- `npm run prettier`, `npm run verify-ts`, `npm run lint`, `npm test`, and `npm run build` pass locally.

Closes #1266
